### PR TITLE
Add friction to discard action for all changes and single file changes

### DIFF
--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -111,9 +111,9 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       disableFiles: false
     };
 
-    /** Add right-click menu options for files in repo 
-      * 
-      */
+    /** Add right-click menu options for files in repo
+     *
+     */
 
     if (!commands.hasCommand(CommandIDs.gitFileOpen)) {
       commands.addCommand(CommandIDs.gitFileOpen, {
@@ -216,7 +216,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   }
 
   /** Handle clicks on a staged file
-   * 
+   *
    */
   handleClickStaged(event: any) {
     event.preventDefault();
@@ -393,9 +393,19 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   /** Discard changes in all unstaged files */
   discardAllUnstagedFiles(path: string, refresh: Function) {
     let gitApi = new Git();
-    gitApi.checkout(false, false, null, true, null, path).then(response => {
-      refresh();
-    });
+    gitApi
+      .checkout(false, false, null, true, null, path)
+      .then(response => {
+        refresh();
+      })
+      .catch(() => {
+        showDialog({
+          title: 'Discard all changes failed.',
+          buttons: [Dialog.warnButton({ label: 'DISMISS' })]
+        }).then(() => {
+          /** no-op */
+        });
+      });
   }
 
   /** Add a specific unstaged file */
@@ -409,9 +419,19 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   /** Discard changes in a specific unstaged file */
   discardUnstagedFile(file: string, path: string, refresh: Function) {
     let gitApi = new Git();
-    gitApi.checkout(false, false, null, false, file, path).then(response => {
-      refresh();
-    });
+    gitApi
+      .checkout(false, false, null, false, file, path)
+      .then(response => {
+        refresh();
+      })
+      .catch(() => {
+        showDialog({
+          title: `Discard changes for ${file} failed.`,
+          buttons: [Dialog.warnButton({ label: 'DISMISS' })]
+        }).then(() => {
+          /** no-op */
+        });
+      });
   }
 
   /** Add all untracked files */


### PR DESCRIPTION
### Notes
This change includes a modal confirmation before discarding all or single file changes and Error message when discard operation fails.

It fixes #226 

### Screenshots of pop-ups
#### Discard all changes
![discardallchanges](https://user-images.githubusercontent.com/15882916/47171105-b2306200-d2bc-11e8-963d-e6affb697344.png)

#### Discard single file changes
![discardsinglefilechanges](https://user-images.githubusercontent.com/15882916/47171162-d3914e00-d2bc-11e8-9bd3-ef6d8e36170c.png)

#### Discard all changes failed
![discardallchangesfailure](https://user-images.githubusercontent.com/15882916/47171165-d5f3a800-d2bc-11e8-9b4c-212a8e3ed21b.png)

#### Discard single file changes failed
![discardsinglefilechangesfailure](https://user-images.githubusercontent.com/15882916/47171171-d9872f00-d2bc-11e8-8833-7ed75d965f29.png)