### PR TITLE
 Fix git repo determination when there are no tags

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -594,7 +594,7 @@ class Git:
         nearest tag associated with lastest commit in branch.
         Reference : https://git-scm.com/docs/git-describe#git-describe-ltcommit-ishgt82308203
         """
-        command = ['git', 'describe', commit_sha]
+        command = ['git', 'describe', '--tags', commit_sha]
         p = subprocess.Popen(
             command,
             stdout=PIPE,
@@ -605,6 +605,8 @@ class Git:
         if p.returncode == 0:
             return output.decode('utf-8').strip()
         elif "fatal: No tags can describe '{}'.".format(commit_sha) in error.decode('utf-8'):
+            return None
+        elif "fatal: No names found" in error.decode('utf-8'):
             return None
         else:
             raise Exception('Error [{}] occurred while executing [{}] command to get nearest tag associated with branch.'.format(

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -52,7 +52,6 @@ class GitAllHistoryHandler(GitHandler):
         current_path = self.get_json_body()["current_path"]
         show_top_level = self.git.show_top_level(current_path)
         if show_top_level["code"] != 0:
-            print('without show top level result', show_top_level)
             self.finish(json.dumps(show_top_level))
         else:
             branch = self.git.branch(current_path)
@@ -68,7 +67,6 @@ class GitAllHistoryHandler(GitHandler):
                     "status": status,
                 },
             }
-            print('With show top level result', result)
             self.finish(json.dumps(result))
 
 

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -52,6 +52,7 @@ class GitAllHistoryHandler(GitHandler):
         current_path = self.get_json_body()["current_path"]
         show_top_level = self.git.show_top_level(current_path)
         if show_top_level["code"] != 0:
+            print('without show top level result', show_top_level)
             self.finish(json.dumps(show_top_level))
         else:
             branch = self.git.branch(current_path)
@@ -67,6 +68,7 @@ class GitAllHistoryHandler(GitHandler):
                     "status": status,
                 },
             }
+            print('With show top level result', result)
             self.finish(json.dumps(result))
 
 

--- a/tests/unit/test_branch.py
+++ b/tests/unit/test_branch.py
@@ -104,7 +104,8 @@ def test_get_current_branch_failure(mock_subproc_popen):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('', 'fatal: Not a git repository (or any of the parent directories): .git'.encode('utf-8')),
+        'communicate.return_value': (
+            '', 'fatal: Not a git repository (or any of the parent directories): .git'.encode('utf-8')),
         'returncode': 128
     }
     process_mock.configure_mock(**attrs)
@@ -113,7 +114,7 @@ def test_get_current_branch_failure(mock_subproc_popen):
     # When
     with pytest.raises(Exception) as error:
         Git(root_dir='/bin').get_current_branch(current_path='test_curr_path')
-    
+
     # Then
     mock_subproc_popen.assert_has_calls([
         call(
@@ -124,8 +125,10 @@ def test_get_current_branch_failure(mock_subproc_popen):
         ),
         call().communicate()
     ])
-    assert 'Error [fatal: Not a git repository (or any of the parent directories): .git] '\
-    'occurred while executing [git rev-parse --abbrev-ref HEAD] command to get current branch.' == str(error.value)
+    assert 'Error [fatal: Not a git repository (or any of the parent directories): .git] ' \
+           'occurred while executing [git rev-parse --abbrev-ref HEAD] command to get current branch.' == str(
+        error.value)
+
 
 @patch('subprocess.Popen')
 def test_get_detached_head_name_success(mock_subproc_popen):
@@ -166,7 +169,8 @@ def test_get_detached_head_name_failure(mock_subproc_popen):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('', 'fatal: Not a git repository (or any of the parent directories): .git'.encode('utf-8')),
+        'communicate.return_value': (
+            '', 'fatal: Not a git repository (or any of the parent directories): .git'.encode('utf-8')),
         'returncode': 128
     }
     process_mock.configure_mock(**attrs)
@@ -175,7 +179,7 @@ def test_get_detached_head_name_failure(mock_subproc_popen):
     # When
     with pytest.raises(Exception) as error:
         Git(root_dir='/bin')._get_detached_head_name(current_path='test_curr_path')
-    
+
     # Then
     mock_subproc_popen.assert_has_calls([
         call(
@@ -186,9 +190,8 @@ def test_get_detached_head_name_failure(mock_subproc_popen):
         ),
         call().communicate()
     ])
-    assert 'Error [fatal: Not a git repository (or any of the parent directories): .git] '\
-    'occurred while executing [git branch -a] command to get detached HEAD name.' == str(error.value)
-
+    assert 'Error [fatal: Not a git repository (or any of the parent directories): .git] ' \
+           'occurred while executing [git branch -a] command to get detached HEAD name.' == str(error.value)
 
 
 @patch('subprocess.Popen')
@@ -218,7 +221,7 @@ def test_get_upstream_branch_success(mock_subproc_popen):
         mock_subproc_popen.assert_has_calls([
             call(
                 ['git', 'rev-parse', '--abbrev-ref',
-                    '{}@{{upstream}}'.format(test_case[0])],
+                 '{}@{{upstream}}'.format(test_case[0])],
                 stdout=PIPE,
                 stderr=PIPE,
                 cwd='/bin/test_curr_path'
@@ -244,12 +247,13 @@ def test_get_upstream_branch_failure(mock_subproc_popen):
     with pytest.raises(Exception) as error:
         Git(root_dir='/bin').get_upstream_branch(
             current_path='test_curr_path', branch_name='blah')
-    
-    assert "Error [fatal: no such branch: 'blah'] "\
-    "occurred while executing [git rev-parse --abbrev-ref blah@{upstream}] command to get upstream branch." == str(error.value)
+
+    assert "Error [fatal: no such branch: 'blah'] " \
+           "occurred while executing [git rev-parse --abbrev-ref blah@{upstream}] command to get upstream branch." == str(
+        error.value)
 
     actual_response = Git(root_dir='/bin').get_upstream_branch(
-            current_path='test_curr_path', branch_name='test')
+        current_path='test_curr_path', branch_name='test')
 
     assert None == actual_response
 
@@ -257,7 +261,7 @@ def test_get_upstream_branch_failure(mock_subproc_popen):
     mock_subproc_popen.assert_has_calls([
         call(
             ['git', 'rev-parse', '--abbrev-ref',
-                'blah@{upstream}'],
+             'blah@{upstream}'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
@@ -265,14 +269,14 @@ def test_get_upstream_branch_failure(mock_subproc_popen):
         call().communicate(),
         call(
             ['git', 'rev-parse', '--abbrev-ref',
-                'test@{upstream}'],
+             'test@{upstream}'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
         ),
         call().communicate()
     ], any_order=False)
-    
+
 
 @patch('subprocess.Popen')
 def test_get_tag_success(mock_subproc_popen):
@@ -292,7 +296,7 @@ def test_get_tag_success(mock_subproc_popen):
     # Then
     mock_subproc_popen.assert_has_calls([
         call(
-            ['git', 'describe', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
+            ['git', 'describe', '--tags', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
@@ -316,33 +320,34 @@ def test_get_tag_failure(mock_subproc_popen):
     with pytest.raises(Exception) as error:
         Git(root_dir='/bin')._get_tag(
             current_path='test_curr_path', commit_sha='blah')
-    
-    assert "Error [fatal: Not a valid object name blah] "\
-    "occurred while executing [git describe blah] command to get nearest tag associated with branch." == str(error.value)
+
+    assert "Error [fatal: Not a valid object name blah] " \
+           "occurred while executing [git describe --tags blah] command to get nearest tag associated with branch." == str(
+        error.value)
 
     actual_response = Git(root_dir='/bin')._get_tag(
-            current_path='test_curr_path', commit_sha='01234567899999abcdefghijklmnopqrstuvwxyz')
+        current_path='test_curr_path', commit_sha='01234567899999abcdefghijklmnopqrstuvwxyz')
 
     assert None == actual_response
 
     # Then
     mock_subproc_popen.assert_has_calls([
         call(
-            ['git', 'describe', 'blah'],
+            ['git', 'describe', '--tags', 'blah'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
         ),
         call().communicate(),
         call(
-            ['git', 'describe', '01234567899999abcdefghijklmnopqrstuvwxyz'],
+            ['git', 'describe', '--tags', '01234567899999abcdefghijklmnopqrstuvwxyz'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
         ),
         call().communicate()
     ], any_order=False)
-    
+
 
 @patch('subprocess.Popen')
 def test_branch_success(mock_subproc_popen):
@@ -446,7 +451,7 @@ def test_branch_success(mock_subproc_popen):
         ),
         call().communicate(),
         call(
-            ['git', 'describe', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
+            ['git', 'describe', '--tags', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
@@ -460,7 +465,7 @@ def test_branch_success(mock_subproc_popen):
         ),
         call().communicate(),
         call(
-            ['git', 'describe', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
+            ['git', 'describe', '--tags', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
@@ -474,7 +479,7 @@ def test_branch_success(mock_subproc_popen):
         ),
         call().communicate(),
         call(
-            ['git', 'describe', '01234567899999abcdefghijklmnopqrstuvwxyz'],
+            ['git', 'describe', '--tags', '01234567899999abcdefghijklmnopqrstuvwxyz'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
@@ -482,14 +487,14 @@ def test_branch_success(mock_subproc_popen):
         call().communicate(),
         # Calls to get tag for remote branch
         call(
-            ['git', 'describe', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
+            ['git', 'describe', '--tags', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
         ),
         call().communicate(),
         call(
-            ['git', 'describe', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
+            ['git', 'describe', '--tags', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
@@ -505,7 +510,8 @@ def test_branch_failure(mock_subproc_popen):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('', 'fatal: Not a git repository (or any of the parent directories): .git'.encode('utf-8')),
+        'communicate.return_value': (
+            '', 'fatal: Not a git repository (or any of the parent directories): .git'.encode('utf-8')),
         'returncode': 128
     }
     process_mock.configure_mock(**attrs)
@@ -530,6 +536,7 @@ def test_branch_failure(mock_subproc_popen):
         call().communicate()
     ])
     assert expected_response == actual_response
+
 
 @patch('subprocess.Popen')
 def test_branch_success_detached_head(mock_subproc_popen):
@@ -619,7 +626,7 @@ def test_branch_success_detached_head(mock_subproc_popen):
         ),
         call().communicate(),
         call(
-            ['git', 'describe', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
+            ['git', 'describe', '--tags', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
@@ -627,7 +634,7 @@ def test_branch_success_detached_head(mock_subproc_popen):
         call().communicate(),
         # Calls to get tag for remote branch
         call(
-            ['git', 'describe', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
+            ['git', 'describe', '--tags', 'abcdefghijklmnopqrstuvwxyz01234567890123'],
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path'
@@ -643,3 +650,31 @@ def test_branch_success_detached_head(mock_subproc_popen):
     ], any_order=False)
 
     assert expected_response == actual_response
+
+
+@patch('subprocess.Popen')
+def test_no_tags(mock_subproc_popen):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': (b'', b'fatal: No names found, cannot describe anything.\n'),
+        'returncode': 128
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin')._get_tag('/path/foo', '768c79ad661598889f29bdf8916f4cc488f5062a')
+
+    # Then
+    # Then
+    mock_subproc_popen.assert_has_calls([
+        call(
+            ['git', 'describe', '--tags', '768c79ad661598889f29bdf8916f4cc488f5062a'],
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd='/path/foo'
+        ),
+        call().communicate()
+    ])
+    assert actual_response is None

--- a/tests/unit/test_branch.py
+++ b/tests/unit/test_branch.py
@@ -667,7 +667,6 @@ def test_no_tags(mock_subproc_popen):
     actual_response = Git(root_dir='/bin')._get_tag('/path/foo', '768c79ad661598889f29bdf8916f4cc488f5062a')
 
     # Then
-    # Then
     mock_subproc_popen.assert_has_calls([
         call(
             ['git', 'describe', '--tags', '768c79ad661598889f29bdf8916f4cc488f5062a'],


### PR DESCRIPTION
When there are no tags, `git describe` returns `fatal: No names found, cannot describe anything`. This fails the entire `/git/all_history` API call and we fail to identify the Git repo completely.

This commit doesn't fail in this case but returns an empty list of tags and also uses the `--tag` option which returns non-annotated tags as well.

---
### **Testing**


Unit Tested: pytest test/
Tested via local JupyterLab installation and with a fresh GitLab repo

---