### PR TITLE
Release 0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/git",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "description": "A JupyterLab extension for version control using git",
   "main": "lib/index.js",
   "license": "BSD-3-Clause",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='jupyterlab_git',
-    version='0.3.0',
+    version='0.4.4',
     author='Git Intern Team, Noah Stapp, Jenna Landy, Alena Mueller',
     description="A server extension for JupyterLab's git extension",
     long_description=long_description,


### PR DESCRIPTION
https://pypi.org/project/jupyterlab-git/0.4.4/#history
https://www.npmjs.com/package/@jupyterlab/git

I don't think there is a way to create tags via PR.  If so, I can push a `v0.4.4` tag to the repo after this is merged.

Related to #262 