### PR TITLE
Add full file path to tooltip over file

### DIFF
--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -277,6 +277,7 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
               this.props.app
             )
           }
+          title={this.props.file.to}
         >
           {this.props.extractFilename(this.props.file.to)}
           <span className={this.getFileChangedLabelClass(this.props.file.y)}>

--- a/tests/test-components/FileItem.spec.tsx
+++ b/tests/test-components/FileItem.spec.tsx
@@ -1,0 +1,49 @@
+import {
+  FileItem,
+  IFileItemProps
+} from '../../src/components/FileItem';
+import * as React from 'react';
+import 'jest';
+import { shallow } from "enzyme";
+
+
+describe('FileItem', () => {
+  const props: IFileItemProps = {
+    topRepoPath: '',
+    file: {
+      to: 'some/file/path/file-name'
+    },
+    stage: '',
+    app: null,
+    refresh: null,
+    moveFile: () => {},
+    discardFile: () => {},
+    moveFileIconClass: () => {},
+    moveFileIconSelectedClass: 'string',
+    moveFileTitle: '',
+    openFile: () => {},
+    extractFilename: () => {},
+    contextMenu: () => {},
+    parseFileExtension: () => {},
+    parseSelectedFileExtension: () => {},
+    selectedFile: 0,
+    updateSelectedFile: () => {},
+    fileIndex: 0,
+    selectedStage: '',
+    selectedDiscardFile: 0,
+    updateSelectedDiscardFile: () => {},
+    disableFile: false,
+    toggleDisableFiles: () => {},
+    sideBarExpanded: false,
+    currentTheme: ''
+  };
+
+  describe("#render()", () => {
+    const component = shallow(<FileItem {...props} />);
+    it("should display the full path on hover", () => {
+      expect(
+        component.find('[title="some/file/path/file-name"]')
+      ).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
This fixes #327 by showing a the full file path on hover over a file name:

<img width="455" alt="Screen Shot 2019-04-03 at 3 54 52 PM" src="https://user-images.githubusercontent.com/1186124/55508967-050e9380-5629-11e9-86cc-fa69e5d8a5bf.png">

