### PR TITLE
Fix dark theme appearance

### DIFF
--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -48,7 +48,6 @@ export interface IBranchHeaderProps {
   disabled: boolean;
   toggleSidebar: Function;
   showList: boolean;
-  currentTheme: string;
   sideBarExpanded: boolean;
 }
 
@@ -205,10 +204,10 @@ export class BranchHeader extends React.Component<
               className={
                 this.props.disabled
                   ? classes(
-                      branchDropdownButtonStyle(this.props.currentTheme),
+                      branchDropdownButtonStyle,
                       headerButtonDisabledStyle
                     )
-                  : branchDropdownButtonStyle(this.props.currentTheme)
+                  : branchDropdownButtonStyle
               }
               title={'Change the current branch'}
               onClick={() => this.toggleSelect()}
@@ -218,10 +217,10 @@ export class BranchHeader extends React.Component<
                 className={
                   this.props.disabled
                     ? classes(
-                        newBranchButtonStyle(this.props.currentTheme),
+                        newBranchButtonStyle,
                         headerButtonDisabledStyle
                       )
-                    : newBranchButtonStyle(this.props.currentTheme)
+                    : newBranchButtonStyle
                 }
                 title={'Create a new branch'}
                 onClick={() => this.toggleNewBranchBox()}

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -38,7 +38,7 @@ export interface IFileItemProps {
   refresh: any;
   moveFile: Function;
   discardFile: Function;
-  moveFileIconClass: Function;
+  moveFileIconClass: string;
   moveFileIconSelectedClass: string;
   moveFileTitle: string;
   openFile: Function;
@@ -55,7 +55,6 @@ export interface IFileItemProps {
   disableFile: boolean;
   toggleDisableFiles: Function;
   sideBarExpanded: boolean;
-  currentTheme: string;
 }
 
 export class FileItem extends React.Component<IFileItemProps, {}> {
@@ -161,7 +160,7 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
         changeStageButtonStyle,
         changeStageButtonLeftStyle,
         fileGitButtonStyle,
-        this.props.moveFileIconClass(this.props.currentTheme)
+        this.props.moveFileIconClass
       );
     } else {
       return this.checkSelected()
@@ -177,7 +176,7 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
             changeStageButtonStyle,
             changeStageButtonLeftStyle,
             fileGitButtonStyle,
-            this.props.moveFileIconClass(this.props.currentTheme)
+            this.props.moveFileIconClass
           );
     }
   }
@@ -188,7 +187,7 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
         fileButtonStyle,
         changeStageButtonStyle,
         fileGitButtonStyle,
-        discardFileButtonStyle(this.props.currentTheme)
+        discardFileButtonStyle
       );
     } else {
       return this.checkSelected()
@@ -202,7 +201,7 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
             fileButtonStyle,
             changeStageButtonStyle,
             fileGitButtonStyle,
-            discardFileButtonStyle(this.props.currentTheme)
+            discardFileButtonStyle
           );
     }
   }

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -79,7 +79,6 @@ export interface IFileListProps {
   refresh: any;
   sideBarExpanded: boolean;
   display: boolean;
-  currentTheme: string;
 }
 
 export class FileList extends React.Component<IFileListProps, IFileListState> {
@@ -518,7 +517,6 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               disableOthers={null}
               isDisabled={this.state.disableStaged}
               sideBarExpanded={this.props.sideBarExpanded}
-              currentTheme={this.props.currentTheme}
             />
             <GitStage
               heading={'Changed'}
@@ -552,7 +550,6 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               disableOthers={this.disableStagesForDiscardAll}
               isDisabled={this.state.disableUnstaged}
               sideBarExpanded={this.props.sideBarExpanded}
-              currentTheme={this.props.currentTheme}
             />
             <GitStage
               heading={'Untracked'}
@@ -586,7 +583,6 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               disableOthers={null}
               isDisabled={this.state.disableUntracked}
               sideBarExpanded={this.props.sideBarExpanded}
-              currentTheme={this.props.currentTheme}
             />
           </div>
         )}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -223,7 +223,6 @@ export class GitPanel extends React.Component<
           topRepoPath={this.state.topRepoPath}
           refresh={this.refresh}
           currentBranch={this.state.currentBranch}
-          isLightTheme={this.props.app.shell.dataset.themeLight}
         />
         <div>
           {this.state.showWarning && (
@@ -239,7 +238,6 @@ export class GitPanel extends React.Component<
                 disabled={this.state.disableSwitchBranch}
                 toggleSidebar={this.toggleSidebar}
                 showList={this.state.showList}
-                currentTheme={this.props.app.shell.dataset.themeLight}
                 sideBarExpanded={this.state.sideBarExpanded}
               />
               <HistorySideBar
@@ -247,7 +245,6 @@ export class GitPanel extends React.Component<
                 branches={this.state.branches}
                 pastCommits={this.state.pastCommits}
                 topRepoPath={this.state.topRepoPath}
-                currentTheme={this.props.app.shell.dataset.themeLight}
                 app={this.props.app}
                 refresh={this.refresh}
                 diff={this.props.diff}
@@ -264,7 +261,6 @@ export class GitPanel extends React.Component<
                 refresh={this.refresh}
                 diff={this.props.diff}
                 sideBarExpanded={this.state.sideBarExpanded}
-                currentTheme={this.props.app.shell.dataset.themeLight}
               />
             </div>
           )}

--- a/src/components/GitStage.tsx
+++ b/src/components/GitStage.tsx
@@ -34,7 +34,7 @@ export interface IGitStageProps {
   discardAllFiles: Function;
   discardFile: Function;
   moveFile: Function;
-  moveFileIconClass: Function;
+  moveFileIconClass: string;
   moveFileIconSelectedClass: string;
   moveAllFilesTitle: string;
   moveFileTitle: string;
@@ -54,7 +54,6 @@ export interface IGitStageProps {
   isDisabled: boolean;
   disableOthers: Function;
   sideBarExpanded: boolean;
-  currentTheme: string;
 }
 
 export interface IGitStageState {
@@ -127,9 +126,7 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
           )}
           <button
             disabled={this.checkContents()}
-            className={`${this.props.moveFileIconClass(
-              this.props.currentTheme
-            )} ${changeStageButtonStyle}
+            className={`${this.props.moveFileIconClass} ${changeStageButtonStyle}
                ${changeStageButtonLeftStyle}`}
             title={this.props.moveAllFilesTitle}
             onClick={() =>
@@ -144,7 +141,7 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
               disabled={this.checkContents()}
               className={classes(
                 changeStageButtonStyle,
-                discardFileButtonStyle(this.props.currentTheme)
+                discardFileButtonStyle
               )}
               title={'Discard All Changes'}
               onClick={() => this.discardAllChanges()}
@@ -188,7 +185,6 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
                     disableFile={this.props.disableFiles}
                     toggleDisableFiles={this.props.toggleDisableFiles}
                     sideBarExpanded={this.props.sideBarExpanded}
-                    currentTheme={this.props.currentTheme}
                   />
                 );
               }

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -10,7 +10,6 @@ export interface IHistorySideBarProps {
   branches: GitBranchResult["branches"];
   isExpanded: boolean;
   topRepoPath: string;
-  currentTheme: string;
   app: JupyterLab;
   refresh: () => void;
   diff: IDiffCallback;
@@ -30,7 +29,6 @@ export class HistorySideBar extends React.Component<IHistorySideBarProps, {}> {
               pastCommit={pastCommit}
               branches={this.props.branches}
               topRepoPath={this.props.topRepoPath}
-              currentTheme={this.props.currentTheme}
               app={this.props.app}
               refresh={this.props.refresh}
               diff={this.props.diff}

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -21,7 +21,6 @@ export interface IPastCommitNodeProps {
   pastCommit: SingleCommitInfo;
   branches: GitBranchResult["branches"];
   topRepoPath: string;
-  currentTheme: string;
   app: JupyterLab;
   diff: IDiffCallback;
   refresh: () => void;
@@ -112,7 +111,6 @@ export class PastCommitNode extends React.Component<
               <SinglePastCommitInfo
                 data={this.props.pastCommit}
                 topRepoPath={this.props.topRepoPath}
-                currentTheme={this.props.currentTheme}
                 app={this.props.app}
                 diff={this.props.diff}
                 refresh={this.props.refresh}

--- a/src/components/PastCommits.tsx
+++ b/src/components/PastCommits.tsx
@@ -21,7 +21,6 @@ export interface IPastCommitsProps {
   refresh: any;
   diff: IDiffCallback;
   sideBarExpanded: boolean;
-  currentTheme: string;
 }
 
 export class PastCommits extends React.Component<IPastCommitsProps, {}> {
@@ -41,7 +40,6 @@ export class PastCommits extends React.Component<IPastCommitsProps, {}> {
           refresh={this.props.refresh}
           sideBarExpanded={this.props.sideBarExpanded}
           display={this.props.showList}
-          currentTheme={this.props.currentTheme}
         />
       </div>
     );

--- a/src/components/PathHeader.tsx
+++ b/src/components/PathHeader.tsx
@@ -24,7 +24,6 @@ export interface IPathHeaderProps {
   topRepoPath: string;
   refresh: any;
   currentBranch: string;
-  isLightTheme: string;
 }
 
 export class PathHeader extends React.Component<IPathHeaderProps,
@@ -47,12 +46,12 @@ export class PathHeader extends React.Component<IPathHeaderProps,
           this.props.currentBranch}
         </span>
         <button
-          className={classes(gitPullStyle(this.props.isLightTheme), 'jp-Icon-16')}
+          className={classes(gitPullStyle, 'jp-Icon-16')}
           title={'Pull latest changes'}
           onClick={() => this.executeGitPull()}
         />
         <button
-          className={classes(gitPushStyle(this.props.isLightTheme), 'jp-Icon-16')}
+          className={classes(gitPushStyle, 'jp-Icon-16')}
           title={'Push committed changes'}
           onClick={() => this.executeGitPush()}
         />

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -31,7 +31,6 @@ export interface ISinglePastCommitInfoProps {
   diff: IDiffCallback;
 
   refresh: () => void;
-  currentTheme: string;
 }
 
 export interface ISinglePastCommitInfoState {
@@ -139,7 +138,7 @@ export class SinglePastCommitInfo extends React.Component<
               <span
                 className={classes(
                   iconStyle,
-                  insertionIconStyle(this.props.currentTheme)
+                  insertionIconStyle
                 )}
               />
               {this.state.insertionCount}
@@ -148,7 +147,7 @@ export class SinglePastCommitInfo extends React.Component<
               <span
                 className={classes(
                   iconStyle,
-                  deletionIconStyle(this.props.currentTheme)
+                  deletionIconStyle
                 )}
               />
               {this.state.deletionCount}
@@ -162,7 +161,7 @@ export class SinglePastCommitInfo extends React.Component<
               className={classes(
                 changeStageButtonStyle,
                 floatRightStyle,
-                discardFileButtonStyle(this.props.currentTheme)
+                discardFileButtonStyle
               )}
               onClick={this.showDeleteCommit}
             />
@@ -170,7 +169,7 @@ export class SinglePastCommitInfo extends React.Component<
               className={classes(
                 changeStageButtonStyle,
                 floatRightStyle,
-                revertButtonStyle(this.props.currentTheme)
+                revertButtonStyle
               )}
               onClick={this.showResetToCommit}
             />

--- a/src/componentsStyle/BranchHeaderStyle.tsx
+++ b/src/componentsStyle/BranchHeaderStyle.tsx
@@ -174,10 +174,21 @@ export const stagedCommitMessageStyle = style({
   flex: '20 1 auto',
   resize: 'none',
   padding: '4px 8px',
+  backgroundColor: 'var(--jp-layout-color1)',
+  color: 'var(--jp-ui-font-color0)',
 
   $nest: {
     '&:focus': {
       outline: 'none'
+    },
+    '&::-webkit-input-placeholder': {
+      color: 'var(--jp-ui-font-color3)'
+    },
+    '&::-moz-placeholder': {
+      color: 'var(--jp-ui-font-color3)'
+    },
+    '&::-ms-input-placeholder': {
+      color: 'var(--jp-ui-font-color3)'
     }
   }
 });

--- a/src/componentsStyle/BranchHeaderStyle.tsx
+++ b/src/componentsStyle/BranchHeaderStyle.tsx
@@ -13,7 +13,7 @@ export const selectedHeaderStyle = style({
 });
 
 export const unSelectedHeaderStyle = style({
-  backgroundColor: "#ededed",
+  backgroundColor: 'var(--jp-layout-color2)',
   borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
   paddingTop: 'var(--jp-border-width)',
 });

--- a/src/componentsStyle/BranchHeaderStyle.tsx
+++ b/src/componentsStyle/BranchHeaderStyle.tsx
@@ -54,7 +54,7 @@ export const branchTrackingLabelStyle = style({
   marginTop: '5px',
   marginBottom: '5px',
   display: 'inline-block',
-  color: '#828282',
+  color: 'var(--jp-ui-font-color2)',
   fontWeight: 'normal'
 });
 

--- a/src/componentsStyle/BranchHeaderStyle.tsx
+++ b/src/componentsStyle/BranchHeaderStyle.tsx
@@ -90,57 +90,27 @@ export const headerButtonStyle = style({
   marginLeft: '5px'
 });
 
-export function branchDropdownButtonStyle(isLight: string) {
-  if (isLight === 'true' || isLight === undefined) {
-    return style({
-      backgroundImage: 'var(--jp-icon-arrow-down)',
-      backgroundSize: '100%',
-      backgroundRepeat: 'no-repeat',
-      backgroundPosition: 'center',
-      height: '18px',
-      width: '18px',
-      display: 'inline-block',
-      verticalAlign: 'middle'
-    });
-  } else {
-    return style({
-      backgroundImage: 'var(--jp-icon-arrow-down-white)',
-      backgroundSize: '100%',
-      backgroundRepeat: 'no-repeat',
-      backgroundPosition: 'center',
-      height: '18px',
-      width: '18px',
-      display: 'inline-block',
-      verticalAlign: 'middle'
-    });
-  }
-}
+export const branchDropdownButtonStyle = style({
+  backgroundImage: 'var(--jp-icon-arrow-down)',
+  backgroundSize: '100%',
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'center',
+  height: '18px',
+  width: '18px',
+  display: 'inline-block',
+  verticalAlign: 'middle'
+});
 
-export function newBranchButtonStyle(isLight: string) {
-  if (isLight === 'true' || isLight === undefined) {
-    return style({
-      backgroundImage: 'var(--jp-icon-plus)',
-      backgroundSize: '100%',
-      backgroundRepeat: 'no-repeat',
-      backgroundPosition: 'center',
-      height: '18px',
-      width: '18px',
-      display: 'inline-block',
-      verticalAlign: 'middle'
-    });
-  } else {
-    return style({
-      backgroundImage: 'var(--jp-icon-plus-white)',
-      backgroundSize: '100%',
-      backgroundRepeat: 'no-repeat',
-      backgroundPosition: 'center',
-      height: '18px',
-      width: '18px',
-      display: 'inline-block',
-      verticalAlign: 'middle'
-    });
-  }
-}
+export const newBranchButtonStyle = style({
+  backgroundImage: 'var(--jp-icon-plus)',
+  backgroundSize: '100%',
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'center',
+  height: '18px',
+  width: '18px',
+  display: 'inline-block',
+  verticalAlign: 'middle'
+});
 
 export const branchTrackingIconStyle = style({
   backgroundImage: 'var(--jp-icon-branch-tracking)',

--- a/src/componentsStyle/FileListStyle.tsx
+++ b/src/componentsStyle/FileListStyle.tsx
@@ -1,28 +1,12 @@
 import { style } from 'typestyle';
 
-export function moveFileUpButtonStyle(isLight: string) {
-  if (isLight === 'true' || isLight === undefined) {
-    return style({
-      backgroundImage: 'var(--jp-icon-move-file-up)'
-    });
-  } else {
-    return style({
-      backgroundImage: 'var(--jp-icon-move-file-up-white)'
-    });
-  }
-}
+export const moveFileUpButtonStyle = style({
+  backgroundImage: 'var(--jp-icon-move-file-up)'
+});
 
-export function moveFileDownButtonStyle(isLight: string) {
-  if (isLight === 'true' || isLight === undefined) {
-    return style({
-      backgroundImage: 'var(--jp-icon-move-file-down)'
-    });
-  } else {
-    return style({
-      backgroundImage: 'var(--jp-icon-move-file-down-white)'
-    });
-  }
-}
+export const moveFileDownButtonStyle = style({
+  backgroundImage: 'var(--jp-icon-move-file-down)'
+});
 
 export const moveFileUpButtonSelectedStyle = style({
   backgroundImage: 'var(--jp-icon-move-file-up-hover)'

--- a/src/componentsStyle/GitStageStyle.tsx
+++ b/src/componentsStyle/GitStageStyle.tsx
@@ -73,21 +73,11 @@ export const changeStageButtonStyle = style({
   }
 });
 
-export function discardFileButtonStyle(isLight: string) {
-  if(isLight === 'true' || isLight === undefined) {
-    return style({
-      backgroundImage: 'var(--jp-icon-discard-file)',
-      marginLeft: '6px',
-      backgroundSize: '120%'
-    });
-  } else {
-    return style({
-      backgroundImage: 'var(--jp-icon-discard-file-white)',
-      marginLeft: '6px',
-      backgroundSize: '120%'
-    });
-  }
-}
+export const discardFileButtonStyle = style({
+  backgroundImage: 'var(--jp-icon-discard-file)',
+  marginLeft: '6px',
+  backgroundSize: '120%'
+});
 
 export const discardAllWarningStyle = style({
   height: '40px !important',

--- a/src/componentsStyle/PastCommitNodeStyle.tsx
+++ b/src/componentsStyle/PastCommitNodeStyle.tsx
@@ -11,7 +11,7 @@ export const pastCommitNodeStyle = style({
 export const pastCommitHeaderStyle = style({
   display: 'flex',
   justifyContent: 'space-between',
-  color: '#828282',
+  color: 'var(--jp-ui-font-color2)',
   paddingBottom: "5px"
 });
 
@@ -25,6 +25,9 @@ export const branchesStyle = style({
 
 export const branchStyle = style({
   padding: "2px",
+  // Special case as black, regardless of theme, because
+  // backgrounds of colors are not based on theme either
+  color: '#000000de',
   border: "var(--jp-border-width) solid #424242",
   borderRadius: "4px",
   margin: "3px",

--- a/src/componentsStyle/PathHeaderStyle.tsx
+++ b/src/componentsStyle/PathHeaderStyle.tsx
@@ -43,68 +43,50 @@ export const repoRefreshStyle = style({
   }
 });
 
-export function gitPushStyle(isLightTheme: string) {
+export const gitPushStyle = style({
+  width: 'var(--jp-private-running-button-width)',
+  background: 'var(--jp-layout-color1)',
+  border: 'none',
+  backgroundImage: 'var(--jp-icon-git-push)',
+  backgroundSize: '16px',
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'center',
+  boxSizing: 'border-box',
+  outline: 'none',
+  padding: '0px 6px',
+  margin: 'auto 5px auto auto',
+  height: '24px',
 
-  let backgroundImage;
-  if (isLightTheme === undefined || isLightTheme === 'true') {
-    backgroundImage = 'var(--jp-icon-git-push)';
-  } else {
-    backgroundImage = 'var(--jp-icon-git-push-white)';
-  }
-  return style({
-    width: 'var(--jp-private-running-button-width)',
-    background: 'var(--jp-layout-color1)',
-    border: 'none',
-    backgroundImage: backgroundImage,
-    backgroundSize: '16px',
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'center',
-    boxSizing: 'border-box',
-    outline: 'none',
-    padding: '0px 6px',
-    margin: 'auto 5px auto auto',
-    height: '24px',
-
-    $nest: {
-      '&:hover': {
-        backgroundColor: 'var(--jp-layout-color2)'
-      },
-      '&:active': {
-        backgroundColor: 'var(--jp-layout-color3)',
-      }
+  $nest: {
+    '&:hover': {
+      backgroundColor: 'var(--jp-layout-color2)'
+    },
+    '&:active': {
+      backgroundColor: 'var(--jp-layout-color3)',
     }
-  });
-}
-
-export function gitPullStyle(isLightTheme: string) {
-
-  let backgroundImage;
-  if (isLightTheme === undefined || isLightTheme === 'true') {
-    backgroundImage = 'var(--jp-icon-git-pull)';
-  } else {
-    backgroundImage = 'var(--jp-icon-git-pull-white)';
   }
-  return style({
-    width: 'var(--jp-private-running-button-width)',
-    background: 'var(--jp-layout-color1)',
-    border: 'none',
-    backgroundImage: backgroundImage,
-    backgroundSize: '16px',
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'center',
-    boxSizing: 'border-box',
-    outline: 'none',
-    padding: '0px 6px',
-    margin: 'auto 5px auto auto',
-    height: '24px',
+});
 
-    $nest: {
-      '&:hover': {
-        backgroundColor: 'var(--jp-layout-color2)'
-      },
-      '&:active': {
-        backgroundColor: 'var(--jp-layout-color3)',
-      }
+export const gitPullStyle = style({
+  width: 'var(--jp-private-running-button-width)',
+  background: 'var(--jp-layout-color1)',
+  border: 'none',
+  backgroundImage: 'var(--jp-icon-git-pull)',
+  backgroundSize: '16px',
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'center',
+  boxSizing: 'border-box',
+  outline: 'none',
+  padding: '0px 6px',
+  margin: 'auto 5px auto auto',
+  height: '24px',
+
+  $nest: {
+    '&:hover': {
+      backgroundColor: 'var(--jp-layout-color2)'
+    },
+    '&:active': {
+      backgroundColor: 'var(--jp-layout-color3)',
     }
-  });
-}
+  }
+});

--- a/src/componentsStyle/SinglePastCommitInfoStyle.tsx
+++ b/src/componentsStyle/SinglePastCommitInfoStyle.tsx
@@ -81,45 +81,19 @@ export const numberofChangedFilesStyle = style({
   backgroundImage: 'var(--jp-icon-file)'
 });
 
-export function insertionIconStyle(isLight: string) {
-  if (isLight === 'true' || isLight === undefined) {
-    return style({
-      backgroundImage: 'var(--jp-icon-insertions-made)'
-    });
-  } else {
-    return style({
-      backgroundImage: 'var(--jp-icon-insertions-made-white)'
-    });
-  }
-}
+export const insertionIconStyle = style({
+  backgroundImage: 'var(--jp-icon-insertions-made)'
+});
 
-export function deletionIconStyle(isLight: string) {
-  if (isLight === 'true' || isLight === undefined) {
-    return style({
-      backgroundImage: 'var(--jp-icon-deletions-made)'
-    });
-  } else {
-    return style({
-      backgroundImage: 'var(--jp-icon-deletions-made-white)'
-    });
-  }
-}
+export const deletionIconStyle = style({
+  backgroundImage: 'var(--jp-icon-deletions-made)'
+});
 
-export function revertButtonStyle(isLight: string) {
-  if (isLight === 'true' || isLight === undefined) {
-    return style({
-      backgroundImage: 'var(--jp-icon-rewind)',
-      marginLeft: '6px',
-      backgroundSize: '100%'
-    });
-  } else {
-    return style({
-      backgroundImage: 'var(--jp-icon-rewind-white)',
-      marginLeft: '6px',
-      backgroundSize: '100%'
-    });
-  }
-}
+export const revertButtonStyle = style({
+  backgroundImage: 'var(--jp-icon-rewind)',
+  marginLeft: '6px',
+  backgroundSize: '100%'
+});
 
 export const numberOfDeletionsStyle = style({
   position: 'absolute',

--- a/style/variables.css
+++ b/style/variables.css
@@ -5,38 +5,44 @@
 @import url('https://fonts.googleapis.com/css?family=Oswald');
 
 :root {
-  --jp-icon-discard-file: url('./images/discard.svg');
-  --jp-icon-discard-file-white: url('./images/discard-selected.svg');
   --jp-icon-discard-file-selected: url('./images/discard-selected.svg');
-  --jp-icon-insertions-made: url('./images/insertions-made-icon.svg');
-  --jp-icon-insertions-made-white: url('./images/insertions-made-icon-white.svg');
-  --jp-icon-deletions-made: url('./images/deletions-made-icon.svg');
-  --jp-icon-deletions-made-white: url('./images/deletions-made-icon-white.svg');
   --jp-Git-icon-author: url('./images/author.svg');
   --jp-image-caretdownwhite: url('./images/caretdownwhite.svg');
   --jp-caret-right-white: url('./images/caretrightwhite.svg');
-  --jp-icon-move-file-down: url('./images/move-file-down.svg');
-  --jp-icon-move-file-down-white: url('./images/move-file-down-hover.svg');
   --jp-icon-move-file-down-hover: url('./images/move-file-down-hover.svg');
-  --jp-icon-move-file-up: url('./images/move-file-up.svg');
-  --jp-icon-move-file-up-white: url('./images/move-file-up-hover.svg');
   --jp-icon-move-file-up-hover: url('./images/move-file-up-hover.svg');
   --jp-icon-path-arrow-right: url('./images/path-arrow-right.svg');
   --jp-checkmark: url('./images/checkmark-icon.svg');
-  --jp-icon-arrow-down: url('./images/arrow-down.svg');
-  --jp-icon-arrow-down-white: url('./images/arrow-down-white.svg');
-  --jp-icon-plus: url('./images/plus.svg');
-  --jp-icon-plus-white: url('./images/plus-white.svg');
   --jp-icon-clear-white: url('./images/clear-white.svg');
-  --jp-icon-rewind: url('./images/rewind.svg');
-  --jp-icon-rewind-white: url('./images/rewind-white.svg');
   --jp-icon-git: url('./images/git-icon.svg');
   --jp-icon-git-clone: url('./images/git-clone-icon.svg');
   --jp-icon-git-clone-disabled: url('./images/git-clone-icon-disabled.svg');
-  --jp-icon-git-push: url('./images/git-push.svg');
-  --jp-icon-git-push-white: url('./images/git-push-white.svg');
-  --jp-icon-git-pull: url('./images/git-pull.svg');
-  --jp-icon-git-pull-white: url('./images/git-pull-white.svg');
   --jp-icon-git-push-disabled: url('./images/git-clone-icon-disabled.svg');
   --jp-icon-git-pull-disabled: url('./images/git-clone-icon-disabled.svg');
+}
+
+[data-theme-light="true"] {
+  --jp-icon-arrow-down: url('./images/arrow-down.svg');
+  --jp-icon-deletions-made: url('./images/deletions-made-icon.svg');
+  --jp-icon-discard-file: url('./images/discard.svg');
+  --jp-icon-git-pull: url('./images/git-pull.svg');
+  --jp-icon-git-push: url('./images/git-push.svg');
+  --jp-icon-insertions-made: url('./images/insertions-made-icon.svg');
+  --jp-icon-move-file-down: url('./images/move-file-down.svg');
+  --jp-icon-move-file-up: url('./images/move-file-up.svg');
+  --jp-icon-plus: url('./images/plus.svg');
+  --jp-icon-rewind: url('./images/rewind.svg');
+}
+
+[data-theme-light="false"] {
+  --jp-icon-arrow-down: url('./images/arrow-down-white.svg');
+  --jp-icon-deletions-made: url('./images/deletions-made-icon-white.svg');
+  --jp-icon-discard-file: url('./images/discard-selected.svg');
+  --jp-icon-git-pull: url('./images/git-pull-white.svg');
+  --jp-icon-git-push: url('./images/git-push-white.svg');
+  --jp-icon-insertions-made: url('./images/insertions-made-icon-white.svg');
+  --jp-icon-move-file-down-white: url('./images/move-file-down-hover.svg');
+  --jp-icon-move-file-up: url('./images/move-file-up-hover.svg');
+  --jp-icon-plus: url('./images/plus-white.svg');
+  --jp-icon-rewind: url('./images/rewind-white.svg');
 }

--- a/tests/test-components/BranchHeader.spec.tsx
+++ b/tests/test-components/BranchHeader.spec.tsx
@@ -27,8 +27,7 @@ describe('BranchHeader', () => {
     toggleSidebar: function() {
       return true;
     },
-    showList: true,
-    currentTheme: 'dark'
+    showList: true
   };
 
   describe('#constructor()', () => {
@@ -148,8 +147,7 @@ describe('BranchHeader', () => {
         toggleSidebar: function() {
           return true;
         },
-        showList: false,
-        currentTheme: 'dark'
+        showList: false
       });
       let actual = branchHeader.getBranchStyle();
       let expected = classes(branchStyle, smallBranchStyle);

--- a/tests/test-components/HistorySideBar.spec.tsx
+++ b/tests/test-components/HistorySideBar.spec.tsx
@@ -22,7 +22,6 @@ describe("HistorySideBar", () => {
     branches: [],
     isExpanded: true,
     topRepoPath: null,
-    currentTheme: null,
     app: null,
     refresh: null,
     diff: null

--- a/tests/test-components/PastCommitNode.spec.tsx
+++ b/tests/test-components/PastCommitNode.spec.tsx
@@ -48,7 +48,6 @@ describe("PastCommitNode", () => {
   );
   const props = {
     topRepoPath: null,
-    currentTheme: null,
     app: null,
     diff: null,
     refresh: null,

--- a/tests/test-components/PathHeader.spec.tsx
+++ b/tests/test-components/PathHeader.spec.tsx
@@ -11,7 +11,6 @@ describe('PathHeader', function () {
     topRepoPath: '/foo',
     refresh: null,
     currentBranch: 'bar',
-    isLightTheme: 'true'
   };
 
   it('should have repo and branch details', function () {
@@ -22,40 +21,20 @@ describe('PathHeader', function () {
     expect(node.text()).toEqual('repo / bar');
   });
 
-  it('should have all buttons in light theme', function () {
+  it('should have all buttons', function () {
     // When
     const node = shallow(<PathHeader {...props} />);
 
     // Then
     const buttons = node.find('button');
     expect(buttons).toHaveLength(3);
-    expect(buttons.find(`.${gitPullStyle('true')}`)).toHaveLength(1);
-    expect(buttons.find(`.${gitPullStyle('true')}`).prop('title')).toEqual('Pull latest changes');
-    expect(buttons.find(`.${gitPushStyle('true')}`)).toHaveLength(1);
-    expect(buttons.find(`.${gitPushStyle('true')}`).prop('title')).toEqual('Push committed changes');
+    expect(buttons.find(`.${gitPullStyle}`)).toHaveLength(1);
+    expect(buttons.find(`.${gitPullStyle}`).prop('title')).toEqual('Pull latest changes');
+    expect(buttons.find(`.${gitPushStyle}`)).toHaveLength(1);
+    expect(buttons.find(`.${gitPushStyle}`).prop('title')).toEqual('Push committed changes');
     expect(buttons.find(`.${repoRefreshStyle}`)).toHaveLength(1);
   });
 
-  it('should have all buttons in dark theme', function () {
-      const props: IPathHeaderProps = {
-    currentFileBrowserPath: '/path/to/repo',
-    topRepoPath: '/foo',
-    refresh: null,
-    currentBranch: 'bar',
-    isLightTheme: 'false'
-  };
-    // When
-    const node = shallow(<PathHeader {...props} />);
-
-    // Then
-    const buttons = node.find('button');
-    expect(buttons).toHaveLength(3);
-    expect(buttons.find(`.${gitPullStyle('false')}`)).toHaveLength(1);
-    expect(buttons.find(`.${gitPullStyle('false')}`).prop('title')).toEqual('Pull latest changes');
-    expect(buttons.find(`.${gitPushStyle('false')}`)).toHaveLength(1);
-    expect(buttons.find(`.${gitPushStyle('false')}`).prop('title')).toEqual('Push committed changes');
-    expect(buttons.find(`.${repoRefreshStyle}`)).toHaveLength(1);
-  });
 
   it('should call API on button click', function () {
     // Given
@@ -68,11 +47,11 @@ describe('PathHeader', function () {
     // Then
     const buttons = node.find('button');
 
-    buttons.find(`.${gitPullStyle('true')}`).simulate('click');
+    buttons.find(`.${gitPullStyle}`).simulate('click');
     expect(spyPull).toHaveBeenCalledTimes(1);
     expect(spyPull).toHaveBeenCalledWith('/path/to/repo');
 
-    buttons.find(`.${gitPushStyle('true')}`).simulate('click');
+    buttons.find(`.${gitPushStyle}`).simulate('click');
     expect(spyPush).toHaveBeenCalledTimes(1);
     expect(spyPush).toHaveBeenCalledWith('/path/to/repo');
   });


### PR DESCRIPTION
This closes #307 by improving the appearance of in the dark theme. 

It also [switches from detecting the with JS to CSS](https://github.com/jupyterlab/jupyterlab-git/commit/0c340ab58376f7688430cf397c2063d45dc1a771).

# Main Page
## Light Theme
### Before
<img width="838" alt="Screen Shot 2019-04-01 at 4 45 03 PM" src="https://user-images.githubusercontent.com/1186124/55362174-395a4680-54a7-11e9-9023-1e005258a61e.png">

### After
<img width="1369" alt="Screen Shot 2019-04-01 at 5 46 27 PM" src="https://user-images.githubusercontent.com/1186124/55362019-d10b6500-54a6-11e9-9377-adf44193f952.png">

## Dark Theme
### Before
<img width="1920" alt="Screen Shot 2019-04-01 at 4 45 17 PM" src="https://user-images.githubusercontent.com/1186124/55362120-15970080-54a7-11e9-9f1a-0034570ac2e7.png">

### After
<img width="1250" alt="Screen Shot 2019-04-01 at 5 46 11 PM" src="https://user-images.githubusercontent.com/1186124/55362079-0021d680-54a7-11e9-8067-622e3087bedd.png">


# History Page
## Light Theme
### Before
<img width="787" alt="Screen Shot 2019-04-01 at 4 45 07 PM" src="https://user-images.githubusercontent.com/1186124/55362142-247db300-54a7-11e9-9fdc-3d41241152be.png">

### After
<img width="1141" alt="Screen Shot 2019-04-01 at 5 46 23 PM" src="https://user-images.githubusercontent.com/1186124/55361980-b33e0000-54a6-11e9-9e9f-266cec5c2ab2.png">

## Dark Theme
### Before
<img width="1920" alt="Screen Shot 2019-04-01 at 4 45 12 PM" src="https://user-images.githubusercontent.com/1186124/55362109-0dd75c00-54a7-11e9-87da-b13d2874667c.png">

### After
<img width="1221" alt="Screen Shot 2019-04-01 at 5 46 17 PM" src="https://user-images.githubusercontent.com/1186124/55362045-e54f6200-54a6-11e9-8d72-921e7ad7d663.png">
