### PR TITLE
Rename extension API method, provide interface

### DIFF
--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -10,7 +10,8 @@ import {
   GitAllHistory,
   GitLogResult,
   SingleCommitInfo,
-  GitStatusFileResult
+  GitStatusFileResult,
+  IDiffCallback,
 } from '../git';
 
 import { PathHeader } from './PathHeader';
@@ -54,7 +55,7 @@ export interface IGitSessionNodeState {
 /** Interface for GitPanel component props */
 export interface IGitSessionNodeProps {
   app: JupyterLab;
-  diff: any;
+  diff: IDiffCallback;
 }
 
 /** A React component for the git extension's main display */

--- a/src/components/GitWidget.tsx
+++ b/src/components/GitWidget.tsx
@@ -16,6 +16,9 @@ import { GitPanel } from './GitPanel';
 
 import { gitWidgetStyle } from '../componentsStyle/GitWidgetStyle';
 
+import { IDiffCallback } from '../git';
+
+
 import '../../style/variables.css';
 
 /**
@@ -66,7 +69,7 @@ export class GitWidget extends Widget {
   /**
    * Construct a new running widget.
    */
-  constructor(app: JupyterLab, options: IOptions, diff_function: any) {
+  constructor(app: JupyterLab, options: IOptions, diff_function: IDiffCallback) {
     super({
       node: (options.renderer || defaultRenderer).createNode()
     });

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -1,7 +1,7 @@
 import { JupyterLab } from "@jupyterlab/application";
 import * as React from "react";
 import { historySideBarStyle } from "../componentsStyle/HistorySideBarStyle";
-import { GitBranchResult, SingleCommitInfo } from "../git";
+import { GitBranchResult, SingleCommitInfo, IDiffCallback } from "../git";
 import { PastCommitNode } from "./PastCommitNode";
 
 /** Interface for PastCommits component props */
@@ -13,12 +13,7 @@ export interface IHistorySideBarProps {
   currentTheme: string;
   app: JupyterLab;
   refresh: () => void;
-  diff: (
-    app: JupyterLab,
-    filename: string,
-    revisionA: string,
-    revisionB: string
-  ) => void;
+  diff: IDiffCallback;
 }
 
 export class HistorySideBar extends React.Component<IHistorySideBarProps, {}> {

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -14,7 +14,7 @@ import {
   remoteBranchStyle,
   workingBranchStyle
 } from "../componentsStyle/PastCommitNodeStyle";
-import { GitBranchResult, SingleCommitInfo } from "../git";
+import { GitBranchResult, SingleCommitInfo, IDiffCallback } from "../git";
 import { SinglePastCommitInfo } from "./SinglePastCommitInfo";
 
 export interface IPastCommitNodeProps {
@@ -23,12 +23,7 @@ export interface IPastCommitNodeProps {
   topRepoPath: string;
   currentTheme: string;
   app: JupyterLab;
-  diff: (
-    app: JupyterLab,
-    filename: string,
-    revisionA: string,
-    revisionB: string
-  ) => void;
+  diff: IDiffCallback;
   refresh: () => void;
 }
 

--- a/src/components/PastCommits.tsx
+++ b/src/components/PastCommits.tsx
@@ -4,6 +4,8 @@ import { FileList } from './FileList';
 
 import { pastCommitsContainerStyle } from '../componentsStyle/PastCommitsStyle';
 
+import { IDiffCallback } from '../git';
+
 import * as React from 'react';
 
 /** Interface for PastCommits component props */
@@ -17,7 +19,7 @@ export interface IPastCommitsProps {
   untrackedFiles: any;
   app: JupyterLab;
   refresh: any;
-  diff: any;
+  diff: IDiffCallback;
   sideBarExpanded: boolean;
   currentTheme: string;
 }

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -20,7 +20,7 @@ import {
   numberofChangedFilesStyle,
   revertButtonStyle
 } from "../componentsStyle/SinglePastCommitInfoStyle";
-import { CommitModifiedFile, Git, SingleCommitInfo } from "../git";
+import { CommitModifiedFile, Git, SingleCommitInfo, IDiffCallback } from "../git";
 import { parseFileExtension } from "./FileList";
 import { ResetDeleteSingleCommit } from "./ResetDeleteSingleCommit";
 
@@ -28,12 +28,8 @@ export interface ISinglePastCommitInfoProps {
   topRepoPath: string;
   data: SingleCommitInfo;
   app: JupyterLab;
-  diff: (
-    app: JupyterLab,
-    filename: string,
-    revisionA: string,
-    revisionB: string
-  ) => void;
+  diff: IDiffCallback;
+
   refresh: () => void;
   currentTheme: string;
 }
@@ -219,7 +215,6 @@ export class SinglePastCommitInfo extends React.Component<
                     className={commitDetailFilePathStyle}
                     onDoubleClick={() => {
                       this.props.diff(
-                        this.props.app,
                         modifiedFile.modified_file_path,
                         this.props.data.commit,
                         this.props.data.pre_commit

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,6 +4,15 @@ import { URLExt } from '@jupyterlab/coreutils';
 
 'use strict';
 
+
+
+/** Function type for diffing a file's revisions */
+export type IDiffCallback = (
+  filename: string,
+  revisionA: string,
+  revisionB: string
+) => void;
+
 /** Interface for GitAllHistory request result,
  * has all repo information */
 export interface GitAllHistory {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,9 @@ import { Token } from '@phosphor/coreutils';
 
 import { gitTabStyle } from './componentsStyle/GitWidgetStyle';
 
+import { IDiffCallback } from './git';
+export { IDiffCallback } from './git';
+
 import '../style/variables.css';
 import {GitClone} from "./gitClone";
 
@@ -29,14 +32,6 @@ import {GitClone} from "./gitClone";
 export const EXTENSION_ID = 'jupyter.extensions.git_plugin';
 
 export const IGitExtension = new Token<IGitExtension>(EXTENSION_ID);
-
-
-/** Function type for diffing a file's revisions */
-export type IDiffCallback = (
-  filename: string,
-  revisionA: string,
-  revisionB: string
-) => void;
 
 
 /** Interface for extension class */
@@ -67,6 +62,7 @@ export class GitExtension implements IGitExtension {
   git_plugin: GitWidget;
   git_clone_widget: GitClone;
   constructor(app: JupyterLab, restorer: ILayoutRestorer, factory: IFileBrowserFactory) {
+    this.app = app;
     this.git_plugin = new GitWidget(
       app,
       { manager: app.serviceManager },
@@ -93,7 +89,6 @@ export class GitExtension implements IGitExtension {
   }
 
   performDiff(
-    app: JupyterLab,
     filename: string,
     revisionA: string,
     revisionB: string
@@ -102,12 +97,13 @@ export class GitExtension implements IGitExtension {
     if (this.diffProviders[extension] !== undefined) {
       this.diffProviders[extension](filename, revisionA, revisionB);
     } else {
-      app.commands.execute('git:terminal-cmd', {
+      this.app.commands.execute('git:terminal-cmd', {
         cmd: 'git diff ' + revisionA + ' ' + revisionB
       });
     }
   }
 
+  private app: JupyterLab;
   private diffProviders: { [key: string]: IDiffCallback } = {};
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
   IFileBrowserFactory
 } from '@jupyterlab/filebrowser'
 
-import { IMainMenu } from '@jupyterlab/mainmenu';
+import {IMainMenu } from '@jupyterlab/mainmenu';
 
 import { Menu } from '@phosphor/widgets';
 
@@ -25,12 +25,33 @@ import { gitTabStyle } from './componentsStyle/GitWidgetStyle';
 import '../style/variables.css';
 import {GitClone} from "./gitClone";
 
+
+export const EXTENSION_ID = 'jupyter.extensions.git_plugin';
+
+export const IGitExtension = new Token<IGitExtension>(EXTENSION_ID);
+
+
+/** Function type for diffing a file's revisions */
+export type IDiffCallback = (
+  filename: string,
+  revisionA: string,
+  revisionB: string
+) => void;
+
+
+/** Interface for extension class */
+export interface IGitExtension {
+  registerDiffProvider(filetypes: string[], callback: IDiffCallback): void;
+}
+
+
 /**
  * The default running sessions extension.
  */
 const plugin: JupyterLabPlugin<IGitExtension> = {
   id: 'jupyter.extensions.running-sessions-git',
   requires: [IMainMenu, ILayoutRestorer, IFileBrowserFactory],
+  provides: IGitExtension,
   activate,
   autoStart: true
 };
@@ -40,21 +61,6 @@ const plugin: JupyterLabPlugin<IGitExtension> = {
  */
 export default plugin;
 
-export const EXTENSION_ID = 'jupyter.extensions.git_plugin';
-
-export const IGitExtension = new Token<IGitExtension>(EXTENSION_ID);
-
-/** Interface for extension class */
-export interface IGitExtension {
-  register_diff_provider(filetypes: string[], callback: IDiffCallback): void;
-}
-
-/** Function type for diffing a file's revisions */
-export type IDiffCallback = (
-  filename: string,
-  revisionA: string,
-  revisionB: string
-) => void;
 
 /** Main extension class */
 export class GitExtension implements IGitExtension {
@@ -80,7 +86,7 @@ export class GitExtension implements IGitExtension {
     this.git_clone_widget = new GitClone(factory);
   }
 
-  register_diff_provider(filetypes: string[], callback: IDiffCallback): void {
+  registerDiffProvider(filetypes: string[], callback: IDiffCallback): void {
     filetypes.forEach(fileType => {
       this.diffProviders[fileType] = callback;
     });
@@ -104,6 +110,8 @@ export class GitExtension implements IGitExtension {
 
   private diffProviders: { [key: string]: IDiffCallback } = {};
 }
+
+
 /**
  * Activate the running plugin.
  */


### PR DESCRIPTION
- Rename `register_diff_provider` --> `registerDiffProvider`.
- Ensure `IGitExtension` is listed in `provides` of plugin.
- Re-order declarations to enable previous point (and help reading of code).

TODO: Still untested. I'll try to develop against this locally with nbdime and see if I can get this to work. If and when, I'll ping this PR again!

Fixes #192.