### PR TITLE
Improve history overview

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy'
   },
-  testRegex: '/tests/test-.*/.*.spec.ts$',
+  testRegex: '/tests/test-.*/.*.spec.ts[x]?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testPathIgnorePatterns: ['/dev_mode/', '/lib/', '/node_modules/'],
   automock: false,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,11 @@
     "typestyle": "^2.0.1"
   },
   "devDependencies": {
+    "@types/enzyme": "3.1.15",
     "@types/jest": "^23.3.5",
+    "@types/react": "16.4.16",
+    "enzyme": "3.7.0",
+    "enzyme-adapter-react-16": "1.7.0",
     "jest": "^23.6.0",
     "jest-fetch-mock": "^1.6.6",
     "prettier": "^1.14.3",

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,1 +1,4 @@
 global.fetch = require('jest-fetch-mock');
+require("enzyme").configure({
+    adapter: new (require('enzyme-adapter-react-16'))
+});

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -19,7 +19,9 @@ import {
   smallBranchStyle,
   expandedBranchStyle,
   openHistorySideBarButtonStyle,
-  openHistorySideBarIconStyle,
+  historyLabelStyle,
+  selectedHeaderStyle,
+  unSelectedHeaderStyle,
   branchHeaderCenterContent,
   branchTrackingIconStyle,
   branchTrackingLabelStyle
@@ -47,6 +49,7 @@ export interface IBranchHeaderProps {
   toggleSidebar: Function;
   showList: boolean;
   currentTheme: string;
+  sideBarExpanded: boolean;
 }
 
 export class BranchHeader extends React.Component<
@@ -158,74 +161,103 @@ export class BranchHeader extends React.Component<
     }
   };
 
+  getHistoryHeaderStyle() {
+    if (this.props.sideBarExpanded) {
+      return classes(
+        openHistorySideBarButtonStyle,
+        selectedHeaderStyle
+      );
+    }
+    return classes(
+      unSelectedHeaderStyle,
+      openHistorySideBarButtonStyle
+    )
+  }
+
+  getBranchHeaderStyle() {
+    if (this.props.sideBarExpanded) {
+      return classes(
+        branchHeaderCenterContent,
+        unSelectedHeaderStyle
+      );
+    }
+    return classes(
+      selectedHeaderStyle,
+      branchHeaderCenterContent
+    )
+  }
+
   render() {
     return (
       <div className={this.getBranchStyle()}>
-        <button
-          className={openHistorySideBarButtonStyle}
-          onClick={() => this.props.toggleSidebar()}
-          title={'Show commit history'}
-        >
-          History
-          <span className={openHistorySideBarIconStyle} />
-        </button>
-        <div className={branchHeaderCenterContent}>
-          <h3 className={branchLabelStyle}>{this.props.currentBranch}</h3>
-          <div
-            className={
-              this.props.disabled
-                ? classes(
-                    branchDropdownButtonStyle(this.props.currentTheme),
-                    headerButtonDisabledStyle
-                  )
-                : branchDropdownButtonStyle(this.props.currentTheme)
-            }
-            title={'Change the current branch'}
-            onClick={() => this.toggleSelect()}
-          />
-          {!this.state.showNewBranchBox && (
+        <div style={{display: "flex"}}>
+          <div className={this.getHistoryHeaderStyle()}
+            onClick={this.props.sideBarExpanded ? null : () => this.props.toggleSidebar()}
+            title={'Show commit history'}
+          >
+            <h3 className={historyLabelStyle}>History</h3>
+          </div>
+          <div className={this.getBranchHeaderStyle()}
+            onClick={this.props.sideBarExpanded ? () => this.props.toggleSidebar() : null}
+          >
+            <h3 className={branchLabelStyle}>{this.props.currentBranch}</h3>
             <div
               className={
                 this.props.disabled
                   ? classes(
-                      newBranchButtonStyle(this.props.currentTheme),
+                      branchDropdownButtonStyle(this.props.currentTheme),
                       headerButtonDisabledStyle
                     )
-                  : newBranchButtonStyle(this.props.currentTheme)
+                  : branchDropdownButtonStyle(this.props.currentTheme)
               }
-              title={'Create a new branch'}
-              onClick={() => this.toggleNewBranchBox()}
+              title={'Change the current branch'}
+              onClick={() => this.toggleSelect()}
             />
-          )}
-          {this.state.showNewBranchBox &&
-            this.props.showList && (
-              <NewBranchBox
-                createNewBranch={this.createNewBranch}
-                toggleNewBranchBox={this.toggleNewBranchBox}
+            {!this.state.showNewBranchBox && (
+              <div
+                className={
+                  this.props.disabled
+                    ? classes(
+                        newBranchButtonStyle(this.props.currentTheme),
+                        headerButtonDisabledStyle
+                      )
+                    : newBranchButtonStyle(this.props.currentTheme)
+                }
+                title={'Create a new branch'}
+                onClick={() => this.toggleNewBranchBox()}
               />
             )}
-          {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<div className={branchTrackingIconStyle}/>)}
-          {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<h3 className={branchTrackingLabelStyle}>{this.props.upstreamBranch}</h3>)}
-        </div>
-        {this.state.dropdownOpen && (
-          <div>
-            {this.props.data.map((branch: any, branchIndex: number) => {
-              return (
-                <li
-                  className={branchListItemStyle}
-                  key={branchIndex}
-                  onClick={() => this.switchBranch(branch.name)}
-                >
-                  {branch.name}
-                </li>
-              );
-            })}
+            {this.state.showNewBranchBox &&
+              this.props.showList && (
+                <NewBranchBox
+                  createNewBranch={this.createNewBranch}
+                  toggleNewBranchBox={this.toggleNewBranchBox}
+                />
+              )}
+            {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<div className={branchTrackingButtonStyle}/>)}
+            {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<h3 className={branchTrackingLabelStyle}>{this.props.upstreamBranch}</h3>)}
           </div>
-        )}
-        {this.state.showNewBranchBox && (
-          <div>Branching from {this.props.currentBranch}</div>
-        )}
-        {this.state.showCommitBox &&
+          {this.state.dropdownOpen && (
+            <div>
+              {this.props.data.map((branch: any, branchIndex: number) => {
+                return (
+                  <li
+                    className={branchListItemStyle}
+                    key={branchIndex}
+                    onClick={() => this.switchBranch(branch.name)}
+                  >
+                    {branch.name}
+                  </li>
+                );
+              })}
+            </div>
+          )}
+          {this.state.showNewBranchBox && (
+            <div>Branching from {this.props.currentBranch}</div>
+          )}
+        </div>
+        {!this.props.sideBarExpanded &&
+          this.state.showCommitBox &&
           this.props.showList && (
             <CommitBox
               checkReadyForSubmit={this.updateCommitBoxState}

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -237,25 +237,25 @@ export class BranchHeader extends React.Component<
             {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<div className={branchTrackingButtonStyle}/>)}
             {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<h3 className={branchTrackingLabelStyle}>{this.props.upstreamBranch}</h3>)}
           </div>
-          {this.state.dropdownOpen && (
-            <div>
-              {this.props.data.map((branch: any, branchIndex: number) => {
-                return (
-                  <li
-                    className={branchListItemStyle}
-                    key={branchIndex}
-                    onClick={() => this.switchBranch(branch.name)}
-                  >
-                    {branch.name}
-                  </li>
-                );
-              })}
-            </div>
-          )}
-          {this.state.showNewBranchBox && (
-            <div>Branching from {this.props.currentBranch}</div>
-          )}
         </div>
+        {this.state.dropdownOpen && (
+          <div>
+            {this.props.data.map((branch: any, branchIndex: number) => {
+              return (
+                <li
+                  className={branchListItemStyle}
+                  key={branchIndex}
+                  onClick={() => this.switchBranch(branch.name)}
+                >
+                  {branch.name}
+                </li>
+              );
+            })}
+          </div>
+        )}
+        {this.state.showNewBranchBox && (
+          <div>Branching from {this.props.currentBranch}</div>
+        )}
         {!this.props.sideBarExpanded &&
           this.state.showCommitBox &&
           this.props.showList && (

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -238,35 +238,36 @@ export class BranchHeader extends React.Component<
             {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<h3 className={branchTrackingLabelStyle}>{this.props.upstreamBranch}</h3>)}
           </div>
         </div>
-        {this.state.dropdownOpen && (
-          <div>
-            {this.props.data.map((branch: any, branchIndex: number) => {
-              return (
-                <li
-                  className={branchListItemStyle}
-                  key={branchIndex}
-                  onClick={() => this.switchBranch(branch.name)}
-                >
-                  {branch.name}
-                </li>
-              );
-            })}
-          </div>
-        )}
-        {this.state.showNewBranchBox && (
-          <div>Branching from {this.props.currentBranch}</div>
-        )}
-        {!this.props.sideBarExpanded &&
-          this.state.showCommitBox &&
-          this.props.showList && (
-            <CommitBox
-              checkReadyForSubmit={this.updateCommitBoxState}
-              stagedFiles={this.props.stagedFiles}
-              commitAllStagedFiles={this.commitAllStagedFiles}
-              topRepoPath={this.props.topRepoPath}
-              refresh={this.props.refresh}
-            />
+        {!this.props.sideBarExpanded && (<>
+          {this.state.dropdownOpen && (
+            <div>
+              {this.props.data.map((branch: any, branchIndex: number) => {
+                return (
+                  <li
+                    className={branchListItemStyle}
+                    key={branchIndex}
+                    onClick={() => this.switchBranch(branch.name)}
+                  >
+                    {branch.name}
+                  </li>
+                );
+              })}
+            </div>
           )}
+          {this.state.showNewBranchBox && (
+            <div>Branching from {this.props.currentBranch}</div>
+          )}
+          {this.state.showCommitBox &&
+            this.props.showList && (
+              <CommitBox
+                checkReadyForSubmit={this.updateCommitBoxState}
+                stagedFiles={this.props.stagedFiles}
+                commitAllStagedFiles={this.commitAllStagedFiles}
+                topRepoPath={this.props.topRepoPath}
+                refresh={this.props.refresh}
+              />
+            )}
+        </>)}
       </div>
     );
   }

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -234,7 +234,7 @@ export class BranchHeader extends React.Component<
                   toggleNewBranchBox={this.toggleNewBranchBox}
                 />
               )}
-            {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<div className={branchTrackingButtonStyle}/>)}
+            {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<div className={branchTrackingIconStyle}/>)}
             {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<h3 className={branchTrackingLabelStyle}>{this.props.upstreamBranch}</h3>)}
           </div>
         </div>

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -276,15 +276,11 @@ export class GitPanel extends React.Component<
               />
               <HistorySideBar
                 isExpanded={this.state.sideBarExpanded}
-                currentFileBrowserPath={this.state.currentFileBrowserPath}
                 pastCommits={this.state.pastCommits}
-                setShowList={this.setShowList}
-                getPastCommit={this.showPastCommitWork}
               />
               <PastCommits
                 currentFileBrowserPath={this.state.currentFileBrowserPath}
                 topRepoPath={this.state.topRepoPath}
-                pastCommits={this.state.pastCommits}
                 inNewRepo={this.state.inNewRepo}
                 showList={this.state.showList}
                 stagedFiles={this.state.stagedFiles}
@@ -293,13 +289,6 @@ export class GitPanel extends React.Component<
                 app={this.props.app}
                 refresh={this.refresh}
                 diff={this.props.diff}
-                pastCommitInfo={this.state.pastCommitInfo}
-                pastCommitFilesChanged={this.state.pastCommitFilesChanged}
-                pastCommitInsertionCount={this.state.pastCommitInsertionCount}
-                pastCommitDeletionCount={this.state.pastCommitDeletionCount}
-                pastCommitData={this.state.pastCommitData}
-                pastCommitNumber={this.state.pastCommitNumber}
-                pastCommitFilelist={this.state.pastCommitFilelist}
                 sideBarExpanded={this.state.sideBarExpanded}
                 currentTheme={this.props.app.shell.dataset.themeLight}
               />

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -23,13 +23,10 @@ import { HistorySideBar } from './HistorySideBar';
 
 import {
   panelContainerStyle,
-  panelPushedContentStyle,
-  panelContentStyle,
   panelWarningStyle,
   findRepoButtonStyle
 } from '../componentsStyle/GitPanelStyle';
 
-import { classes } from 'typestyle';
 
 /** Interface for GitPanel component state */
 export interface IGitSessionNodeState {
@@ -249,11 +246,7 @@ export class GitPanel extends React.Component<
     this.setState({ sideBarExpanded: !this.state.sideBarExpanded });
   };
 
-  getContentClass(): string {
-    return this.state.sideBarExpanded
-      ? classes(panelPushedContentStyle, panelContentStyle)
-      : panelContentStyle;
-  }
+
 
   render() {
     return (
@@ -264,16 +257,9 @@ export class GitPanel extends React.Component<
           refresh={this.refresh}
           currentBranch={this.state.currentBranch}
         />
-        <div className={this.getContentClass()}>
+        <div>
           {this.state.showWarning && (
             <div>
-              <HistorySideBar
-                isExpanded={this.state.sideBarExpanded}
-                currentFileBrowserPath={this.state.currentFileBrowserPath}
-                pastCommits={this.state.pastCommits}
-                setShowList={this.setShowList}
-                getPastCommit={this.showPastCommitWork}
-              />
               <BranchHeader
                 currentFileBrowserPath={this.state.currentFileBrowserPath}
                 topRepoPath={this.state.topRepoPath}
@@ -286,6 +272,14 @@ export class GitPanel extends React.Component<
                 toggleSidebar={this.toggleSidebar}
                 showList={this.state.showList}
                 currentTheme={this.props.app.shell.dataset.themeLight}
+                sideBarExpanded={this.state.sideBarExpanded}
+              />
+              <HistorySideBar
+                isExpanded={this.state.sideBarExpanded}
+                currentFileBrowserPath={this.state.currentFileBrowserPath}
+                pastCommits={this.state.pastCommits}
+                setShowList={this.setShowList}
+                getPastCommit={this.showPastCommitWork}
               />
               <PastCommits
                 currentFileBrowserPath={this.state.currentFileBrowserPath}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -276,6 +276,7 @@ export class GitPanel extends React.Component<
               />
               <HistorySideBar
                 isExpanded={this.state.sideBarExpanded}
+                data={this.state.branches}
                 pastCommits={this.state.pastCommits}
               />
               <PastCommits

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -242,7 +242,7 @@ export class GitPanel extends React.Component<
               />
               <HistorySideBar
                 isExpanded={this.state.sideBarExpanded}
-                data={this.state.branches}
+                branches={this.state.branches}
                 pastCommits={this.state.pastCommits}
                 topRepoPath={this.state.topRepoPath}
                 currentTheme={this.props.app.shell.dataset.themeLight}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -49,13 +49,6 @@ export interface IGitSessionNodeState {
 
   sideBarExpanded: boolean;
 
-  pastCommitInfo: string;
-  pastCommitFilesChanged: string;
-  pastCommitInsertionCount: string;
-  pastCommitDeletionCount: string;
-  pastCommitData: any;
-  pastCommitNumber: any;
-  pastCommitFilelist: any;
 }
 
 /** Interface for GitPanel component props */
@@ -86,13 +79,6 @@ export class GitPanel extends React.Component<
       unstagedFiles: [],
       untrackedFiles: [],
       sideBarExpanded: false,
-      pastCommitInfo: '',
-      pastCommitFilesChanged: '',
-      pastCommitInsertionCount: '',
-      pastCommitDeletionCount: '',
-      pastCommitData: '',
-      pastCommitNumber: '',
-      pastCommitFilelist: ''
     };
   }
 
@@ -100,26 +86,6 @@ export class GitPanel extends React.Component<
     this.setState({ showList: state });
   };
 
-  /** Show the commit message and changes from a past commit */
-  showPastCommitWork = async (
-    pastCommit: SingleCommitInfo,
-    pastCommitIndex: number,
-    path: string
-  ) => {
-    let gitApi = new Git();
-    let detailedLogData = await gitApi.detailedLog(pastCommit.commit, path);
-    if (detailedLogData.code === 0) {
-      this.setState({
-        pastCommitInfo: detailedLogData.modified_file_note,
-        pastCommitFilesChanged: detailedLogData.modified_files_count,
-        pastCommitInsertionCount: detailedLogData.number_of_insertions,
-        pastCommitDeletionCount: detailedLogData.number_of_deletions,
-        pastCommitData: pastCommit,
-        pastCommitNumber: pastCommitIndex + ' commit(s) before',
-        pastCommitFilelist: detailedLogData.modified_files
-      });
-    }
-  };
 
   /**
    * Refresh widget, update all content
@@ -278,6 +244,11 @@ export class GitPanel extends React.Component<
                 isExpanded={this.state.sideBarExpanded}
                 data={this.state.branches}
                 pastCommits={this.state.pastCommits}
+                topRepoPath={this.state.topRepoPath}
+                currentTheme={this.props.app.shell.dataset.themeLight}
+                app={this.props.app}
+                refresh={this.refresh}
+                diff={this.props.diff}
               />
               <PastCommits
                 currentFileBrowserPath={this.state.currentFileBrowserPath}

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -21,28 +21,12 @@ export interface IHistorySideBarProps {
   diff: any;
 }
 
-/** Interface for PastCommits component state */
-export interface IHistorySideBarState {
-  activeNode: number;
-}
+
 
 export class HistorySideBar extends React.Component<
   IHistorySideBarProps,
-  IHistorySideBarState
+  {}
 > {
-  constructor(props: IHistorySideBarProps) {
-    super(props);
-
-    this.state = {
-      activeNode: -1
-    };
-  }
-
-
-  updateActiveNode = (index: number): void => {
-    this.setState({ activeNode: index });
-  };
-
   render() {
     if (!this.props.isExpanded) {
       return null;

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -4,20 +4,15 @@ import { SingleCommitInfo } from "../git";
 
 import {
   historySideBarStyle,
-  historySideBarExpandedStyle
 } from "../componentsStyle/HistorySideBarStyle";
 
-import { classes } from "typestyle";
 
 import * as React from "react";
 
 /** Interface for PastCommits component props */
 export interface IHistorySideBarProps {
-  currentFileBrowserPath: string;
   pastCommits: SingleCommitInfo[];
   isExpanded: boolean;
-  setShowList: Function;
-  getPastCommit: Function;
 }
 
 /** Interface for PastCommits component state */
@@ -37,11 +32,6 @@ export class HistorySideBar extends React.Component<
     };
   }
 
-  getSideBarClass(): string {
-    return this.props.isExpanded
-      ? classes(historySideBarExpandedStyle, historySideBarStyle)
-      : historySideBarStyle;
-  }
 
   updateActiveNode = (index: number): void => {
     this.setState({ activeNode: index });
@@ -52,32 +42,12 @@ export class HistorySideBar extends React.Component<
       return null;
     }
     return (
-      <div className={this.getSideBarClass()}>
-        <PastCommitNode
-          key={-1}
-          index={-1}
-          isLast={false}
-          pastCommit={null}
-          currentFileBrowserPath={this.props.currentFileBrowserPath}
-          setShowList={this.props.setShowList}
-          getPastCommit={this.props.getPastCommit}
-          activeNode={this.state.activeNode}
-          updateActiveNode={this.updateActiveNode}
-          isVisible={this.props.isExpanded}
-        />
+      <div className={historySideBarStyle}>
         {this.props.pastCommits.map(
           (pastCommit: SingleCommitInfo, pastCommitIndex: number) => (
             <PastCommitNode
               key={pastCommitIndex}
-              index={pastCommitIndex}
-              isLast={pastCommitIndex === this.props.pastCommits.length - 1}
               pastCommit={pastCommit}
-              currentFileBrowserPath={this.props.currentFileBrowserPath}
-              setShowList={this.props.setShowList}
-              getPastCommit={this.props.getPastCommit}
-              activeNode={this.state.activeNode}
-              updateActiveNode={this.updateActiveNode}
-              isVisible={this.props.isExpanded}
             />
           )
         )}

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -1,6 +1,6 @@
 import { PastCommitNode } from "./PastCommitNode";
 
-import { SingleCommitInfo } from "../git";
+import { SingleCommitInfo, GitBranchResult } from "../git";
 
 import {
   historySideBarStyle,
@@ -12,6 +12,7 @@ import * as React from "react";
 /** Interface for PastCommits component props */
 export interface IHistorySideBarProps {
   pastCommits: SingleCommitInfo[];
+  data: GitBranchResult["branches"];
   isExpanded: boolean;
 }
 
@@ -48,6 +49,7 @@ export class HistorySideBar extends React.Component<
             <PastCommitNode
               key={pastCommitIndex}
               pastCommit={pastCommit}
+              data={this.props.data}
             />
           )
         )}

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -14,6 +14,11 @@ export interface IHistorySideBarProps {
   pastCommits: SingleCommitInfo[];
   data: GitBranchResult["branches"];
   isExpanded: boolean;
+  topRepoPath: string;
+  currentTheme: string;
+  app: any;
+  refresh: any;
+  diff: any;
 }
 
 /** Interface for PastCommits component state */
@@ -50,6 +55,11 @@ export class HistorySideBar extends React.Component<
               key={pastCommitIndex}
               pastCommit={pastCommit}
               data={this.props.data}
+              topRepoPath={this.props.topRepoPath}
+              currentTheme={this.props.currentTheme}
+              app={this.props.app}
+              refresh={this.props.refresh}
+              diff={this.props.diff}
             />
           )
         )}

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -1,13 +1,8 @@
-import { PastCommitNode } from "./PastCommitNode";
-
-import { SingleCommitInfo, GitBranchResult } from "../git";
-
-import {
-  historySideBarStyle,
-} from "../componentsStyle/HistorySideBarStyle";
-
-
+import { JupyterLab } from "@jupyterlab/application";
 import * as React from "react";
+import { historySideBarStyle } from "../componentsStyle/HistorySideBarStyle";
+import { GitBranchResult, SingleCommitInfo } from "../git";
+import { PastCommitNode } from "./PastCommitNode";
 
 /** Interface for PastCommits component props */
 export interface IHistorySideBarProps {
@@ -16,17 +11,17 @@ export interface IHistorySideBarProps {
   isExpanded: boolean;
   topRepoPath: string;
   currentTheme: string;
-  app: any;
-  refresh: any;
-  diff: any;
+  app: JupyterLab;
+  refresh: () => void;
+  diff: (
+    app: JupyterLab,
+    filename: string,
+    revisionA: string,
+    revisionB: string
+  ) => void;
 }
 
-
-
-export class HistorySideBar extends React.Component<
-  IHistorySideBarProps,
-  {}
-> {
+export class HistorySideBar extends React.Component<IHistorySideBarProps, {}> {
   render() {
     if (!this.props.isExpanded) {
       return null;

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -12,7 +12,7 @@ import * as React from "react";
 /** Interface for PastCommits component props */
 export interface IHistorySideBarProps {
   pastCommits: SingleCommitInfo[];
-  data: GitBranchResult["branches"];
+  branches: GitBranchResult["branches"];
   isExpanded: boolean;
   topRepoPath: string;
   currentTheme: string;
@@ -38,7 +38,7 @@ export class HistorySideBar extends React.Component<
             <PastCommitNode
               key={pastCommitIndex}
               pastCommit={pastCommit}
-              data={this.props.data}
+              branches={this.props.branches}
               topRepoPath={this.props.topRepoPath}
               currentTheme={this.props.currentTheme}
               app={this.props.app}

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -1,15 +1,15 @@
-import { PastCommitNode } from './PastCommitNode';
+import { PastCommitNode } from "./PastCommitNode";
 
-import { SingleCommitInfo } from '../git';
+import { SingleCommitInfo } from "../git";
 
 import {
   historySideBarStyle,
   historySideBarExpandedStyle
-} from '../componentsStyle/HistorySideBarStyle';
+} from "../componentsStyle/HistorySideBarStyle";
 
-import { classes } from 'typestyle';
+import { classes } from "typestyle";
 
-import * as React from 'react';
+import * as React from "react";
 
 /** Interface for PastCommits component props */
 export interface IHistorySideBarProps {
@@ -48,6 +48,9 @@ export class HistorySideBar extends React.Component<
   };
 
   render() {
+    if (!this.props.isExpanded) {
+      return null;
+    }
     return (
       <div className={this.getSideBarClass()}>
         <PastCommitNode

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -3,18 +3,46 @@ import {
   pastCommitHeaderStyle,
   pastCommitHeaderItemStyle,
   pastCommitBodyStyle,
-} from '../componentsStyle/PastCommitNodeStyle';
-import { SingleCommitInfo } from "../git";
+  branchStyle,
+  branchesStyle,
+  remoteBranchStyle,
+  localBranchStyle,
+  workingBranchStyle
+} from "../componentsStyle/PastCommitNodeStyle";
 
+import { classes } from "typestyle";
 
-import * as React from 'react';
+import { SingleCommitInfo, GitBranchResult } from "../git";
+
+import * as React from "react";
 
 export interface IPastCommitNodeProps {
   pastCommit: SingleCommitInfo;
-
+  data: GitBranchResult["branches"];
 }
 
 export class PastCommitNode extends React.Component<IPastCommitNodeProps, {}> {
+  getBranchesForCommit() {
+    const idAbrev = this.props.pastCommit.commit.slice(0, 7);
+    const branches = [];
+    for (let i = 0; i < this.props.data.length; i++) {
+      const branch = this.props.data[i];
+      // https://git-scm.com/docs/git-describe#git-describe-ltcommit-ishgt82308203
+      if (!branch.tag) {
+        continue;
+      }
+      const tagParts = branch.tag.split("-");
+      const lastTagPart = tagParts[tagParts.length - 1];
+      if (lastTagPart[0] == "g") {
+        const currentIdAbrev = lastTagPart.slice(1);
+        if (currentIdAbrev == idAbrev) {
+          branches.push(branch);
+        }
+      }
+    }
+    return branches;
+  }
+
   render() {
     return (
       <div className={pastCommitNodeStyle}>
@@ -28,6 +56,26 @@ export class PastCommitNode extends React.Component<IPastCommitNodeProps, {}> {
           <div className={pastCommitHeaderItemStyle}>
             {this.props.pastCommit.date}
           </div>
+        </div>
+        <div className={branchesStyle}>
+          {this.getBranchesForCommit().map((branch, id) => (
+            <>
+              {branch.is_current_branch && (
+                <span className={classes(branchStyle, workingBranchStyle)} key={id}>
+                  working
+                </span>
+              )}
+              <span
+                className={classes(
+                  branchStyle,
+                  branch.is_remote_branch ? remoteBranchStyle : localBranchStyle
+                )}
+                key={id}
+              >
+                {branch.name}
+              </span>
+            </>
+          ))}
         </div>
         <div className={pastCommitBodyStyle}>
           {this.props.pastCommit.commit_msg}

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -7,21 +7,43 @@ import {
   branchesStyle,
   remoteBranchStyle,
   localBranchStyle,
-  workingBranchStyle
+  workingBranchStyle,
+  pastCommitExpandedStyle,
+  collapseStyle
 } from "../componentsStyle/PastCommitNodeStyle";
 
 import { classes } from "typestyle";
 
 import { SingleCommitInfo, GitBranchResult } from "../git";
 
+import { SinglePastCommitInfo } from "./SinglePastCommitInfo";
+
 import * as React from "react";
 
 export interface IPastCommitNodeProps {
   pastCommit: SingleCommitInfo;
   data: GitBranchResult["branches"];
+  topRepoPath: string;
+  currentTheme: string;
+  app: any;
+  diff: any;
+  refresh: any;
 }
 
-export class PastCommitNode extends React.Component<IPastCommitNodeProps, {}> {
+export interface IPastCommitNodeState {
+  expanded: boolean;
+}
+
+export class PastCommitNode extends React.Component<
+  IPastCommitNodeProps,
+  IPastCommitNodeState
+> {
+  constructor(props: IPastCommitNodeProps) {
+    super(props);
+    this.state = {
+      expanded: false
+    };
+  }
   getBranchesForCommit() {
     const idAbrev = this.props.pastCommit.commit.slice(0, 7);
     const branches = [];
@@ -44,9 +66,26 @@ export class PastCommitNode extends React.Component<IPastCommitNodeProps, {}> {
     return branches;
   }
 
+  expand() {
+    this.setState({expanded: true});
+  }
+
+  collapse() {
+    this.setState({expanded: false});
+  }
+
+  getNodeClass() {
+    if (this.state.expanded) {
+      return classes(pastCommitNodeStyle, pastCommitExpandedStyle)
+    }
+    return pastCommitNodeStyle
+  }
   render() {
     return (
-      <div className={pastCommitNodeStyle}>
+      <div
+        onClick={() => {!this.state.expanded && this.expand()}}
+        className={this.getNodeClass()}
+      >
         <div className={pastCommitHeaderStyle}>
           <div className={pastCommitHeaderItemStyle}>
             {this.props.pastCommit.author}
@@ -60,12 +99,9 @@ export class PastCommitNode extends React.Component<IPastCommitNodeProps, {}> {
         </div>
         <div className={branchesStyle}>
           {this.getBranchesForCommit().map((branch, id) => (
-            <>
+            <React.Fragment key={id}>
               {branch.is_current_branch && (
-                <span
-                  className={classes(branchStyle, workingBranchStyle)}
-                  key={id}
-                >
+                <span className={classes(branchStyle, workingBranchStyle)}>
                   working
                 </span>
               )}
@@ -74,15 +110,29 @@ export class PastCommitNode extends React.Component<IPastCommitNodeProps, {}> {
                   branchStyle,
                   branch.is_remote_branch ? remoteBranchStyle : localBranchStyle
                 )}
-                key={id}
               >
                 {branch.name}
               </span>
-            </>
+            </React.Fragment>
           ))}
         </div>
         <div className={pastCommitBodyStyle}>
           {this.props.pastCommit.commit_msg}
+          {this.state.expanded && (
+            <>
+              <SinglePastCommitInfo
+                data={this.props.pastCommit}
+                topRepoPath={this.props.topRepoPath}
+                currentTheme={this.props.currentTheme}
+                app={this.props.app}
+                diff={this.props.diff}
+                refresh={this.props.refresh}
+              />
+              <div className={collapseStyle} onClick={() => this.collapse()}>
+                Collapse
+              </div>
+            </>
+          )}
         </div>
       </div>
     );

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -22,7 +22,7 @@ import * as React from "react";
 
 export interface IPastCommitNodeProps {
   pastCommit: SingleCommitInfo;
-  data: GitBranchResult["branches"];
+  branches: GitBranchResult["branches"];
   topRepoPath: string;
   currentTheme: string;
   app: any;
@@ -47,8 +47,8 @@ export class PastCommitNode extends React.Component<
   getBranchesForCommit() {
     const idAbrev = this.props.pastCommit.commit.slice(0, 7);
     const branches = [];
-    for (let i = 0; i < this.props.data.length; i++) {
-      const branch = this.props.data[i];
+    for (let i = 0; i < this.props.branches.length; i++) {
+      const branch = this.props.branches[i];
       // tag sent from describe command. Must unparse to find commit hash
       // https://git-scm.com/docs/git-describe#git-describe-ltcommit-ishgt82308203
       if (!branch.tag) {

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -27,6 +27,7 @@ export class PastCommitNode extends React.Component<IPastCommitNodeProps, {}> {
     const branches = [];
     for (let i = 0; i < this.props.data.length; i++) {
       const branch = this.props.data[i];
+      // tag sent from describe command. Must unparse to find commit hash
       // https://git-scm.com/docs/git-describe#git-describe-ltcommit-ishgt82308203
       if (!branch.tag) {
         continue;
@@ -61,7 +62,10 @@ export class PastCommitNode extends React.Component<IPastCommitNodeProps, {}> {
           {this.getBranchesForCommit().map((branch, id) => (
             <>
               {branch.is_current_branch && (
-                <span className={classes(branchStyle, workingBranchStyle)} key={id}>
+                <span
+                  className={classes(branchStyle, workingBranchStyle)}
+                  key={id}
+                >
                   working
                 </span>
               )}

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -91,7 +91,7 @@ export class PastCommitNode extends React.Component<
             {this.props.pastCommit.author}
           </div>
           <div className={pastCommitHeaderItemStyle}>
-            {this.props.pastCommit.commit.slice(0, 9)}
+            {this.props.pastCommit.commit.slice(0, 7)}
           </div>
           <div className={pastCommitHeaderItemStyle}>
             {this.props.pastCommit.date}

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -1,114 +1,37 @@
 import {
   pastCommitNodeStyle,
-  pastCommitWorkingNodeStyle,
-  pastCommitContentStyle,
-  pastCommitWorkingContentStyle,
-  pastCommitHeadContentStyle,
-  pastCommitNumberContentStyle,
-  pastCommitActiveContentStyle,
-  pastCommitLineStyle
+  pastCommitHeaderStyle,
+  pastCommitHeaderItemStyle,
+  pastCommitBodyStyle,
 } from '../componentsStyle/PastCommitNodeStyle';
+import { SingleCommitInfo } from "../git";
 
-import { classes } from 'typestyle';
 
 import * as React from 'react';
 
 export interface IPastCommitNodeProps {
-  index: number;
-  isLast: boolean;
-  pastCommit: any;
-  currentFileBrowserPath: string;
-  setShowList: Function;
-  getPastCommit: Function;
-  activeNode: number;
-  updateActiveNode: Function;
-  isVisible: boolean;
+  pastCommit: SingleCommitInfo;
+
 }
 
 export class PastCommitNode extends React.Component<IPastCommitNodeProps, {}> {
-  constructor(props: IPastCommitNodeProps) {
-    super(props);
-  }
-
-  getPastCommitNodeClass(): string {
-    if (!this.props.isVisible) {
-      return null;
-    }
-    return this.props.index === -1
-      ? classes(pastCommitWorkingNodeStyle, pastCommitNodeStyle)
-      : classes(pastCommitNodeStyle);
-  }
-
-  getPastCommitLineClass(): string {
-    if (!this.props.isVisible) {
-      return null;
-    }
-    return this.props.isLast ? null : classes(pastCommitLineStyle);
-  }
-
-  getContent(): string | number {
-    if (this.props.index === -1) {
-      return 'WORKING';
-    } else if (this.props.index === 0) {
-      return 'HEAD';
-    } else {
-      return this.props.index;
-    }
-  }
-
-  getContentClass(): string {
-    const activeContentStyle =
-      this.props.index === this.props.activeNode
-        ? pastCommitActiveContentStyle
-        : null;
-    if (!this.props.isVisible) {
-      return null;
-    }
-    if (this.props.index === -1) {
-      return classes(
-        pastCommitWorkingContentStyle,
-        pastCommitContentStyle,
-        activeContentStyle
-      );
-    } else if (this.props.index === 0) {
-      return classes(
-        pastCommitHeadContentStyle,
-        pastCommitContentStyle,
-        activeContentStyle
-      );
-    } else {
-      return classes(
-        pastCommitNumberContentStyle,
-        pastCommitContentStyle,
-        activeContentStyle
-      );
-    }
-  }
-
-  handleClick(): void {
-    this.props.index === -1
-      ? this.props.setShowList(true)
-      : (this.props.getPastCommit(
-          this.props.pastCommit,
-          this.props.index,
-          this.props.currentFileBrowserPath
-        ),
-        this.props.setShowList(false));
-    this.props.updateActiveNode(this.props.index);
-  }
-
   render() {
     return (
-      <div key={this.props.index}>
-        <div
-          className={this.getPastCommitNodeClass()}
-          onClick={() => this.handleClick()}
-        >
-          <span className={this.getContentClass()}>
-            {this.props.isVisible && this.getContent()}
-          </span>
+      <div className={pastCommitNodeStyle}>
+        <div className={pastCommitHeaderStyle}>
+          <div className={pastCommitHeaderItemStyle}>
+            {this.props.pastCommit.author}
+          </div>
+          <div className={pastCommitHeaderItemStyle}>
+            {this.props.pastCommit.commit.slice(0, 9)}
+          </div>
+          <div className={pastCommitHeaderItemStyle}>
+            {this.props.pastCommit.date}
+          </div>
         </div>
-        <div className={this.getPastCommitLineClass()} />
+        <div className={pastCommitBodyStyle}>
+          {this.props.pastCommit.commit_msg}
+        </div>
       </div>
     );
   }

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -1,33 +1,35 @@
-import {
-  pastCommitNodeStyle,
-  pastCommitHeaderStyle,
-  pastCommitHeaderItemStyle,
-  pastCommitBodyStyle,
-  branchStyle,
-  branchesStyle,
-  remoteBranchStyle,
-  localBranchStyle,
-  workingBranchStyle,
-  pastCommitExpandedStyle,
-  collapseStyle
-} from "../componentsStyle/PastCommitNodeStyle";
-
-import { classes } from "typestyle";
-
-import { SingleCommitInfo, GitBranchResult } from "../git";
-
-import { SinglePastCommitInfo } from "./SinglePastCommitInfo";
-
+import { JupyterLab } from "@jupyterlab/application";
 import * as React from "react";
+import { classes } from "typestyle";
+import {
+  branchesStyle,
+  branchStyle,
+  collapseStyle,
+  localBranchStyle,
+  pastCommitBodyStyle,
+  pastCommitExpandedStyle,
+  pastCommitHeaderItemStyle,
+  pastCommitHeaderStyle,
+  pastCommitNodeStyle,
+  remoteBranchStyle,
+  workingBranchStyle
+} from "../componentsStyle/PastCommitNodeStyle";
+import { GitBranchResult, SingleCommitInfo } from "../git";
+import { SinglePastCommitInfo } from "./SinglePastCommitInfo";
 
 export interface IPastCommitNodeProps {
   pastCommit: SingleCommitInfo;
   branches: GitBranchResult["branches"];
   topRepoPath: string;
   currentTheme: string;
-  app: any;
-  diff: any;
-  refresh: any;
+  app: JupyterLab;
+  diff: (
+    app: JupyterLab,
+    filename: string,
+    revisionA: string,
+    revisionB: string
+  ) => void;
+  refresh: () => void;
 }
 
 export interface IPastCommitNodeState {
@@ -67,23 +69,25 @@ export class PastCommitNode extends React.Component<
   }
 
   expand() {
-    this.setState({expanded: true});
+    this.setState({ expanded: true });
   }
 
   collapse() {
-    this.setState({expanded: false});
+    this.setState({ expanded: false });
   }
 
   getNodeClass() {
     if (this.state.expanded) {
-      return classes(pastCommitNodeStyle, pastCommitExpandedStyle)
+      return classes(pastCommitNodeStyle, pastCommitExpandedStyle);
     }
-    return pastCommitNodeStyle
+    return pastCommitNodeStyle;
   }
   render() {
     return (
       <div
-        onClick={() => {!this.state.expanded && this.expand()}}
+        onClick={() => {
+          !this.state.expanded && this.expand();
+        }}
         className={this.getNodeClass()}
       >
         <div className={pastCommitHeaderStyle}>

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -69,11 +69,11 @@ export class PastCommitNode extends React.Component<
   }
 
   expand() {
-    this.setState({ expanded: true });
+    this.setState(() => ({ expanded: true }));
   }
 
   collapse() {
-    this.setState({ expanded: false });
+    this.setState(() => ({ expanded: false }));
   }
 
   getNodeClass() {

--- a/src/components/PastCommits.tsx
+++ b/src/components/PastCommits.tsx
@@ -2,8 +2,6 @@ import { JupyterLab } from '@jupyterlab/application';
 
 import { FileList } from './FileList';
 
-import { SinglePastCommitInfo } from './SinglePastCommitInfo';
-
 import { pastCommitsContainerStyle } from '../componentsStyle/PastCommitsStyle';
 
 import * as React from 'react';
@@ -12,7 +10,6 @@ import * as React from 'react';
 export interface IPastCommitsProps {
   currentFileBrowserPath: string;
   topRepoPath: string;
-  pastCommits: any;
   inNewRepo: boolean;
   showList: boolean;
   stagedFiles: any;
@@ -21,45 +18,17 @@ export interface IPastCommitsProps {
   app: JupyterLab;
   refresh: any;
   diff: any;
-  pastCommitInfo: string;
-  pastCommitFilesChanged: string;
-  pastCommitInsertionCount: string;
-  pastCommitDeletionCount: string;
-  pastCommitData: any;
-  pastCommitNumber: any;
-  pastCommitFilelist: any;
   sideBarExpanded: boolean;
   currentTheme: string;
 }
 
 export class PastCommits extends React.Component<IPastCommitsProps, {}> {
-  constructor(props: IPastCommitsProps) {
-    super(props);
-  }
-
   render() {
     if (this.props.sideBarExpanded) {
       return null;
     }
     return (
       <div className={pastCommitsContainerStyle}>
-        {!this.props.showList && (
-          <SinglePastCommitInfo
-            topRepoPath={this.props.topRepoPath}
-            num={this.props.pastCommitNumber}
-            data={this.props.pastCommitData}
-            info={this.props.pastCommitInfo}
-            filesChanged={this.props.pastCommitFilesChanged}
-            insertionCount={this.props.pastCommitInsertionCount}
-            deletionCount={this.props.pastCommitDeletionCount}
-            list={this.props.pastCommitFilelist}
-            app={this.props.app}
-            diff={this.props.diff}
-            display={!this.props.showList}
-            currentTheme={this.props.currentTheme}
-            refresh={this.props.refresh}
-          />
-        )}
         <FileList
           currentFileBrowserPath={this.props.currentFileBrowserPath}
           topRepoPath={this.props.topRepoPath}

--- a/src/components/PastCommits.tsx
+++ b/src/components/PastCommits.tsx
@@ -38,6 +38,9 @@ export class PastCommits extends React.Component<IPastCommitsProps, {}> {
   }
 
   render() {
+    if (this.props.sideBarExpanded) {
+      return null;
+    }
     return (
       <div className={pastCommitsContainerStyle}>
         {!this.props.showList && (

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -49,6 +49,7 @@ export interface ISinglePastCommitInfoState {
   insertionCount: string;
   deletionCount: string;
   list: Array<CommitModifiedFile>;
+  loadingState: "loading" | "error" | "success"
 }
 
 export class SinglePastCommitInfo extends React.Component<
@@ -65,6 +66,7 @@ export class SinglePastCommitInfo extends React.Component<
       insertionCount: "",
       deletionCount: "",
       list: [],
+      loadingState: "loading"
     
     };
     this.showPastCommitWork();
@@ -77,6 +79,7 @@ export class SinglePastCommitInfo extends React.Component<
       detailedLogData = await gitApi.detailedLog(this.props.data.commit, this.props.topRepoPath);
     } catch(err) {
       console.error(`Error while gettting detailed log for commit ${this.props.data.commit} and path ${this.props.topRepoPath}`, err);
+      this.setState(() => ({loadingState: "error"}));
       return;
     }
     if (detailedLogData.code === 0) {
@@ -85,7 +88,8 @@ export class SinglePastCommitInfo extends React.Component<
         filesChanged: detailedLogData.modified_files_count,
         insertionCount: detailedLogData.number_of_insertions,
         deletionCount: detailedLogData.number_of_deletions,
-        list: detailedLogData.modified_files
+        list: detailedLogData.modified_files,
+        loadingState: "success"
       });
     }
   };
@@ -117,6 +121,12 @@ export class SinglePastCommitInfo extends React.Component<
   };
 
   render() {
+    if (this.state.loadingState == "loading") {
+      return <div>...</div>
+    }
+    if (this.state.loadingState == "error") {
+      return <div>Error loading commit data</div>
+    }
     return (
       <div>
         <div className={commitStyle}>

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -45,7 +45,7 @@ export interface ISinglePastCommitInfoState {
   filesChanged: string;
   insertionCount: string;
   deletionCount: string;
-  list: Array<CommitModifiedFile>;
+  modifiedFiles: Array<CommitModifiedFile>;
   loadingState: "loading" | "error" | "success";
 }
 
@@ -62,7 +62,7 @@ export class SinglePastCommitInfo extends React.Component<
       filesChanged: "",
       insertionCount: "",
       deletionCount: "",
-      list: [],
+      modifiedFiles: [],
       loadingState: "loading"
     };
     this.showPastCommitWork();
@@ -92,7 +92,7 @@ export class SinglePastCommitInfo extends React.Component<
         filesChanged: detailedLogData.modified_files_count,
         insertionCount: detailedLogData.number_of_insertions,
         deletionCount: detailedLogData.number_of_deletions,
-        list: detailedLogData.modified_files,
+        modifiedFiles: detailedLogData.modified_files,
         loadingState: "success"
       });
     }
@@ -199,8 +199,8 @@ export class SinglePastCommitInfo extends React.Component<
               />
             )}
           </div>
-          {this.state.list.length > 0 &&
-            this.state.list.map((modifiedFile, modifiedFileIndex) => {
+          {this.state.modifiedFiles.length > 0 &&
+            this.state.modifiedFiles.map((modifiedFile, modifiedFileIndex) => {
               return (
                 <li className={commitDetailFileStyle} key={modifiedFileIndex}>
                   <span

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -72,7 +72,13 @@ export class SinglePastCommitInfo extends React.Component<
 
   showPastCommitWork = async () => {
     let gitApi = new Git();
-    let detailedLogData = await gitApi.detailedLog(this.props.data.commit, this.props.topRepoPath);
+    let detailedLogData;
+    try {
+      detailedLogData = await gitApi.detailedLog(this.props.data.commit, this.props.topRepoPath);
+    } catch(err) {
+      console.error(`Error while gettting detailed log for commit ${this.props.data.commit} and path ${this.props.topRepoPath}`, err);
+      return;
+    }
     if (detailedLogData.code === 0) {
       this.setState({
         info: detailedLogData.modified_file_note,

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -1,43 +1,40 @@
-import { JupyterLab } from '@jupyterlab/application';
-
-import { Git, SingleCommitInfo, CommitModifiedFile } from '../git';
-
-import { parseFileExtension } from './FileList';
-
-import { ResetDeleteSingleCommit } from './ResetDeleteSingleCommit';
-
-import {
-  commitStyle,
-  commitOverviewNumbers,
-  commitDetailStyle,
-  commitDetailHeader,
-  commitDetailFileStyle,
-  commitDetailFilePathStyle,
-  iconStyle,
-  insertionIconStyle,
-  numberofChangedFilesStyle,
-  floatRightStyle,
-  deletionIconStyle,
-  revertButtonStyle
-} from '../componentsStyle/SinglePastCommitInfoStyle';
-
+import { JupyterLab } from "@jupyterlab/application";
+import * as React from "react";
+import { classes } from "typestyle/";
+import { fileIconStyle } from "../componentsStyle/FileItemStyle";
 import {
   changeStageButtonStyle,
   discardFileButtonStyle
-} from '../componentsStyle/GitStageStyle';
-
-import { fileIconStyle } from '../componentsStyle/FileItemStyle';
-
-import * as React from 'react';
-
-import { classes } from 'typestyle/';
+} from "../componentsStyle/GitStageStyle";
+import {
+  commitDetailFilePathStyle,
+  commitDetailFileStyle,
+  commitDetailHeader,
+  commitDetailStyle,
+  commitOverviewNumbers,
+  commitStyle,
+  deletionIconStyle,
+  floatRightStyle,
+  iconStyle,
+  insertionIconStyle,
+  numberofChangedFilesStyle,
+  revertButtonStyle
+} from "../componentsStyle/SinglePastCommitInfoStyle";
+import { CommitModifiedFile, Git, SingleCommitInfo } from "../git";
+import { parseFileExtension } from "./FileList";
+import { ResetDeleteSingleCommit } from "./ResetDeleteSingleCommit";
 
 export interface ISinglePastCommitInfoProps {
   topRepoPath: string;
   data: SingleCommitInfo;
   app: JupyterLab;
-  diff: any;
-  refresh: Function;
+  diff: (
+    app: JupyterLab,
+    filename: string,
+    revisionA: string,
+    revisionB: string
+  ) => void;
+  refresh: () => void;
   currentTheme: string;
 }
 
@@ -49,7 +46,7 @@ export interface ISinglePastCommitInfoState {
   insertionCount: string;
   deletionCount: string;
   list: Array<CommitModifiedFile>;
-  loadingState: "loading" | "error" | "success"
+  loadingState: "loading" | "error" | "success";
 }
 
 export class SinglePastCommitInfo extends React.Component<
@@ -67,7 +64,6 @@ export class SinglePastCommitInfo extends React.Component<
       deletionCount: "",
       list: [],
       loadingState: "loading"
-    
     };
     this.showPastCommitWork();
   }
@@ -76,10 +72,18 @@ export class SinglePastCommitInfo extends React.Component<
     let gitApi = new Git();
     let detailedLogData;
     try {
-      detailedLogData = await gitApi.detailedLog(this.props.data.commit, this.props.topRepoPath);
-    } catch(err) {
-      console.error(`Error while gettting detailed log for commit ${this.props.data.commit} and path ${this.props.topRepoPath}`, err);
-      this.setState(() => ({loadingState: "error"}));
+      detailedLogData = await gitApi.detailedLog(
+        this.props.data.commit,
+        this.props.topRepoPath
+      );
+    } catch (err) {
+      console.error(
+        `Error while gettting detailed log for commit ${
+          this.props.data.commit
+        } and path ${this.props.topRepoPath}`,
+        err
+      );
+      this.setState(() => ({ loadingState: "error" }));
       return;
     }
     if (detailedLogData.code === 0) {
@@ -122,10 +126,10 @@ export class SinglePastCommitInfo extends React.Component<
 
   render() {
     if (this.state.loadingState == "loading") {
-      return <div>...</div>
+      return <div>...</div>;
     }
     if (this.state.loadingState == "error") {
-      return <div>Error loading commit data</div>
+      return <div>Error loading commit data</div>;
     }
     return (
       <div>
@@ -205,9 +209,9 @@ export class SinglePastCommitInfo extends React.Component<
                     )}`}
                     onDoubleClick={() => {
                       window.open(
-                        'https://github.com/search?q=' +
+                        "https://github.com/search?q=" +
                           this.props.data.commit +
-                          '&type=Commits&utf8=%E2%9C%93'
+                          "&type=Commits&utf8=%E2%9C%93"
                       );
                     }}
                   />

--- a/src/componentsStyle/BranchHeaderStyle.tsx
+++ b/src/componentsStyle/BranchHeaderStyle.tsx
@@ -2,9 +2,20 @@ import { style } from 'typestyle';
 
 export const branchStyle = style({
   zIndex: 1,
-  height: '100px',
   textAlign: 'center',
-  overflowY: 'auto'
+  overflowY: 'auto',
+});
+
+
+export const selectedHeaderStyle = style({
+  borderTop: 'var(--jp-border-width) solid var(--jp-border-color2)',
+  paddingBottom: 'var(--jp-border-width)',
+});
+
+export const unSelectedHeaderStyle = style({
+  backgroundColor: "#ededed",
+  borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
+  paddingTop: 'var(--jp-border-width)',
 });
 
 export const smallBranchStyle = style({
@@ -16,23 +27,19 @@ export const expandedBranchStyle = style({
 });
 
 export const openHistorySideBarButtonStyle = style({
-  backgroundColor: 'var(--jp-layout-color3)',
   width: '50px',
-  height: '15px',
-  position: 'fixed',
-  left: '33px',
-  outline: 'none',
-  border: 'none',
-  color: '#FFFFFF'
+  flex: 'initial',
+  paddingLeft: '10px',
+  paddingRight: '10px',
+  borderRight: 'var(--jp-border-width) solid var(--jp-border-color2)',
 });
 
-export const openHistorySideBarIconStyle = style({
-  backgroundImage: 'var(--jp-caret-right-white)',
-  backgroundPosition: 'center',
-  backgroundRepeat: 'no-repeat',
-  backgroundSize: '100%',
-  width: '8px',
-  height: '8px'
+export const historyLabelStyle = style({
+  fontSize: 'var(--jp-ui-font-size1)',
+  marginTop: '5px',
+  marginBottom: '5px',
+  display: 'inline-block',
+  fontWeight: 'normal',
 });
 
 export const branchLabelStyle = style({
@@ -206,5 +213,7 @@ export const stagedCommitMessageStyle = style({
 });
 
 export const branchHeaderCenterContent = style({
-  padding: '0 50px 0 50px'
+  paddingLeft: '40px',
+  paddingRight: '40px',
+  flex: 'auto'
 });

--- a/src/componentsStyle/BranchHeaderStyle.tsx
+++ b/src/componentsStyle/BranchHeaderStyle.tsx
@@ -213,7 +213,7 @@ export const stagedCommitMessageStyle = style({
 });
 
 export const branchHeaderCenterContent = style({
-  paddingLeft: '40px',
-  paddingRight: '40px',
+  paddingLeft: '5px',
+  paddingRight: '5px',
   flex: 'auto'
 });

--- a/src/componentsStyle/GitPanelStyle.tsx
+++ b/src/componentsStyle/GitPanelStyle.tsx
@@ -7,17 +7,7 @@ export const panelContainerStyle = style({
   height: '100%'
 });
 
-export const panelPushedContentStyle = style({
-  position: 'relative',
-  left: '50px',
-  width: 'calc(100% - 50px)'
-});
 
-export const panelContentStyle = style({
-  '-webkit-transition': 'all 0.5s ease',
-  '-moz-transition': 'all 0.5s ease',
-  transition: 'all 0.5s ease'
-});
 
 export const panelWarningStyle = style({
   textAlign: 'center',

--- a/src/componentsStyle/HistorySideBarStyle.tsx
+++ b/src/componentsStyle/HistorySideBarStyle.tsx
@@ -5,12 +5,7 @@ export const historySideBarStyle = style({
   visibility: 'hidden',
   width: '0px',
   opacity: 0,
-  position: 'fixed',
   backgroundColor: 'var(--jp-layout-color2)',
-  transition: 'width 0.3s ease, visibility 0.3s ease, opacity 0.3s ease',
-  '-webkit-transition':
-    'width 0.3s ease, visibility 0.3s ease, opacity 0.3s ease',
-  '-moz-transition': 'width 0.3s ease, visibility 0.3s ease, opacity 0.3s ease',
   left: '33px',
   top: '70px',
 

--- a/src/componentsStyle/HistorySideBarStyle.tsx
+++ b/src/componentsStyle/HistorySideBarStyle.tsx
@@ -2,22 +2,7 @@ import { style } from 'typestyle';
 
 export const historySideBarStyle = style({
   height: '100vh',
-  visibility: 'hidden',
-  width: '0px',
-  opacity: 0,
-  backgroundColor: 'var(--jp-layout-color2)',
-  left: '33px',
-  top: '70px',
-
-  $nest: {
-    '&:first-child': {
-      paddingTop: '14px'
-    }
-  }
+  display: 'flex',
+  flexDirection: 'column',
 });
 
-export const historySideBarExpandedStyle = style({
-  width: '50px',
-  visibility: 'visible',
-  opacity: 1
-});

--- a/src/componentsStyle/PastCommitNodeStyle.tsx
+++ b/src/componentsStyle/PastCommitNodeStyle.tsx
@@ -16,6 +16,34 @@ export const pastCommitHeaderStyle = style({
 });
 
 
+
+export const branchesStyle = style({
+  display: "flex",
+  fontSize: "0.8em",
+  marginLeft: "-5px",
+});
+
+export const branchStyle = style({
+  padding: "2px",
+  border: "var(--jp-border-width) solid #424242",
+  borderRadius: "4px",
+  margin: "3px",
+});
+
+export const remoteBranchStyle = style({
+  backgroundColor: "#ffcdd3"
+});
+
+export const localBranchStyle = style({
+  backgroundColor: "#b2ebf3"
+});
+
+
+export const workingBranchStyle = style({
+  backgroundColor: "#ffce83"
+});
+
+
 export const pastCommitHeaderItemStyle = style({
 });
 

--- a/src/componentsStyle/PastCommitNodeStyle.tsx
+++ b/src/componentsStyle/PastCommitNodeStyle.tsx
@@ -1,52 +1,25 @@
 import { style } from 'typestyle';
 
 export const pastCommitNodeStyle = style({
-  position: 'relative',
-  color: 'var(--jp-ui-font-color1)',
-  width: '36px',
-  height: '36px',
-  border: '2px solid #000',
-  borderRadius: '50%',
-  outline: 'none !important',
-  margin: '-1px auto -1px auto',
-  textAlign: 'center',
-  lineHeight: '36px'
+  flex: 'auto',
+  display: 'flex',
+  flexDirection: 'column',
+  padding: "10px",
+  borderBottom: "var(--jp-border-width) solid var(--jp-border-color2)",
 });
 
-export const pastCommitWorkingNodeStyle = style({
-  border: '2px dashed #000',
-  borderRadius: '50%',
-  marginTop: '5px'
+export const pastCommitHeaderStyle = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  color: '#828282',
+  paddingBottom: "5px"
 });
 
-export const pastCommitContentStyle = style({
-  fontFamily: 'Oswald'
+
+export const pastCommitHeaderItemStyle = style({
 });
 
-export const pastCommitWorkingContentStyle = style({
-  left: '-5px',
-  backgroundColor: 'var(--jp-layout-color2)',
-  height: '13px',
-  position: 'absolute',
-  lineHeight: '100%',
-  marginTop: '11px'
-});
 
-export const pastCommitHeadContentStyle = style({
-  left: '5%'
-});
-
-export const pastCommitNumberContentStyle = style({
-  left: '38%'
-});
-
-export const pastCommitActiveContentStyle = style({
-  color: 'var(--jp-brand-color2)'
-});
-
-export const pastCommitLineStyle = style({
-  backgroundColor: '#000',
-  height: '18px',
-  width: '3px',
-  margin: '0 auto'
+export const pastCommitBodyStyle = style({
+  flex: 'auto',
 });

--- a/src/componentsStyle/PastCommitNodeStyle.tsx
+++ b/src/componentsStyle/PastCommitNodeStyle.tsx
@@ -43,10 +43,18 @@ export const workingBranchStyle = style({
   backgroundColor: "#ffce83"
 });
 
+export const pastCommitExpandedStyle = style({
+  backgroundColor: "#f9f9f9"
+});
 
 export const pastCommitHeaderItemStyle = style({
 });
 
+
+export const collapseStyle = style({
+  color: "#1a76d2",
+  float: "right"
+})
 
 export const pastCommitBodyStyle = style({
   flex: 'auto',

--- a/src/componentsStyle/PastCommitNodeStyle.tsx
+++ b/src/componentsStyle/PastCommitNodeStyle.tsx
@@ -1,7 +1,7 @@
 import { style } from 'typestyle';
 
 export const pastCommitNodeStyle = style({
-  flex: 'auto',
+  flexGrow: 0,
   display: 'flex',
   flexDirection: 'column',
   padding: "10px",

--- a/src/componentsStyle/PathHeaderStyle.tsx
+++ b/src/componentsStyle/PathHeaderStyle.tsx
@@ -5,7 +5,6 @@ export const repoStyle = style({
   flexDirection: 'row',
   backgroundColor: 'var(--jp-layout-color1)',
   lineHeight: 'var(--jp-private-running-item-height)',
-  borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
   minHeight: '35px'
 });
 

--- a/src/componentsStyle/SinglePastCommitInfoStyle.tsx
+++ b/src/componentsStyle/SinglePastCommitInfoStyle.tsx
@@ -3,9 +3,9 @@ import { style } from 'typestyle';
 export const commitStyle = style({
   flex: '0 0 auto',
   width: '100%',
-  paddingLeft: '10px',
   fontSize: '12px',
-  marginBottom: '10px'
+  marginBottom: '10px',
+  marginTop: '5px',
 });
 
 export const headerStyle = style({
@@ -16,34 +16,10 @@ export const headerStyle = style({
   height: '30px'
 });
 
-export const commitNumberLabelStyle = style({
+export const floatRightStyle = style({
   float: 'right',
-  paddingRight: '19px',
-  fontWeight: 'bold',
-  display: 'inline-block'
-});
+})
 
-export const commitAuthorLabelStyle = style({
-  fontSize: '10px'
-});
-
-export const commitAuthorIconStyle = style({
-  backgroundImage: 'var(--jp-Git-icon-author)',
-  display: 'inline-block',
-  height: '9px',
-  width: '9px'
-});
-
-export const commitLabelDateStyle = style({
-  fontSize: '13px',
-  display: 'inline-block'
-});
-
-export const commitLabelMessageStyle = style({
-  fontSize: '13px',
-  textAlign: 'left',
-  paddingRight: '10px'
-});
 
 export const commitOverviewNumbers = style({
   fontSize: '13px',
@@ -62,12 +38,10 @@ export const commitOverviewNumbers = style({
 export const commitDetailStyle = style({
   flex: '1 1 auto',
   margin: '0',
-  paddingLeft: '10px',
   overflow: 'auto'
 });
 
 export const commitDetailHeader = style({
-  borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
   fontSize: '13px',
   fontWeight: 'bold'
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -250,7 +250,7 @@ export class Git {
       }
       return response.json();
     } catch (err) {
-      throw ServerConnection.NetworkError;
+      throw new ServerConnection.NetworkError(err);
     }
   }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -43,15 +43,13 @@ export interface GitCheckoutResult {
  * has the result of changing the current working branch */
 export interface GitBranchResult {
   code: number;
-  branches?: [
-    {
-      is_current_branch: boolean;
-      is_remote_branch: boolean;
-      name: string;
-      upstream: string;
-      tag: string;
-    }
-  ];
+  branches?: Array<{
+    is_current_branch: boolean;
+    is_remote_branch: boolean;
+    name: string;
+    upstream: string;
+    tag: string;
+  }>;
 }
 
 /** Interface for GitStatus request result,

--- a/tests/test-components/BranchHeader.spec.ts
+++ b/tests/test-components/BranchHeader.spec.ts
@@ -18,6 +18,7 @@ describe('BranchHeader', () => {
     currentFileBrowserPath: '/current/absolute/path',
     topRepoPath: '/absolute/path/to/git/repo',
     currentBranch: 'master',
+    sideBarExpanded: false,
     upstreamBranch: 'origin/master',
     stagedFiles: ['test-1', 'test-2'],
     data: ['master', 'feature-1', 'feature-2', 'patch-007'],
@@ -142,6 +143,7 @@ describe('BranchHeader', () => {
         stagedFiles: ['test-1', 'test-2'],
         data: ['master', 'feature-1', 'feature-2', 'patch-007'],
         refresh: 'update all content',
+        sideBarExpanded: false,
         disabled: false,
         toggleSidebar: function() {
           return true;

--- a/tests/test-components/HistorySideBar.spec.tsx
+++ b/tests/test-components/HistorySideBar.spec.tsx
@@ -19,7 +19,7 @@ describe("HistorySideBar", () => {
         pre_commit: null
       }
     ],
-    data: [],
+    branches: [],
     isExpanded: true,
     topRepoPath: null,
     currentTheme: null,

--- a/tests/test-components/HistorySideBar.spec.tsx
+++ b/tests/test-components/HistorySideBar.spec.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { shallow } from "enzyme";
+import {
+  HistorySideBar,
+  IHistorySideBarProps
+} from "../../src/components/HistorySideBar";
+import 'jest';
+
+import { PastCommitNode } from "../../src/components/PastCommitNode";
+
+describe("HistorySideBar", () => {
+  const props: IHistorySideBarProps = {
+    pastCommits: [
+      {
+        commit: null,
+        author: null,
+        date: null,
+        commit_msg: null,
+        pre_commit: null
+      }
+    ],
+    data: [],
+    isExpanded: true,
+    topRepoPath: null,
+    currentTheme: null,
+    app: null,
+    refresh: null,
+    diff: null
+  };
+  test("renders commit nodes when expanded", () => {
+    const historySideBar = shallow(<HistorySideBar {...props} />);
+    expect(historySideBar.find(PastCommitNode)).toHaveLength(1);
+  });
+  test("does not render commit nodes when not expanded", () => {
+    const historySideBar = shallow(
+      <HistorySideBar {...props} isExpanded={false} />
+    );
+    expect(historySideBar.find(PastCommitNode)).toHaveLength(0);
+  });
+});

--- a/tests/test-components/PastCommitNode.spec.tsx
+++ b/tests/test-components/PastCommitNode.spec.tsx
@@ -55,7 +55,7 @@ describe("PastCommitNode", () => {
       commit_msg: "message",
       pre_commit: "pre_commit"
     },
-    data: branches
+    branches: branches
   };
   test("Includes commit info", () => {
     const pastCommitNode = shallow(<PastCommitNode {...props} />);

--- a/tests/test-components/PastCommitNode.spec.tsx
+++ b/tests/test-components/PastCommitNode.spec.tsx
@@ -1,0 +1,89 @@
+import * as React from "react";
+import { shallow } from "enzyme";
+import { SinglePastCommitInfo } from "../../src/components/SinglePastCommitInfo";
+import { PastCommitNode } from "../../src/components/PastCommitNode";
+import { GitBranchResult } from "../../src/git";
+import {  collapseStyle} from "../../src/componentsStyle/PastCommitNodeStyle";
+import "jest";
+
+describe("PastCommitNode", () => {
+  const notMatchingBranches = [
+    {
+      is_current_branch: false,
+      is_remote_branch: false,
+      name: "name1",
+      upstream: "upstream",
+      tag: "v1.0.4"
+    },
+    {
+      is_current_branch: false,
+      is_remote_branch: true,
+      name: "name2",
+      upstream: "upstream",
+      tag: null
+    }
+  ];
+  const matchingBranches = [
+    {
+      is_current_branch: false,
+      is_remote_branch: false,
+      name: "name3",
+      upstream: "upstream",
+      tag: "v1.0.4-14-g2414721"
+    },
+    {
+      is_current_branch: false,
+      is_remote_branch: true,
+      name: "name4",
+      upstream: "upstream",
+      tag: "v1.0.5-0-g2414721"
+    }
+  ];
+  const branches: GitBranchResult["branches"] = notMatchingBranches.concat(
+    matchingBranches
+  );
+  const props = {
+    topRepoPath: null,
+    currentTheme: null,
+    app: null,
+    diff: null,
+    refresh: null,
+    pastCommit: {
+      commit: "2414721b194453f058079d897d13c4e377f92dc6",
+      author: "author",
+      date: "date",
+      commit_msg: "message",
+      pre_commit: "pre_commit"
+    },
+    data: branches
+  };
+  test("Includes commit info", () => {
+    const pastCommitNode = shallow(<PastCommitNode {...props} />);
+    expect(pastCommitNode.text()).toMatch(props.pastCommit.author);
+    expect(pastCommitNode.text()).toMatch(props.pastCommit.commit.slice(0, 9));
+    expect(pastCommitNode.text()).toMatch(props.pastCommit.date);
+    expect(pastCommitNode.text()).toMatch(props.pastCommit.commit_msg);
+  });
+  test("Includes only relevent branch info", () => {
+    const pastCommitNode = shallow(<PastCommitNode {...props} />);
+    expect(pastCommitNode.text()).toMatch("name3");
+    expect(pastCommitNode.text()).toMatch("name4");
+    expect(pastCommitNode.text()).not.toMatch("name1");
+    expect(pastCommitNode.text()).not.toMatch("name2");
+  });
+  test("Doesnt include details at first", () => {
+    const pastCommitNode = shallow(<PastCommitNode {...props} />);
+    expect(pastCommitNode.find(SinglePastCommitInfo)).toHaveLength(0);
+  });
+  test("includes details after click", () => {
+    const pastCommitNode = shallow(<PastCommitNode {...props} />);
+    pastCommitNode.simulate('click');
+    expect(pastCommitNode.find(SinglePastCommitInfo)).toHaveLength(1);
+  });
+  test("hides details after collapse", () => {
+    const pastCommitNode = shallow(<PastCommitNode {...props} />);
+    pastCommitNode.simulate('click');
+    pastCommitNode.find(`.${collapseStyle}`).simulate('click');
+    expect(pastCommitNode.find(SinglePastCommitInfo)).toHaveLength(0);
+  });
+});

--- a/tests/test-components/PastCommitNode.spec.tsx
+++ b/tests/test-components/PastCommitNode.spec.tsx
@@ -60,7 +60,7 @@ describe("PastCommitNode", () => {
   test("Includes commit info", () => {
     const pastCommitNode = shallow(<PastCommitNode {...props} />);
     expect(pastCommitNode.text()).toMatch(props.pastCommit.author);
-    expect(pastCommitNode.text()).toMatch(props.pastCommit.commit.slice(0, 9));
+    expect(pastCommitNode.text()).toMatch(props.pastCommit.commit.slice(0, 7));
     expect(pastCommitNode.text()).toMatch(props.pastCommit.date);
     expect(pastCommitNode.text()).toMatch(props.pastCommit.commit_msg);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,17 +420,43 @@
     "@phosphor/signaling" "^1.2.2"
     "@phosphor/virtualdom" "^1.1.2"
 
+"@types/cheerio@*":
+  version "0.22.9"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.9.tgz#b5990152604c2ada749b7f88cab3476f21f39d7b"
+  integrity sha512-q6LuBI0t5u04f0Q4/R+cGBqIbZMtJkVvCSF+nTfFBBdQqQvJR/mNHeWjRkszyLl7oyf2rDoKUYMEjTw5AV0hiw==
+
+"@types/enzyme@3.1.15":
+  version "3.1.15"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.1.15.tgz#fc9a9695ba9f90cd50c4967e64a8c66ec96913d1"
+  integrity sha512-6b4JWgV+FNec1c4+8HauGbXg5gRc1oQK93t2+4W+bHjG/PzO+iPvagY6d6bXAZ+t+ps51Zb2F9LQ4vl0S0Epog==
+  dependencies:
+    "@types/cheerio" "*"
+    "@types/react" "*"
+
 "@types/jest@^23.3.5":
   version "23.3.5"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.5.tgz#870a1434208b60603745bfd214fc3fc675142364"
   integrity sha512-3LI+vUC3Wju28vbjIjsTKakhMB8HC4l+tMz+Z8WRzVK+kmvezE5jcOvKtBpznWSI5KDLFo+FouUhpTKoekadCA==
+
+"@types/node@*":
+  version "10.12.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.10.tgz#4fa76e6598b7de3f0cb6ec3abacc4f59e5b3a2ce"
+  integrity sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==
 
 "@types/prop-types@*":
   version "15.5.6"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"
   integrity sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==
 
-"@types/react@~16.4.13":
+"@types/react@*":
+  version "16.7.6"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.6.tgz#80e4bab0d0731ad3ae51f320c4b08bdca5f03040"
+  integrity sha512-QBUfzftr/8eg/q3ZRgf/GaDP6rTYc7ZNem+g4oZM38C9vXyV8AWRWaTQuW5yCoZTsfHrN7b3DeEiUnqH9SrnpA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@16.4.16", "@types/react@~16.4.13":
   version "16.4.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.16.tgz#99f91b1200ae8c2062030402006d3b3c3a177043"
   integrity sha512-lxyoipLWweAnLnSsV4Ho2NAZTKKmxeYgkTQ6PaDiPDU9JJBUY2zJVVGiK1smzYv8+ZgbqEmcm5xM74GCpunSEA==
@@ -598,6 +624,15 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+array.prototype.flat@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz#812db8f02cad24d3fab65dd67eabe3b8903494a4"
+  integrity sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.10.0"
+    function-bind "^1.1.1"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -849,6 +884,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -975,6 +1015,18 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  integrity sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 chownr@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
@@ -1038,6 +1090,11 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
+  integrity sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=
 
 combined-stream@1.0.6:
   version "1.0.6"
@@ -1120,6 +1177,21 @@ cross-spawn@^5.0.1:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
+  integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.4"
@@ -1256,7 +1328,12 @@ diff@^3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
-dom-serializer@0:
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
+
+dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   integrity sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=
@@ -1288,6 +1365,14 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
 domutils@^1.5.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
@@ -1316,6 +1401,54 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
   integrity sha1-blwtClYhtdra7O+AuQ7ftc13cvA=
 
+enzyme-adapter-react-16@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.7.0.tgz#90344395a89624edbe7f0e443bc19fef62bf1f9f"
+  integrity sha512-rDr0xlnnFPffAPYrvG97QYJaRl9unVDslKee33wTStsBEwZTkESX1H7VHGT5eUc6ifNzPgOJGvSh2zpHT4gXjA==
+  dependencies:
+    enzyme-adapter-utils "^1.9.0"
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    object.values "^1.0.4"
+    prop-types "^15.6.2"
+    react-is "^16.6.1"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.9.0.tgz#3997c20f3387fdcd932b155b3740829ea10aa86c"
+  integrity sha512-uMe4xw4l/Iloh2Fz+EO23XUYMEQXj5k/5ioLUXCNOUCI8Dml5XQMO9+QwUq962hBsY5qftfHHns+d990byWHvg==
+  dependencies:
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    prop-types "^15.6.2"
+    semver "^5.6.0"
+
+enzyme@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.7.0.tgz#9b499e8ca155df44fef64d9f1558961ba1385a46"
+  integrity sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==
+  dependencies:
+    array.prototype.flat "^1.2.1"
+    cheerio "^1.0.0-rc.2"
+    function.prototype.name "^1.1.0"
+    has "^1.0.3"
+    is-boolean-object "^1.0.0"
+    is-callable "^1.1.4"
+    is-number-object "^1.0.3"
+    is-string "^1.0.4"
+    is-subset "^0.1.1"
+    lodash.escape "^4.0.1"
+    lodash.isequal "^4.5.0"
+    object-inspect "^1.6.0"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
+    object.values "^1.0.4"
+    raf "^3.4.0"
+    rst-selector-parser "^2.2.3"
+    string.prototype.trim "^1.1.2"
+
 error-ex@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -1323,7 +1456,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.1:
+es-abstract@^1.10.0, es-abstract@^1.5.0, es-abstract@^1.5.1, es-abstract@^1.6.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   integrity sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==
@@ -1655,10 +1788,19 @@ fsevents@^1.2.3:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+function.prototype.name@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
+  integrity sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    is-callable "^1.1.3"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1762,6 +1904,11 @@ har-validator@~5.1.0:
     ajv "^5.3.0"
     har-schema "^2.0.0"
 
+harmony-reflect@^1.4.6:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
+  integrity sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -1820,7 +1967,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1:
+has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -1859,6 +2006,18 @@ htmlparser2@^3.9.0:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
+htmlparser2@^3.9.1:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
+  integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.0.6"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -1874,6 +2033,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -1903,7 +2069,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -1943,6 +2109,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-boolean-object@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
+  integrity sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -2065,6 +2236,11 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-number-object@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
+  integrity sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -2112,6 +2288,16 @@ is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-string@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
+  integrity sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+  integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
 
 is-symbol@^1.0.2:
   version "1.0.2"
@@ -2764,10 +2950,25 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.escape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
+  integrity sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=
+
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
+
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -2789,7 +2990,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
+lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -2974,6 +3175,11 @@ moment@~2.21.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
   integrity sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==
 
+moo@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
+  integrity sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3030,6 +3236,17 @@ nbdime@^4.0.1:
     codemirror "~5.39.0"
     json-stable-stringify "^1.0.1"
 
+nearley@^2.7.10:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.15.1.tgz#965e4e6ec9ed6b80fc81453e161efbcebb36d247"
+  integrity sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==
+  dependencies:
+    moo "^0.4.3"
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
+
 needle@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
@@ -3077,6 +3294,14 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  integrity sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -3133,6 +3358,13 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -3162,7 +3394,17 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.12:
+object-inspect@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
+
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+  integrity sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=
+
+object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
   integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
@@ -3173,6 +3415,26 @@ object-visit@^1.0.0:
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  integrity sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -3196,6 +3458,16 @@ object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+object.values@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  integrity sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 once@^1.3.0, once@^1.4.0:
   version "1.4.0"
@@ -3296,6 +3568,13 @@ parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
+  dependencies:
+    "@types/node" "*"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -3482,6 +3761,26 @@ querystringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
   integrity sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==
 
+raf@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
+
 randomatic@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.0.tgz#36f2ca708e9e567f5ed2ec01949026d50aa10116"
@@ -3520,6 +3819,21 @@ react-dom@~16.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-is@^16.6.1, react-is@^16.6.3:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
+  integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
+
+react-test-renderer@^16.0.0-0:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.6.3.tgz#5f3a1a7d5c3379d46f7052b848b4b72e47c89f38"
+  integrity sha512-B5bCer+qymrQz/wN03lT0LppbZUDRq6AMfzMKrovzkGzfO81a9T+PWQW6MzkWknbwODQH/qpJno/yFQLX5IWrQ==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.6.3"
+    scheduler "^0.11.2"
 
 react-toggle-display@^2.2.0:
   version "2.2.0"
@@ -3577,6 +3891,15 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.0.6.tgz#351302e4c68b5abd6a2ed55376a7f9a25be3057a"
+  integrity sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 realpath-native@^1.0.0:
   version "1.0.2"
@@ -3725,6 +4048,14 @@ rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  integrity sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
+
 rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
@@ -3791,7 +4122,15 @@ schedule@^0.5.0:
   dependencies:
     object-assign "^4.1.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0:
+scheduler@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
+  integrity sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -4033,7 +4372,16 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@~1.1.1:
+string.prototype.trim@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  integrity sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
+    function-bind "^1.0.2"
+
+string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
@@ -4281,6 +4629,11 @@ uglify-js@^3.1.4:
     commander "~2.17.1"
     source-map "~0.6.1"
 
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+  integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -4317,7 +4670,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
This addresses #245 by making a seperate history tab.

- [x] Add ability to expand commit details
- [x] Add screenshots of new behavior


It implements all the features requested by #245 except for the graphical branch view on the left hand side. 

It also is not a pixel perfect translation of the mockups. I reused as much of the existing styles and components as possible. As a result, there should likely be some cleanup after this to reflect the component name updates. (i.e. `HistorySideBar` is no longer a side bar).

![](http://g.recordit.co/BUCOYCSCJ0.gif)