### PR TITLE
Improve package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,16 +48,16 @@
     "@phosphor/widgets": "^1.6.0",
     "identity-obj-proxy": "^3.0.0",
     "nbdime": "^4.0.1",
-    "react": "^16.5.2",
-    "react-dom": "^16.5.2",
+    "react": "~16.4.2",
+    "react-dom": "~16.4.2"
     "react-toggle-display": "^2.2.0",
-    "tslint": "^5.11.0",
     "typestyle": "^2.0.1"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.15",
     "@types/jest": "^23.3.5",
-    "@types/react": "16.4.16",
+    "@types/react": "~16.4.13",
+    "@types/react-dom": "~16.0.5",
     "enzyme": "3.7.0",
     "enzyme-adapter-react-16": "1.7.0",
     "jest": "^23.6.0",
@@ -65,6 +65,7 @@
     "prettier": "^1.14.3",
     "rimraf": "^2.6.1",
     "ts-jest": "^23.10.4",
+    "tslint": "^5.11.0",
     "tslint-plugin-prettier": "^2.0.0",
     "typescript": "~3.1.2"
   },
@@ -78,5 +79,8 @@
   "bugs": {
     "url": "https://github.com/jupyterlab/jupyterlab-git/issues"
   },
-  "homepage": "https://github.com/jupyterlab/jupyterlab-git"
+  "homepage": "https://github.com/jupyterlab/jupyterlab-git",
+  "resolutions": {
+    "@types/react": "~16.4.13"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "identity-obj-proxy": "^3.0.0",
     "nbdime": "^4.0.1",
     "react": "~16.4.2",
-    "react-dom": "~16.4.2"
+    "react-dom": "~16.4.2",
     "react-toggle-display": "^2.2.0",
     "typestyle": "^2.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,15 +448,14 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"
   integrity sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==
 
-"@types/react@*":
-  version "16.7.6"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.6.tgz#80e4bab0d0731ad3ae51f320c4b08bdca5f03040"
-  integrity sha512-QBUfzftr/8eg/q3ZRgf/GaDP6rTYc7ZNem+g4oZM38C9vXyV8AWRWaTQuW5yCoZTsfHrN7b3DeEiUnqH9SrnpA==
+"@types/react-dom@~16.0.5":
+  version "16.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.11.tgz#bd10ccb0d9260343f4b9a49d4f7a8330a5c1f081"
+  integrity sha512-x6zUx9/42B5Kl2Vl9HlopV8JF64wLpX3c+Pst9kc1HgzrsH+mkehe/zmHMQTplIrR48H2gpU7ZqurQolYu8XBA==
   dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
+    "@types/react" "*"
 
-"@types/react@16.4.16", "@types/react@~16.4.13":
+"@types/react@*", "@types/react@~16.4.13":
   version "16.4.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.16.tgz#99f91b1200ae8c2062030402006d3b3c3a177043"
   integrity sha512-lxyoipLWweAnLnSsV4Ho2NAZTKKmxeYgkTQ6PaDiPDU9JJBUY2zJVVGiK1smzYv8+ZgbqEmcm5xM74GCpunSEA==
@@ -3800,16 +3799,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.5.2:
-  version "16.5.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.2.tgz#b69ee47aa20bab5327b2b9d7c1fe2a30f2cfa9d7"
-  integrity sha512-RC8LDw8feuZOHVgzEf7f+cxBr/DnKdqp56VU0lAs1f4UfKc4cU8wU4fTq/mgnvynLQo8OtlPC19NUFh/zjZPuA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    schedule "^0.5.0"
-
 react-dom@~16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
@@ -3841,16 +3830,6 @@ react-toggle-display@^2.2.0:
   integrity sha1-IKZt4j5p1b2XXEuzz+rxh0gmbEk=
   dependencies:
     prop-types "^15.5.8"
-
-react@^16.5.2:
-  version "16.5.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.5.2.tgz#19f6b444ed139baa45609eee6dc3d318b3895d42"
-  integrity sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    schedule "^0.5.0"
 
 react@~16.4.2:
   version "16.4.2"
@@ -4114,13 +4093,6 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
-schedule@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.5.0.tgz#c128fffa0b402488b08b55ae74bb9df55cc29cc8"
-  integrity sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==
-  dependencies:
-    object-assign "^4.1.1"
 
 scheduler@^0.11.2:
   version "0.11.2"


### PR DESCRIPTION
The current `package.json` does not allow good integration with JupyterLab.

Changes proposed:
- Use the same version of `react` and `react-dom` as the one of JupyterLab. The current config results in two versions of react being bundled by webpack.
- `tslint` should be a `devDependency` not a `dependency`
- `@types/react` is unfortunately a dependency of `@jupyterlab/apputils` (see https://github.com/jupyterlab/jupyterlab/pull/4386 and https://github.com/jupyterlab/jupyterlab/pull/5268#discussion_r215307531), to ease contribution from new developers `resolutions` key should be added in the configuration file (see https://github.com/jupyterlab/jupyterlab/issues/5456#issuecomment-427881191).