### PR TITLE
Backend APIs for Upstream,Pull,Push operations

### DIFF
--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -316,22 +316,36 @@ class GitCommitHandler(GitHandler):
         self.finish(my_output)
 
 
+class GitUpstreamHandler(GitHandler):
+    def post(self):
+        """
+        Handler for the `git rev-parse --abbrev-ref $CURRENT_BRANCH_NAME@{upstream}` on the repo. Used to check if there
+        is a upstream branch defined for the current Git repo (and a side-effect is disabling the Git push/pull actions)
+
+        Input format:
+            {
+              'current_path': 'current_file_browser_path',
+            }
+        """
+        current_path = self.get_json_body()['current_path']
+        current_branch = self.git.get_current_branch(current_path)
+        upstream = self.git.get_upstream_branch(current_path, current_branch)
+        self.finish(json.dumps({
+            'upstream': upstream
+        }))
+
+
 class GitPullHandler(GitHandler):
     """
-    Handler for 'git pull <first-branch> <second-branch>'. Pulls files from a remote branch.
+    Handler for 'git pull'. Pulls files from a remote branch.
     """
 
     def post(self):
         """
         POST request handler, pulls files from a remote branch to your current branch.
         """
-        data = self.get_json_body()
-        origin = data["origin"]
-        master = data["master"]
-        curr_fb_path = data["curr_fb_path"]
-        my_output = self.git.pull(origin, master, curr_fb_path)
-        self.finish(my_output)
-        print("You Pulled")
+        output = self.git.pull(self.get_json_body()['current_path'])
+        self.finish(json.dumps(output))
 
 
 class GitPushHandler(GitHandler):
@@ -343,15 +357,32 @@ class GitPushHandler(GitHandler):
     def post(self):
         """
         POST request handler,
-        pushes comitted files from your current branch to a remote branch
+        pushes committed files from your current branch to a remote branch
         """
-        data = self.get_json_body()
-        origin = data["origin"]
-        master = data["master"]
-        curr_fb_path = data["curr_fb_path"]
-        my_output = self.git.push(origin, master, curr_fb_path)
-        self.finish(my_output)
-        print("You Pushed")
+        current_path = self.get_json_body()['current_path']
+
+        current_branch = self.git.get_current_branch(current_path)
+        current_upstream = self.git.get_upstream_branch(current_path, current_branch)
+
+        if current_upstream and current_upstream.strip():
+            upstream = current_upstream.split('/')
+            if len(upstream) == 1:
+                # If upstream is a local branch
+                origin = '.'
+                master = ':'.join(['HEAD', upstream[0]])
+            else:
+                # If upstream is a remote branch
+                origin = upstream[0]
+                master = ':'.join(['HEAD', upstream[1]])
+
+            response = self.git.push(origin, master, current_path)
+
+        else:
+            response = {
+                'code': 128,
+                'message': 'fatal: The current branch {} has no upstream branch.'.format(current_branch)
+            }
+        self.finish(json.dumps(response))
 
 
 class GitInitHandler(GitHandler):
@@ -408,7 +439,8 @@ def setup_handlers(web_app):
         ("/git/init", GitInitHandler),
         ("/git/all_history", GitAllHistoryHandler),
         ("/git/add_all_untracked", GitAddAllUntrackedHandler),
-        ("/git/clone", GitCloneHandler)
+        ("/git/clone", GitCloneHandler),
+        ("/git/upstream", GitUpstreamHandler)
     ]
 
     # add the baseurl to our paths

--- a/tests/unit/test_branch.py
+++ b/tests/unit/test_branch.py
@@ -83,7 +83,7 @@ def test_get_current_branch_success(mock_subproc_popen):
     mock_subproc_popen.return_value = process_mock
 
     # When
-    actual_response = Git(root_dir='/bin')._get_current_branch(
+    actual_response = Git(root_dir='/bin').get_current_branch(
         current_path='test_curr_path')
 
     # Then
@@ -112,7 +112,7 @@ def test_get_current_branch_failure(mock_subproc_popen):
 
     # When
     with pytest.raises(Exception) as error:
-        Git(root_dir='/bin')._get_current_branch(current_path='test_curr_path')
+        Git(root_dir='/bin').get_current_branch(current_path='test_curr_path')
     
     # Then
     mock_subproc_popen.assert_has_calls([
@@ -211,7 +211,7 @@ def test_get_upstream_branch_success(mock_subproc_popen):
         mock_subproc_popen.return_value = process_mock
 
         # When
-        actual_response = Git(root_dir='/bin')._get_upstream_branch(
+        actual_response = Git(root_dir='/bin').get_upstream_branch(
             current_path='test_curr_path', branch_name=test_case[0])
 
         # Then
@@ -242,13 +242,13 @@ def test_get_upstream_branch_failure(mock_subproc_popen):
 
     # When
     with pytest.raises(Exception) as error:
-        Git(root_dir='/bin')._get_upstream_branch(
+        Git(root_dir='/bin').get_upstream_branch(
             current_path='test_curr_path', branch_name='blah')
     
     assert "Error [fatal: no such branch: 'blah'] "\
     "occurred while executing [git rev-parse --abbrev-ref blah@{upstream}] command to get upstream branch." == str(error.value)
 
-    actual_response = Git(root_dir='/bin')._get_upstream_branch(
+    actual_response = Git(root_dir='/bin').get_upstream_branch(
             current_path='test_curr_path', branch_name='test')
 
     assert None == actual_response

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1,7 +1,6 @@
-import pytest
-from mock import Mock, ANY
+from mock import Mock, ANY, patch
 
-from jupyterlab_git import handlers
+from jupyterlab_git.handlers import GitUpstreamHandler, GitPushHandler, setup_handlers
 
 
 def test_mapping_added():
@@ -9,6 +8,84 @@ def test_mapping_added():
     mock_web_app.settings = {
         'base_url': 'nb_base_url'
     }
-    handlers.setup_handlers(mock_web_app)
+    setup_handlers(mock_web_app)
 
     mock_web_app.add_handlers.assert_called_once_with(".*", ANY)
+
+
+@patch('jupyterlab_git.handlers.GitUpstreamHandler.__init__', Mock(return_value=None))
+@patch('jupyterlab_git.handlers.GitUpstreamHandler.get_json_body', Mock(return_value={'current_path': 'test_path'}))
+@patch('jupyterlab_git.handlers.GitUpstreamHandler.git')
+@patch('jupyterlab_git.handlers.GitUpstreamHandler.finish')
+def test_push_handler_localbranch(mock_finish, mock_git):
+    # Given
+    mock_git.get_current_branch.return_value = 'foo'
+    mock_git.get_upstream_branch.return_value = 'bar'
+
+    # When
+    GitUpstreamHandler().post()
+
+    # Then
+    mock_git.get_current_branch.assert_called_with('test_path')
+    mock_git.get_upstream_branch.assert_called_with('test_path', 'foo')
+    mock_finish.assert_called_with('{"upstream": "bar"}')
+
+
+@patch('jupyterlab_git.handlers.GitPushHandler.__init__', Mock(return_value=None))
+@patch('jupyterlab_git.handlers.GitPushHandler.get_json_body', Mock(return_value={'current_path': 'test_path'}))
+@patch('jupyterlab_git.handlers.GitPushHandler.git')
+@patch('jupyterlab_git.handlers.GitPushHandler.finish')
+def test_push_handler_localbranch(mock_finish, mock_git):
+    # Given
+    mock_git.get_current_branch.return_value = 'foo'
+    mock_git.get_upstream_branch.return_value = 'localbranch'
+    mock_git.push.return_value = {'code': 0}
+
+    # When
+    GitPushHandler().post()
+
+    # Then
+    mock_git.get_current_branch.assert_called_with('test_path')
+    mock_git.get_upstream_branch.assert_called_with('test_path', 'foo')
+    mock_git.push.assert_called_with('.', 'HEAD:localbranch', 'test_path')
+    mock_finish.assert_called_with('{"code": 0}')
+
+
+@patch('jupyterlab_git.handlers.GitPushHandler.__init__', Mock(return_value=None))
+@patch('jupyterlab_git.handlers.GitPushHandler.get_json_body', Mock(return_value={'current_path': 'test_path'}))
+@patch('jupyterlab_git.handlers.GitPushHandler.git')
+@patch('jupyterlab_git.handlers.GitPushHandler.finish')
+def test_push_handler_remotebranch(mock_finish, mock_git):
+    # Given
+    mock_git.get_current_branch.return_value = 'foo'
+    mock_git.get_upstream_branch.return_value = 'origin/remotebranch'
+    mock_git.push.return_value = {'code': 0}
+
+    # When
+    GitPushHandler().post()
+
+    # Then
+    mock_git.get_current_branch.assert_called_with('test_path')
+    mock_git.get_upstream_branch.assert_called_with('test_path', 'foo')
+    mock_git.push.assert_called_with('origin', 'HEAD:remotebranch', 'test_path')
+    mock_finish.assert_called_with('{"code": 0}')
+
+
+@patch('jupyterlab_git.handlers.GitPushHandler.__init__', Mock(return_value=None))
+@patch('jupyterlab_git.handlers.GitPushHandler.get_json_body', Mock(return_value={'current_path': 'test_path'}))
+@patch('jupyterlab_git.handlers.GitPushHandler.git')
+@patch('jupyterlab_git.handlers.GitPushHandler.finish')
+def test_push_handler_noupstream(mock_finish, mock_git):
+    # Given
+    mock_git.get_current_branch.return_value = 'foo'
+    mock_git.get_upstream_branch.return_value = ''
+    mock_git.push.return_value = {'code': 0}
+
+    # When
+    GitPushHandler().post()
+
+    # Then
+    mock_git.get_current_branch.assert_called_with('test_path')
+    mock_git.get_upstream_branch.assert_called_with('test_path', 'foo')
+    mock_git.push.assert_not_called()
+    mock_finish.assert_called_with('{"code": 128, "message": "fatal: The current branch foo has no upstream branch."}')

--- a/tests/unit/test_pushpull.py
+++ b/tests/unit/test_pushpull.py
@@ -1,0 +1,117 @@
+from subprocess import PIPE
+
+from mock import patch, call, Mock
+
+from jupyterlab_git.git import Git
+
+
+@patch('subprocess.Popen')
+def test_git_pull_fail(mock_subproc_popen):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': ('output', 'Authentication failed'.encode('utf-8')),
+        'returncode': 1
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').pull('test_curr_path')
+
+    # Then
+    mock_subproc_popen.assert_has_calls([
+        call(
+            ['GIT_TERMINAL_PROMPT=0 git pull --no-commit'],
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd='/bin/test_curr_path',
+            shell=True
+        ),
+        call().communicate()
+    ])
+    assert {'code': 1, 'message': 'Authentication failed'} == actual_response
+
+
+@patch('subprocess.Popen')
+def test_git_pull_success(mock_subproc_popen):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': ('output', ''.encode('utf-8')),
+        'returncode': 0
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').pull('test_curr_path')
+
+    # Then
+    mock_subproc_popen.assert_has_calls([
+        call(
+            ['GIT_TERMINAL_PROMPT=0 git pull --no-commit'],
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd='/bin/test_curr_path',
+            shell=True
+        ),
+        call().communicate()
+    ])
+    assert {'code': 0} == actual_response
+
+
+@patch('subprocess.Popen')
+def test_git_push_fail(mock_subproc_popen):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': ('output', 'Authentication failed'.encode('utf-8')),
+        'returncode': 1
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').push('test_origin', 'HEAD:test_master', 'test_curr_path')
+
+    # Then
+    mock_subproc_popen.assert_has_calls([
+        call(
+            ['GIT_TERMINAL_PROMPT=0 git push test_origin HEAD:test_master'],
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd='/bin/test_curr_path',
+            shell=True
+        ),
+        call().communicate()
+    ])
+    assert {'code': 1, 'message': 'Authentication failed'} == actual_response
+
+
+@patch('subprocess.Popen')
+def test_git_push_success(mock_subproc_popen):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': ('output', 'does not matter'.encode('utf-8')),
+        'returncode': 0
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').push('.', 'HEAD:test_master', 'test_curr_path')
+
+    # Then
+    mock_subproc_popen.assert_has_calls([
+        call(
+            ['GIT_TERMINAL_PROMPT=0 git push . HEAD:test_master'],
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd='/bin/test_curr_path',
+            shell=True
+        ),
+        call().communicate()
+    ])
+    assert {'code': 0} == actual_response


### PR DESCRIPTION
This change introduces or modifies 3 APIs

1. `/git/upstream` This gives information about the Upstream branch associated with the current local branch. Used to disable/enable the push/pull buttons
2. `/git/pull` This API actually performs the git pull operation from the currently set upstream branch
3. `/git/push` This API actually performs the git push operation from the currently set upstream branch. This has some logic to determine the upstream branch to push to in the case of local branch pushing to another local branch or an actual remote branch.


### Testing
Unit Tested

API tested locally for
* Upstream with / without remote
* Pull/Push with Authentication error
* Pull/Push with/without remote