### PR TITLE
Fix unstaging deleted files

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -349,7 +349,7 @@ class Git:
         Execute git reset <filename> command & return the result.
         """
         my_output = subprocess.check_output(
-            ["git", "reset", filename], cwd=top_repo_path
+            ["git", "reset", "--", filename], cwd=top_repo_path
         )
         return my_output
 


### PR DESCRIPTION
This fixes unstaging deleted files and closes https://github.com/jupyterlab/jupyterlab-git/issues/294. 

If we don't specify the `--`, then I get this error:

```
fatal: ambiguous argument 'setupJest.js': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```