### PR TITLE
Fix branch UX to show correct current branch

### DIFF
--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -122,8 +122,8 @@ export class GitPanel extends React.Component<
     }
   };
 
-  /** 
-   * Refresh widget, update all content 
+  /**
+   * Refresh widget, update all content
    */
   refresh = async () => {
     try {
@@ -151,7 +151,7 @@ export class GitPanel extends React.Component<
           if (branchData.code === 0) {
             let allBranches = (branchData as GitBranchResult).branches;
             for (var i = 0; i < allBranches.length; i++) {
-              if (allBranches[i].current[0]) {
+              if (allBranches[i].current) {
                 currentBranch = allBranches[i].name;
                 break;
               }
@@ -311,7 +311,8 @@ export class GitPanel extends React.Component<
               <button
                 className={findRepoButtonStyle}
                 onClick={() =>
-                  this.props.app.commands.execute('filebrowser:toggle-main')}
+                  this.props.app.commands.execute('filebrowser:toggle-main')
+                }
               >
                 Go find a repo
               </button>


### PR DESCRIPTION
### Problem
When user switch branch or create new branch, even though the current branch is changed in the repo, it's not refreshed on the frontend.

### Notes
This change fixes the way to check for current branch to show on the frontend using current property of the branch which is a boolean [1] and was treated as list instead [2].

[1] https://github.com/jupyterlab/jupyterlab-git/blob/master/src/git.ts#L48
[2] https://github.com/jupyterlab/jupyterlab-git/blob/master/src/components/GitPanel.tsx#L154