### PR TITLE
Disable modal and enable a tooltip when clone button is disabled

### DIFF
--- a/src/gitClone.ts
+++ b/src/gitClone.ts
@@ -28,8 +28,6 @@ export class GitClone extends Widget {
     fileBrowser: FileBrowser;
     gitApi: Git;
     enabledCloneButton: ToolbarButton;
-    disabledGitButton: HTMLSpanElement;
-    enabledGitButton: HTMLSpanElement;
     disabledCloneButton: ToolbarButton;
 
     /**
@@ -58,15 +56,6 @@ export class GitClone extends Widget {
 
         // Attached a listener on the pathChanged event.
         factory.defaultBrowser.model.pathChanged.connect(() => this.disableIfInGitDirectory());
-
-        // Create the elements for the Git button toggling
-        let disabledGitButton = document.createElement('span');
-        disabledGitButton.className = `${this.gitTabStyleDisabled} jp-Icon jp-Icon-16`;
-
-        let enabledGitButton = document.createElement('span');
-        enabledGitButton.className =  `${this.gitTabStyleEnabled} jp-Icon jp-Icon-16`;
-        this.disabledGitButton = disabledGitButton;
-        this.enabledGitButton =  enabledGitButton;
     }
 
     /**


### PR DESCRIPTION
Previously, the onClick modal would still fire even if the button was disabled. Also, the tooltip wouldn't reflect why the button is disabled. This change fixes both of those.


#253 

### Screenshots
<img width="500" alt="screen shot 2018-10-18 at 11 46 49 pm" src="https://user-images.githubusercontent.com/43826141/47201913-59021600-d330-11e8-97da-791dbd50239d.png">

cc: @neelamgehlot  FYI
