### PR TITLE
Add psutil to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'notebook',
+        'psutil'
     ],
     package_data={'jupyterlab_git':['*']},
 )


### PR DESCRIPTION
I got 
```
> jupyter serverextension enable --py jupyterlab_git

Traceback (most recent call last):
  File "/home/andy/anaconda3/envs/jupyterlab/bin/jupyter-serverextension", line 6, in <module>
    sys.exit(notebook.serverextensions.main())
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/jupyter_core/application.py", line 267, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/traitlets/config/application.py", line 658, in launch_instance
    app.start()
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/notebook/serverextensions.py", line 293, in start
    super(ServerExtensionApp, self).start()
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/jupyter_core/application.py", line 256, in start
    self.subapp.start()
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/notebook/serverextensions.py", line 210, in start
    self.toggle_server_extension_python(arg)
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/notebook/serverextensions.py", line 199, in toggle_server_extension_python
    m, server_exts = _get_server_extension_metadata(package)
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/notebook/serverextensions.py", line 327, in _get_server_extension_metadata
    m = import_item(module)
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/traitlets/utils/importstring.py", line 42, in import_item
    return __import__(parts[0])
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/jupyterlab_git/__init__.py", line 4, in <module>
    from jupyterlab_git.handlers import setup_handlers
  File "/home/andy/anaconda3/envs/jupyterlab/lib/python3.6/site-packages/jupyterlab_git/handlers.py", line 9, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'

```
conda installed psutils, worked.
So I guess it's an install requirement ;)