### PR TITLE
Stricter lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ script:
   - pip install .
   - jupyter labextension install .
   - python -m jupyterlab.browser_check
+  - yarn run lint

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "clean": "rimraf lib",
     "prepublish": "npm run build",
     "watch": "tsc -w",
-    "test": "jest"
+    "test": "jest",
+    "lint": "tslint --project .",
   },
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",

--- a/package.json
+++ b/package.json
@@ -62,17 +62,28 @@
     "@types/react-dom": "~16.0.5",
     "enzyme": "3.7.0",
     "enzyme-adapter-react-16": "1.7.0",
+    "husky": "1.3.1",
     "jest": "^23.6.0",
     "jest-fetch-mock": "^1.6.6",
-    "prettier": "^1.14.3",
+    "lint-staged": "8.1.5",
+    "prettier": "1.16.4",
     "rimraf": "^2.6.1",
     "ts-jest": "^23.10.4",
     "tslint": "^5.11.0",
+    "tslint-config-prettier": "1.18.0",
     "tslint-plugin-prettier": "^2.0.0",
     "typescript": "~3.1.2"
   },
   "directories": {
     "lib": "lib"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": ["tslint --fix", "git add"]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
   "lint-staged": {
     "*.{ts,tsx}": ["tslint --fix", "git add"]
   },
+  "prettier": {
+    "singleQuote": true
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jupyterlab/jupyterlab-git.git"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "lint": "tslint --project .",
+    "tslint-check": "tslint-config-prettier-check ./tslint.json"
   },
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "1.18.0",
     "tslint-plugin-prettier": "^2.0.0",
-    "typescript": "~3.1.2"
+    "typescript": "~3.1.2",
+    "typescript-tslint-plugin": "0.3.1"
   },
   "directories": {
     "lib": "lib"
@@ -83,7 +84,10 @@
     }
   },
   "lint-staged": {
-    "*.{ts,tsx}": ["tslint --fix", "git add"]
+    "*.{ts,tsx}": [
+      "tslint --fix",
+      "git add"
+    ]
   },
   "prettier": {
     "singleQuote": true

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -162,42 +162,40 @@ export class BranchHeader extends React.Component<
 
   getHistoryHeaderStyle() {
     if (this.props.sideBarExpanded) {
-      return classes(
-        openHistorySideBarButtonStyle,
-        selectedHeaderStyle
-      );
+      return classes(openHistorySideBarButtonStyle, selectedHeaderStyle);
     }
-    return classes(
-      unSelectedHeaderStyle,
-      openHistorySideBarButtonStyle
-    )
+    return classes(unSelectedHeaderStyle, openHistorySideBarButtonStyle);
   }
 
   getBranchHeaderStyle() {
     if (this.props.sideBarExpanded) {
-      return classes(
-        branchHeaderCenterContent,
-        unSelectedHeaderStyle
-      );
+      return classes(branchHeaderCenterContent, unSelectedHeaderStyle);
     }
-    return classes(
-      selectedHeaderStyle,
-      branchHeaderCenterContent
-    )
+    return classes(selectedHeaderStyle, branchHeaderCenterContent);
   }
 
   render() {
     return (
       <div className={this.getBranchStyle()}>
-        <div style={{display: "flex"}}>
-          <div className={this.getHistoryHeaderStyle()}
-            onClick={this.props.sideBarExpanded ? null : () => this.props.toggleSidebar()}
+        <div style={{ display: 'flex' }}>
+          <div
+            className={this.getHistoryHeaderStyle()}
+            onClick={
+              this.props.sideBarExpanded
+                ? null
+                : () => this.props.toggleSidebar()
+            }
             title={'Show commit history'}
           >
             <h3 className={historyLabelStyle}>History</h3>
           </div>
-          <div className={this.getBranchHeaderStyle()}
-            onClick={this.props.sideBarExpanded ? () => this.props.toggleSidebar() : null}
+          <div
+            className={this.getBranchHeaderStyle()}
+            onClick={
+              this.props.sideBarExpanded
+                ? () => this.props.toggleSidebar()
+                : null
+            }
           >
             <h3 className={branchLabelStyle}>{this.props.currentBranch}</h3>
             <div
@@ -216,10 +214,7 @@ export class BranchHeader extends React.Component<
               <div
                 className={
                   this.props.disabled
-                    ? classes(
-                        newBranchButtonStyle,
-                        headerButtonDisabledStyle
-                      )
+                    ? classes(newBranchButtonStyle, headerButtonDisabledStyle)
                     : newBranchButtonStyle
                 }
                 title={'Create a new branch'}
@@ -233,40 +228,50 @@ export class BranchHeader extends React.Component<
                   toggleNewBranchBox={this.toggleNewBranchBox}
                 />
               )}
-            {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<div className={branchTrackingIconStyle}/>)}
-            {this.props.upstreamBranch != null && this.props.upstreamBranch != '' && (<h3 className={branchTrackingLabelStyle}>{this.props.upstreamBranch}</h3>)}
+            {this.props.upstreamBranch != null &&
+              this.props.upstreamBranch != '' && (
+                <div className={branchTrackingIconStyle} />
+              )}
+            {this.props.upstreamBranch != null &&
+              this.props.upstreamBranch != '' && (
+                <h3 className={branchTrackingLabelStyle}>
+                  {this.props.upstreamBranch}
+                </h3>
+              )}
           </div>
         </div>
-        {!this.props.sideBarExpanded && (<>
-          {this.state.dropdownOpen && (
-            <div>
-              {this.props.data.map((branch: any, branchIndex: number) => {
-                return (
-                  <li
-                    className={branchListItemStyle}
-                    key={branchIndex}
-                    onClick={() => this.switchBranch(branch.name)}
-                  >
-                    {branch.name}
-                  </li>
-                );
-              })}
-            </div>
-          )}
-          {this.state.showNewBranchBox && (
-            <div>Branching from {this.props.currentBranch}</div>
-          )}
-          {this.state.showCommitBox &&
-            this.props.showList && (
-              <CommitBox
-                checkReadyForSubmit={this.updateCommitBoxState}
-                stagedFiles={this.props.stagedFiles}
-                commitAllStagedFiles={this.commitAllStagedFiles}
-                topRepoPath={this.props.topRepoPath}
-                refresh={this.props.refresh}
-              />
+        {!this.props.sideBarExpanded && (
+          <>
+            {this.state.dropdownOpen && (
+              <div>
+                {this.props.data.map((branch: any, branchIndex: number) => {
+                  return (
+                    <li
+                      className={branchListItemStyle}
+                      key={branchIndex}
+                      onClick={() => this.switchBranch(branch.name)}
+                    >
+                      {branch.name}
+                    </li>
+                  );
+                })}
+              </div>
             )}
-        </>)}
+            {this.state.showNewBranchBox && (
+              <div>Branching from {this.props.currentBranch}</div>
+            )}
+            {this.state.showCommitBox &&
+              this.props.showList && (
+                <CommitBox
+                  checkReadyForSubmit={this.updateCommitBoxState}
+                  stagedFiles={this.props.stagedFiles}
+                  commitAllStagedFiles={this.commitAllStagedFiles}
+                  topRepoPath={this.props.topRepoPath}
+                  refresh={this.props.refresh}
+                />
+              )}
+          </>
+        )}
       </div>
     );
   }

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -221,13 +221,12 @@ export class BranchHeader extends React.Component<
                 onClick={() => this.toggleNewBranchBox()}
               />
             )}
-            {this.state.showNewBranchBox &&
-              this.props.showList && (
-                <NewBranchBox
-                  createNewBranch={this.createNewBranch}
-                  toggleNewBranchBox={this.toggleNewBranchBox}
-                />
-              )}
+            {this.state.showNewBranchBox && this.props.showList && (
+              <NewBranchBox
+                createNewBranch={this.createNewBranch}
+                toggleNewBranchBox={this.toggleNewBranchBox}
+              />
+            )}
             {this.props.upstreamBranch != null &&
               this.props.upstreamBranch != '' && (
                 <div className={branchTrackingIconStyle} />
@@ -260,16 +259,15 @@ export class BranchHeader extends React.Component<
             {this.state.showNewBranchBox && (
               <div>Branching from {this.props.currentBranch}</div>
             )}
-            {this.state.showCommitBox &&
-              this.props.showList && (
-                <CommitBox
-                  checkReadyForSubmit={this.updateCommitBoxState}
-                  stagedFiles={this.props.stagedFiles}
-                  commitAllStagedFiles={this.commitAllStagedFiles}
-                  topRepoPath={this.props.topRepoPath}
-                  refresh={this.props.refresh}
-                />
-              )}
+            {this.state.showCommitBox && this.props.showList && (
+              <CommitBox
+                checkReadyForSubmit={this.updateCommitBoxState}
+                stagedFiles={this.props.stagedFiles}
+                commitAllStagedFiles={this.commitAllStagedFiles}
+                topRepoPath={this.props.topRepoPath}
+                refresh={this.props.refresh}
+              />
+            )}
           </>
         )}
       </div>

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -228,11 +228,11 @@ export class BranchHeader extends React.Component<
               />
             )}
             {this.props.upstreamBranch != null &&
-              this.props.upstreamBranch != '' && (
+              this.props.upstreamBranch !== '' && (
                 <div className={branchTrackingIconStyle} />
               )}
             {this.props.upstreamBranch != null &&
-              this.props.upstreamBranch != '' && (
+              this.props.upstreamBranch !== '' && (
                 <h3 className={branchTrackingLabelStyle}>
                   {this.props.upstreamBranch}
                 </h3>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -596,7 +596,7 @@ export function parseFileExtension(path: string): string {
   if (path[path.length - 1] === '/') {
     return folderFileIconStyle;
   }
-  var fileExtension = PathExt.extname(path).toLocaleLowerCase();
+  let fileExtension = PathExt.extname(path).toLocaleLowerCase();
   switch (fileExtension) {
     case '.md':
       return markdownFileIconStyle;
@@ -638,7 +638,7 @@ export function parseSelectedFileExtension(path: string): string {
   if (path[path.length - 1] === '/') {
     return folderFileIconSelectedStyle;
   }
-  var fileExtension = PathExt.extname(path).toLocaleLowerCase();
+  let fileExtension = PathExt.extname(path).toLocaleLowerCase();
   switch (fileExtension) {
     case '.md':
       return markdownFileIconSelectedStyle;

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -6,7 +6,7 @@ import { Menu } from '@phosphor/widgets';
 
 import { PathExt } from '@jupyterlab/coreutils';
 
-import { Git, GitShowPrefixResult } from '../git';
+import { Git, IGitShowPrefixResult } from '../git';
 
 import {
   moveFileUpButtonStyle,
@@ -214,26 +214,6 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     });
   }
 
-  /** Handle clicks on a staged file
-   *
-   */
-  handleClickStaged(event: any) {
-    event.preventDefault();
-    if (event.buttons === 2) {
-      <select>
-        <option className="jp-Git-switch-branch" value="" disabled>
-          Open
-        </option>
-        <option className="jp-Git-create-branch-line" disabled>
-          unstaged this file
-        </option>
-        <option className="jp-Git-create-branch" value="">
-          CREATE NEW
-        </option>
-      </select>;
-    }
-  }
-
   /** Handle right-click on a staged file */
   contextMenuStaged = (
     event: any,
@@ -349,7 +329,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       }
       let gitApi = new Git();
       let prefixData = await gitApi.showPrefix((fileBrowser as any).model.path);
-      let underRepoPath = (prefixData as GitShowPrefixResult).under_repo_path;
+      let underRepoPath = (prefixData as IGitShowPrefixResult).under_repo_path;
       let fileBrowserPath = (fileBrowser as any).model.path + '/';
       let openFilePath = fileBrowserPath.substring(
         0,

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -11,7 +11,7 @@ import {
   GitLogResult,
   SingleCommitInfo,
   GitStatusFileResult,
-  IDiffCallback,
+  IDiffCallback
 } from '../git';
 
 import { PathHeader } from './PathHeader';
@@ -27,7 +27,6 @@ import {
   panelWarningStyle,
   findRepoButtonStyle
 } from '../componentsStyle/GitPanelStyle';
-
 
 /** Interface for GitPanel component state */
 export interface IGitSessionNodeState {
@@ -49,7 +48,6 @@ export interface IGitSessionNodeState {
   untrackedFiles: any;
 
   sideBarExpanded: boolean;
-
 }
 
 /** Interface for GitPanel component props */
@@ -79,14 +77,13 @@ export class GitPanel extends React.Component<
       stagedFiles: [],
       unstagedFiles: [],
       untrackedFiles: [],
-      sideBarExpanded: false,
+      sideBarExpanded: false
     };
   }
 
   setShowList = (state: boolean) => {
     this.setState({ showList: state });
   };
-
 
   /**
    * Refresh widget, update all content
@@ -212,8 +209,6 @@ export class GitPanel extends React.Component<
   toggleSidebar = (): void => {
     this.setState({ sideBarExpanded: !this.state.sideBarExpanded });
   };
-
-
 
   render() {
     return (

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -4,13 +4,13 @@ import { JupyterLab } from '@jupyterlab/application';
 
 import {
   Git,
-  GitBranchResult,
-  GitStatusResult,
-  GitShowTopLevelResult,
-  GitAllHistory,
-  GitLogResult,
-  SingleCommitInfo,
-  GitStatusFileResult,
+  IGitBranchResult,
+  IGitStatusResult,
+  IGitShowTopLevelResult,
+  IGitAllHistory,
+  IGitLogResult,
+  ISingleCommitInfo,
+  IGitStatusFileResult,
   IDiffCallback
 } from '../git';
 
@@ -105,15 +105,15 @@ export class GitPanel extends React.Component<
 
         if (apiResult.code === 0) {
           // Get top level path of repo
-          let apiShowTopLevel = (apiResult as GitAllHistory).data
+          let apiShowTopLevel = (apiResult as IGitAllHistory).data
             .show_top_level;
 
           // Get current and upstream git branch
-          let branchData = (apiResult as GitAllHistory).data.branch;
+          let branchData = (apiResult as IGitAllHistory).data.branch;
           let currentBranch = 'master';
           let upstreamBranch = '';
           if (branchData.code === 0) {
-            let allBranches = (branchData as GitBranchResult).branches;
+            let allBranches = (branchData as IGitBranchResult).branches;
             for (let i = 0; i < allBranches.length; i++) {
               if (allBranches[i].is_current_branch) {
                 currentBranch = allBranches[i].name;
@@ -124,21 +124,21 @@ export class GitPanel extends React.Component<
           }
 
           // Get git log for current branch
-          let logData = (apiResult as GitAllHistory).data.log;
-          let pastCommits = new Array<SingleCommitInfo>();
+          let logData = (apiResult as IGitAllHistory).data.log;
+          let pastCommits = new Array<ISingleCommitInfo>();
           if (logData.code === 0) {
-            pastCommits = (logData as GitLogResult).commits;
+            pastCommits = (logData as IGitLogResult).commits;
           }
 
           // Get git status for current branch
-          let stagedFiles = new Array<GitStatusFileResult>(),
-            unstagedFiles = new Array<GitStatusFileResult>(),
-            untrackedFiles = new Array<GitStatusFileResult>();
+          let stagedFiles = new Array<IGitStatusFileResult>();
+          let unstagedFiles = new Array<IGitStatusFileResult>();
+          let untrackedFiles = new Array<IGitStatusFileResult>();
           let changedFiles = 0;
           let disableSwitchBranch = true;
-          let statusData = (apiResult as GitAllHistory).data.status;
+          let statusData = (apiResult as IGitAllHistory).data.status;
           if (statusData.code === 0) {
-            let statusFiles = (statusData as GitStatusResult).files;
+            let statusFiles = (statusData as IGitStatusResult).files;
             for (let i = 0; i < statusFiles.length; i++) {
               // If file has been changed
               if (statusFiles[i].x !== '?' && statusFiles[i].x !== '!') {
@@ -171,7 +171,7 @@ export class GitPanel extends React.Component<
           // If not in same repo as before refresh, display the current repo
           let inNewRepo =
             this.state.topRepoPath !==
-            (apiShowTopLevel as GitShowTopLevelResult).top_repo_path;
+            (apiShowTopLevel as IGitShowTopLevelResult).top_repo_path;
           let showList = this.state.showList;
           if (inNewRepo) {
             showList = true;
@@ -179,10 +179,10 @@ export class GitPanel extends React.Component<
 
           this.setState({
             currentFileBrowserPath: (fileBrowser as any).model.path,
-            topRepoPath: (apiShowTopLevel as GitShowTopLevelResult)
+            topRepoPath: (apiShowTopLevel as IGitShowTopLevelResult)
               .top_repo_path,
             showWarning: true,
-            branches: (branchData as GitBranchResult).branches,
+            branches: (branchData as IGitBranchResult).branches,
             currentBranch: currentBranch,
             upstreamBranch: upstreamBranch,
             disableSwitchBranch: disableSwitchBranch,

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -114,7 +114,7 @@ export class GitPanel extends React.Component<
           let upstreamBranch = '';
           if (branchData.code === 0) {
             let allBranches = (branchData as GitBranchResult).branches;
-            for (var i = 0; i < allBranches.length; i++) {
+            for (let i = 0; i < allBranches.length; i++) {
               if (allBranches[i].is_current_branch) {
                 currentBranch = allBranches[i].name;
                 upstreamBranch = allBranches[i].upstream;

--- a/src/components/GitStage.tsx
+++ b/src/components/GitStage.tsx
@@ -126,7 +126,9 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
           )}
           <button
             disabled={this.checkContents()}
-            className={`${this.props.moveFileIconClass} ${changeStageButtonStyle}
+            className={`${
+              this.props.moveFileIconClass
+            } ${changeStageButtonStyle}
                ${changeStageButtonLeftStyle}`}
             title={this.props.moveAllFilesTitle}
             onClick={() =>

--- a/src/components/GitStage.tsx
+++ b/src/components/GitStage.tsx
@@ -1,6 +1,6 @@
 import { JupyterLab } from '@jupyterlab/application';
 
-import { GitStatusFileResult } from '../git';
+import { IGitStatusFileResult } from '../git';
 
 import {
   sectionFileContainerStyle,
@@ -153,10 +153,10 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
         {this.props.showFiles && (
           <div className={sectionFileContainerStyle}>
             {this.props.files.map(
-              (file: GitStatusFileResult, file_index: number) => {
+              (file: IGitStatusFileResult, fileIndex: number) => {
                 return (
                   <FileItem
-                    key={file_index}
+                    key={fileIndex}
                     topRepoPath={this.props.topRepoPath}
                     stage={this.props.heading}
                     file={file}
@@ -178,7 +178,7 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
                     }
                     selectedFile={this.props.selectedFile}
                     updateSelectedFile={this.props.updateSelectedFile}
-                    fileIndex={file_index}
+                    fileIndex={fileIndex}
                     selectedStage={this.props.selectedStage}
                     selectedDiscardFile={this.props.selectedDiscardFile}
                     updateSelectedDiscardFile={

--- a/src/components/GitWidget.tsx
+++ b/src/components/GitWidget.tsx
@@ -18,7 +18,6 @@ import { gitWidgetStyle } from '../componentsStyle/GitWidgetStyle';
 
 import { IDiffCallback } from '../git';
 
-
 import '../../style/variables.css';
 
 /**
@@ -69,7 +68,11 @@ export class GitWidget extends Widget {
   /**
    * Construct a new running widget.
    */
-  constructor(app: JupyterLab, options: IOptions, diff_function: IDiffCallback) {
+  constructor(
+    app: JupyterLab,
+    options: IOptions,
+    diff_function: IDiffCallback
+  ) {
     super({
       node: (options.renderer || defaultRenderer).createNode()
     });
@@ -80,7 +83,7 @@ export class GitWidget extends Widget {
   }
 
   /**
-   * Override widget's default show() to 
+   * Override widget's default show() to
    * refresh content every time Git widget is shown.
    */
   show(): void {

--- a/src/components/GitWidget.tsx
+++ b/src/components/GitWidget.tsx
@@ -68,16 +68,12 @@ export class GitWidget extends Widget {
   /**
    * Construct a new running widget.
    */
-  constructor(
-    app: JupyterLab,
-    options: IOptions,
-    diff_function: IDiffCallback
-  ) {
+  constructor(app: JupyterLab, options: IOptions, diffFunction: IDiffCallback) {
     super({
       node: (options.renderer || defaultRenderer).createNode()
     });
     this.addClass(gitWidgetStyle);
-    const element = <GitPanel app={app} diff={diff_function} />;
+    const element = <GitPanel app={app} diff={diffFunction} />;
     this.component = ReactDOM.render(element, this.node);
     this.component.refresh();
   }
@@ -135,6 +131,7 @@ export class GitWidget extends Widget {
     switch (event.type) {
       case 'change':
         this._evtChange(event as MouseEvent);
+        break;
       case 'click':
         this._evtClick(event as MouseEvent);
         break;

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -1,13 +1,13 @@
-import { JupyterLab } from "@jupyterlab/application";
-import * as React from "react";
-import { historySideBarStyle } from "../componentsStyle/HistorySideBarStyle";
-import { GitBranchResult, SingleCommitInfo, IDiffCallback } from "../git";
-import { PastCommitNode } from "./PastCommitNode";
+import { JupyterLab } from '@jupyterlab/application';
+import * as React from 'react';
+import { historySideBarStyle } from '../componentsStyle/HistorySideBarStyle';
+import { GitBranchResult, SingleCommitInfo, IDiffCallback } from '../git';
+import { PastCommitNode } from './PastCommitNode';
 
 /** Interface for PastCommits component props */
 export interface IHistorySideBarProps {
   pastCommits: SingleCommitInfo[];
-  branches: GitBranchResult["branches"];
+  branches: GitBranchResult['branches'];
   isExpanded: boolean;
   topRepoPath: string;
   app: JupyterLab;

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -1,13 +1,13 @@
 import { JupyterLab } from '@jupyterlab/application';
 import * as React from 'react';
 import { historySideBarStyle } from '../componentsStyle/HistorySideBarStyle';
-import { GitBranchResult, SingleCommitInfo, IDiffCallback } from '../git';
+import { IGitBranchResult, ISingleCommitInfo, IDiffCallback } from '../git';
 import { PastCommitNode } from './PastCommitNode';
 
 /** Interface for PastCommits component props */
 export interface IHistorySideBarProps {
-  pastCommits: SingleCommitInfo[];
-  branches: GitBranchResult['branches'];
+  pastCommits: ISingleCommitInfo[];
+  branches: IGitBranchResult['branches'];
   isExpanded: boolean;
   topRepoPath: string;
   app: JupyterLab;
@@ -23,7 +23,7 @@ export class HistorySideBar extends React.Component<IHistorySideBarProps, {}> {
     return (
       <div className={historySideBarStyle}>
         {this.props.pastCommits.map(
-          (pastCommit: SingleCommitInfo, pastCommitIndex: number) => (
+          (pastCommit: ISingleCommitInfo, pastCommitIndex: number) => (
             <PastCommitNode
               key={pastCommitIndex}
               pastCommit={pastCommit}

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -1,6 +1,6 @@
-import { JupyterLab } from "@jupyterlab/application";
-import * as React from "react";
-import { classes } from "typestyle";
+import { JupyterLab } from '@jupyterlab/application';
+import * as React from 'react';
+import { classes } from 'typestyle';
 import {
   branchesStyle,
   branchStyle,
@@ -13,13 +13,13 @@ import {
   pastCommitNodeStyle,
   remoteBranchStyle,
   workingBranchStyle
-} from "../componentsStyle/PastCommitNodeStyle";
-import { GitBranchResult, SingleCommitInfo, IDiffCallback } from "../git";
-import { SinglePastCommitInfo } from "./SinglePastCommitInfo";
+} from '../componentsStyle/PastCommitNodeStyle';
+import { GitBranchResult, SingleCommitInfo, IDiffCallback } from '../git';
+import { SinglePastCommitInfo } from './SinglePastCommitInfo';
 
 export interface IPastCommitNodeProps {
   pastCommit: SingleCommitInfo;
-  branches: GitBranchResult["branches"];
+  branches: GitBranchResult['branches'];
   topRepoPath: string;
   app: JupyterLab;
   diff: IDiffCallback;

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -14,12 +14,12 @@ import {
   remoteBranchStyle,
   workingBranchStyle
 } from '../componentsStyle/PastCommitNodeStyle';
-import { GitBranchResult, SingleCommitInfo, IDiffCallback } from '../git';
+import { IGitBranchResult, ISingleCommitInfo, IDiffCallback } from '../git';
 import { SinglePastCommitInfo } from './SinglePastCommitInfo';
 
 export interface IPastCommitNodeProps {
-  pastCommit: SingleCommitInfo;
-  branches: GitBranchResult['branches'];
+  pastCommit: ISingleCommitInfo;
+  branches: IGitBranchResult['branches'];
   topRepoPath: string;
   app: JupyterLab;
   diff: IDiffCallback;
@@ -41,11 +41,11 @@ export class PastCommitNode extends React.Component<
     };
   }
   getBranchesForCommit() {
-    const current_commit = this.props.pastCommit.commit;
+    const currentCommit = this.props.pastCommit.commit;
     const branches = [];
     for (let i = 0; i < this.props.branches.length; i++) {
       const branch = this.props.branches[i];
-      if (branch.top_commit && branch.top_commit == current_commit) {
+      if (branch.top_commit && branch.top_commit === currentCommit) {
         branches.push(branch);
       }
     }
@@ -70,6 +70,7 @@ export class PastCommitNode extends React.Component<
     return (
       <div
         onClick={() => {
+          // tslint:disable-next-line: no-unused-expression
           !this.state.expanded && this.expand();
         }}
         className={this.getNodeClass()}

--- a/src/components/PathHeader.tsx
+++ b/src/components/PathHeader.tsx
@@ -8,11 +8,11 @@ import {
 
 import * as React from 'react';
 
-import {classes} from 'typestyle';
+import { classes } from 'typestyle';
 
-import {Git} from '../git';
+import { Git } from '../git';
 
-import {Dialog, showDialog} from '@jupyterlab/apputils';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
 
 export interface IPathHeaderState {
   refresh: any;
@@ -26,8 +26,10 @@ export interface IPathHeaderProps {
   currentBranch: string;
 }
 
-export class PathHeader extends React.Component<IPathHeaderProps,
-  IPathHeaderState> {
+export class PathHeader extends React.Component<
+  IPathHeaderProps,
+  IPathHeaderState
+> {
   constructor(props: IPathHeaderProps) {
     super(props);
     this.state = {
@@ -42,8 +44,8 @@ export class PathHeader extends React.Component<IPathHeaderProps,
       <div className={repoStyle}>
         <span className={repoPathStyle}>
           {relativePath[relativePath.length - 1] +
-          ' / ' +
-          this.props.currentBranch}
+            ' / ' +
+            this.props.currentBranch}
         </span>
         <button
           className={classes(gitPullStyle, 'jp-Icon-16')}
@@ -67,7 +69,8 @@ export class PathHeader extends React.Component<IPathHeaderProps,
    * Execute the `/git/pull` API
    */
   private executeGitPull(): void {
-    this.state.gitApi.pull(this.props.currentFileBrowserPath)
+    this.state.gitApi
+      .pull(this.props.currentFileBrowserPath)
       .then(response => {
         if (response.code != 0) {
           this.showErrorDialog('Pull failed', response.message);
@@ -80,7 +83,8 @@ export class PathHeader extends React.Component<IPathHeaderProps,
    * Execute the `/git/push` API
    */
   private executeGitPush(): void {
-    this.state.gitApi.push(this.props.currentFileBrowserPath)
+    this.state.gitApi
+      .push(this.props.currentFileBrowserPath)
       .then(response => {
         if (response.code != 0) {
           this.showErrorDialog('Push failed', response.message);
@@ -98,7 +102,7 @@ export class PathHeader extends React.Component<IPathHeaderProps,
     return showDialog({
       title: title,
       body: body,
-      buttons: [Dialog.warnButton({label: 'DISMISS'})]
+      buttons: [Dialog.warnButton({ label: 'DISMISS' })]
     }).then(() => {
       // NO-OP
     });

--- a/src/components/PathHeader.tsx
+++ b/src/components/PathHeader.tsx
@@ -72,7 +72,7 @@ export class PathHeader extends React.Component<
     this.state.gitApi
       .pull(this.props.currentFileBrowserPath)
       .then(response => {
-        if (response.code != 0) {
+        if (response.code !== 0) {
           this.showErrorDialog('Pull failed', response.message);
         }
       })
@@ -86,7 +86,7 @@ export class PathHeader extends React.Component<
     this.state.gitApi
       .push(this.props.currentFileBrowserPath)
       .then(response => {
-        if (response.code != 0) {
+        if (response.code !== 0) {
           this.showErrorDialog('Push failed', response.message);
         }
       })

--- a/src/components/ResetDeleteSingleCommit.tsx
+++ b/src/components/ResetDeleteSingleCommit.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import { classes } from 'typestyle';
 
 import {
-  WarningLabel,
-  MessageInput,
-  Button,
-  ResetDeleteButton,
-  CancelButton,
-  ResetDeleteDisabledButton
+  warningLabel,
+  messageInput,
+  button,
+  resetDeleteButton,
+  cancelButton,
+  resetDeleteDisabledButton
 } from '../componentsStyle/SinglePastCommitInfoStyle';
 
 import { Git } from '../git';
@@ -74,19 +74,19 @@ export class ResetDeleteSingleCommit extends React.Component<
   render() {
     return (
       <div>
-        <div className={WarningLabel}>
+        <div className={warningLabel}>
           {this.props.action === 'delete'
             ? "These changes will be gone forever. Commit if you're sure?"
             : "All changes after this will be gone forever. Commit if you're sure?"}
         </div>
         <input
           type="text"
-          className={MessageInput}
+          className={messageInput}
           onChange={event => this.updateMessage(event.currentTarget.value)}
           placeholder="Add a commit message to make changes"
         />
         <button
-          className={classes(Button, CancelButton)}
+          className={classes(button, cancelButton)}
           onClick={this.onCancel}
         >
           Cancel
@@ -94,8 +94,8 @@ export class ResetDeleteSingleCommit extends React.Component<
         <button
           className={
             this.state.resetDeleteDisabled
-              ? classes(Button, ResetDeleteDisabledButton)
-              : classes(Button, ResetDeleteButton)
+              ? classes(button, resetDeleteDisabledButton)
+              : classes(button, resetDeleteButton)
           }
           disabled={this.state.resetDeleteDisabled}
           onClick={this.handleResetDelete}

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -21,9 +21,9 @@ import {
   revertButtonStyle
 } from '../componentsStyle/SinglePastCommitInfoStyle';
 import {
-  CommitModifiedFile,
+  ICommitModifiedFile,
   Git,
-  SingleCommitInfo,
+  ISingleCommitInfo,
   IDiffCallback
 } from '../git';
 import { parseFileExtension } from './FileList';
@@ -31,7 +31,7 @@ import { ResetDeleteSingleCommit } from './ResetDeleteSingleCommit';
 
 export interface ISinglePastCommitInfoProps {
   topRepoPath: string;
-  data: SingleCommitInfo;
+  data: ISingleCommitInfo;
   app: JupyterLab;
   diff: IDiffCallback;
 
@@ -45,7 +45,7 @@ export interface ISinglePastCommitInfoState {
   filesChanged: string;
   insertionCount: string;
   deletionCount: string;
-  modifiedFiles: Array<CommitModifiedFile>;
+  modifiedFiles: Array<ICommitModifiedFile>;
   loadingState: 'loading' | 'error' | 'success';
 }
 
@@ -125,10 +125,10 @@ export class SinglePastCommitInfo extends React.Component<
   };
 
   render() {
-    if (this.state.loadingState == 'loading') {
+    if (this.state.loadingState === 'loading') {
       return <div>...</div>;
     }
-    if (this.state.loadingState == 'error') {
+    if (this.state.loadingState === 'error') {
       return <div>Error loading commit data</div>;
     }
     return (

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -1,11 +1,11 @@
-import { JupyterLab } from "@jupyterlab/application";
-import * as React from "react";
-import { classes } from "typestyle/";
-import { fileIconStyle } from "../componentsStyle/FileItemStyle";
+import { JupyterLab } from '@jupyterlab/application';
+import * as React from 'react';
+import { classes } from 'typestyle/';
+import { fileIconStyle } from '../componentsStyle/FileItemStyle';
 import {
   changeStageButtonStyle,
   discardFileButtonStyle
-} from "../componentsStyle/GitStageStyle";
+} from '../componentsStyle/GitStageStyle';
 import {
   commitDetailFilePathStyle,
   commitDetailFileStyle,
@@ -19,10 +19,15 @@ import {
   insertionIconStyle,
   numberofChangedFilesStyle,
   revertButtonStyle
-} from "../componentsStyle/SinglePastCommitInfoStyle";
-import { CommitModifiedFile, Git, SingleCommitInfo, IDiffCallback } from "../git";
-import { parseFileExtension } from "./FileList";
-import { ResetDeleteSingleCommit } from "./ResetDeleteSingleCommit";
+} from '../componentsStyle/SinglePastCommitInfoStyle';
+import {
+  CommitModifiedFile,
+  Git,
+  SingleCommitInfo,
+  IDiffCallback
+} from '../git';
+import { parseFileExtension } from './FileList';
+import { ResetDeleteSingleCommit } from './ResetDeleteSingleCommit';
 
 export interface ISinglePastCommitInfoProps {
   topRepoPath: string;
@@ -41,7 +46,7 @@ export interface ISinglePastCommitInfoState {
   insertionCount: string;
   deletionCount: string;
   modifiedFiles: Array<CommitModifiedFile>;
-  loadingState: "loading" | "error" | "success";
+  loadingState: 'loading' | 'error' | 'success';
 }
 
 export class SinglePastCommitInfo extends React.Component<
@@ -53,12 +58,12 @@ export class SinglePastCommitInfo extends React.Component<
     this.state = {
       displayDelete: false,
       displayReset: false,
-      info: "",
-      filesChanged: "",
-      insertionCount: "",
-      deletionCount: "",
+      info: '',
+      filesChanged: '',
+      insertionCount: '',
+      deletionCount: '',
       modifiedFiles: [],
-      loadingState: "loading"
+      loadingState: 'loading'
     };
     this.showPastCommitWork();
   }
@@ -78,7 +83,7 @@ export class SinglePastCommitInfo extends React.Component<
         } and path ${this.props.topRepoPath}`,
         err
       );
-      this.setState(() => ({ loadingState: "error" }));
+      this.setState(() => ({ loadingState: 'error' }));
       return;
     }
     if (detailedLogData.code === 0) {
@@ -88,7 +93,7 @@ export class SinglePastCommitInfo extends React.Component<
         insertionCount: detailedLogData.number_of_insertions,
         deletionCount: detailedLogData.number_of_deletions,
         modifiedFiles: detailedLogData.modified_files,
-        loadingState: "success"
+        loadingState: 'success'
       });
     }
   };
@@ -120,10 +125,10 @@ export class SinglePastCommitInfo extends React.Component<
   };
 
   render() {
-    if (this.state.loadingState == "loading") {
+    if (this.state.loadingState == 'loading') {
       return <div>...</div>;
     }
-    if (this.state.loadingState == "error") {
+    if (this.state.loadingState == 'error') {
       return <div>Error loading commit data</div>;
     }
     return (
@@ -135,21 +140,11 @@ export class SinglePastCommitInfo extends React.Component<
               {this.state.filesChanged}
             </span>
             <span>
-              <span
-                className={classes(
-                  iconStyle,
-                  insertionIconStyle
-                )}
-              />
+              <span className={classes(iconStyle, insertionIconStyle)} />
               {this.state.insertionCount}
             </span>
             <span>
-              <span
-                className={classes(
-                  iconStyle,
-                  deletionIconStyle
-                )}
-              />
+              <span className={classes(iconStyle, deletionIconStyle)} />
               {this.state.deletionCount}
             </span>
           </div>
@@ -204,9 +199,9 @@ export class SinglePastCommitInfo extends React.Component<
                     )}`}
                     onDoubleClick={() => {
                       window.open(
-                        "https://github.com/search?q=" +
+                        'https://github.com/search?q=' +
                           this.props.data.commit +
-                          "&type=Commits&utf8=%E2%9C%93"
+                          '&type=Commits&utf8=%E2%9C%93'
                       );
                     }}
                   />

--- a/src/componentsStyle/BranchHeaderStyle.tsx
+++ b/src/componentsStyle/BranchHeaderStyle.tsx
@@ -3,19 +3,18 @@ import { style } from 'typestyle';
 export const branchStyle = style({
   zIndex: 1,
   textAlign: 'center',
-  overflowY: 'auto',
+  overflowY: 'auto'
 });
-
 
 export const selectedHeaderStyle = style({
   borderTop: 'var(--jp-border-width) solid var(--jp-border-color2)',
-  paddingBottom: 'var(--jp-border-width)',
+  paddingBottom: 'var(--jp-border-width)'
 });
 
 export const unSelectedHeaderStyle = style({
   backgroundColor: 'var(--jp-layout-color2)',
   borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
-  paddingTop: 'var(--jp-border-width)',
+  paddingTop: 'var(--jp-border-width)'
 });
 
 export const smallBranchStyle = style({
@@ -31,7 +30,7 @@ export const openHistorySideBarButtonStyle = style({
   flex: 'initial',
   paddingLeft: '10px',
   paddingRight: '10px',
-  borderRight: 'var(--jp-border-width) solid var(--jp-border-color2)',
+  borderRight: 'var(--jp-border-width) solid var(--jp-border-color2)'
 });
 
 export const historyLabelStyle = style({
@@ -39,7 +38,7 @@ export const historyLabelStyle = style({
   marginTop: '5px',
   marginBottom: '5px',
   display: 'inline-block',
-  fontWeight: 'normal',
+  fontWeight: 'normal'
 });
 
 export const branchLabelStyle = style({
@@ -121,8 +120,8 @@ export const branchTrackingIconStyle = style({
   display: 'inline-block',
   verticalAlign: 'middle',
   marginTop: '8px',
-  marginLeft: '10px',
-})
+  marginLeft: '10px'
+});
 
 export const headerButtonDisabledStyle = style({
   opacity: 0.5

--- a/src/componentsStyle/GitPanelStyle.tsx
+++ b/src/componentsStyle/GitPanelStyle.tsx
@@ -7,8 +7,6 @@ export const panelContainerStyle = style({
   height: '100%'
 });
 
-
-
 export const panelWarningStyle = style({
   textAlign: 'center',
   marginTop: '9px'

--- a/src/componentsStyle/HistorySideBarStyle.tsx
+++ b/src/componentsStyle/HistorySideBarStyle.tsx
@@ -3,6 +3,5 @@ import { style } from 'typestyle';
 export const historySideBarStyle = style({
   height: '100vh',
   display: 'flex',
-  flexDirection: 'column',
+  flexDirection: 'column'
 });
-

--- a/src/componentsStyle/PastCommitNodeStyle.tsx
+++ b/src/componentsStyle/PastCommitNodeStyle.tsx
@@ -4,61 +4,56 @@ export const pastCommitNodeStyle = style({
   flexGrow: 0,
   display: 'flex',
   flexDirection: 'column',
-  padding: "10px",
-  borderBottom: "var(--jp-border-width) solid var(--jp-border-color2)",
+  padding: '10px',
+  borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)'
 });
 
 export const pastCommitHeaderStyle = style({
   display: 'flex',
   justifyContent: 'space-between',
   color: 'var(--jp-ui-font-color2)',
-  paddingBottom: "5px"
+  paddingBottom: '5px'
 });
 
-
-
 export const branchesStyle = style({
-  display: "flex",
-  fontSize: "0.8em",
-  marginLeft: "-5px",
+  display: 'flex',
+  fontSize: '0.8em',
+  marginLeft: '-5px'
 });
 
 export const branchStyle = style({
-  padding: "2px",
+  padding: '2px',
   // Special case as black, regardless of theme, because
   // backgrounds of colors are not based on theme either
   color: '#000000de',
-  border: "var(--jp-border-width) solid #424242",
-  borderRadius: "4px",
-  margin: "3px",
+  border: 'var(--jp-border-width) solid #424242',
+  borderRadius: '4px',
+  margin: '3px'
 });
 
 export const remoteBranchStyle = style({
-  backgroundColor: "#ffcdd3"
+  backgroundColor: '#ffcdd3'
 });
 
 export const localBranchStyle = style({
-  backgroundColor: "#b2ebf3"
+  backgroundColor: '#b2ebf3'
 });
 
-
 export const workingBranchStyle = style({
-  backgroundColor: "#ffce83"
+  backgroundColor: '#ffce83'
 });
 
 export const pastCommitExpandedStyle = style({
-  backgroundColor: "#f9f9f9"
+  backgroundColor: '#f9f9f9'
 });
 
-export const pastCommitHeaderItemStyle = style({
-});
-
+export const pastCommitHeaderItemStyle = style({});
 
 export const collapseStyle = style({
-  color: "#1a76d2",
-  float: "right"
-})
+  color: '#1a76d2',
+  float: 'right'
+});
 
 export const pastCommitBodyStyle = style({
-  flex: 'auto',
+  flex: 'auto'
 });

--- a/src/componentsStyle/PathHeaderStyle.tsx
+++ b/src/componentsStyle/PathHeaderStyle.tsx
@@ -1,4 +1,4 @@
-import {style} from 'typestyle';
+import { style } from 'typestyle';
 
 export const repoStyle = style({
   display: 'flex',
@@ -16,7 +16,7 @@ export const repoPathStyle = style({
   overflow: 'hidden',
   whiteSpace: 'nowrap',
   verticalAlign: 'middle',
-  lineHeight: '33px',
+  lineHeight: '33px'
 });
 
 export const repoRefreshStyle = style({
@@ -38,7 +38,7 @@ export const repoRefreshStyle = style({
       backgroundColor: 'var(--jp-layout-color2)'
     },
     '&:active': {
-      backgroundColor: 'var(--jp-layout-color3)',
+      backgroundColor: 'var(--jp-layout-color3)'
     }
   }
 });
@@ -62,7 +62,7 @@ export const gitPushStyle = style({
       backgroundColor: 'var(--jp-layout-color2)'
     },
     '&:active': {
-      backgroundColor: 'var(--jp-layout-color3)',
+      backgroundColor: 'var(--jp-layout-color3)'
     }
   }
 });
@@ -86,7 +86,7 @@ export const gitPullStyle = style({
       backgroundColor: 'var(--jp-layout-color2)'
     },
     '&:active': {
-      backgroundColor: 'var(--jp-layout-color3)',
+      backgroundColor: 'var(--jp-layout-color3)'
     }
   }
 });

--- a/src/componentsStyle/SinglePastCommitInfoStyle.tsx
+++ b/src/componentsStyle/SinglePastCommitInfoStyle.tsx
@@ -5,7 +5,7 @@ export const commitStyle = style({
   width: '100%',
   fontSize: '12px',
   marginBottom: '10px',
-  marginTop: '5px',
+  marginTop: '5px'
 });
 
 export const headerStyle = style({
@@ -17,9 +17,8 @@ export const headerStyle = style({
 });
 
 export const floatRightStyle = style({
-  float: 'right',
-})
-
+  float: 'right'
+});
 
 export const commitOverviewNumbers = style({
   fontSize: '13px',

--- a/src/componentsStyle/SinglePastCommitInfoStyle.tsx
+++ b/src/componentsStyle/SinglePastCommitInfoStyle.tsx
@@ -108,31 +108,31 @@ export const numberOfInsertionsStyle = style({
   marginTop: '1px'
 });
 
-export const WarningLabel = style({
+export const warningLabel = style({
   padding: '5px 1px 5px 0'
 });
 
-export const MessageInput = style({
+export const messageInput = style({
   boxSizing: 'border-box',
   width: '95%',
   marginBottom: '7px'
 });
 
-export const Button = style({
+export const button = style({
   outline: 'none',
   border: 'none',
   color: 'var(--jp-layout-color0)'
 });
 
-export const ResetDeleteDisabledButton = style({
+export const resetDeleteDisabledButton = style({
   backgroundColor: 'var(--jp-error-color2)'
 });
 
-export const ResetDeleteButton = style({
+export const resetDeleteButton = style({
   backgroundColor: 'var(--jp-error-color1)'
 });
 
-export const CancelButton = style({
+export const cancelButton = style({
   backgroundColor: 'var(--jp-layout-color4)',
   marginRight: '4px'
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,8 +2,6 @@ import { ServerConnection } from '@jupyterlab/services';
 
 import { URLExt } from '@jupyterlab/coreutils';
 
-'use strict';
-
 /** Function type for diffing a file's revisions */
 export type IDiffCallback = (
   filename: string,
@@ -12,43 +10,48 @@ export type IDiffCallback = (
 ) => void;
 
 /** Interface for GitAllHistory request result,
- * has all repo information */
-export interface GitAllHistory {
+ * has all repo information
+ */
+export interface IGitAllHistory {
   code: number;
   data?: {
-    show_top_level?: GitShowTopLevelResult;
-    branch?: GitBranchResult;
-    log?: GitLogResult;
-    status?: GitStatusResult;
+    show_top_level?: IGitShowTopLevelResult;
+    branch?: IGitBranchResult;
+    log?: IGitLogResult;
+    status?: IGitStatusResult;
   };
 }
 
 /** Interface for GitShowTopLevel request result,
- * has the git root directory inside a repository */
-export interface GitShowTopLevelResult {
+ * has the git root directory inside a repository
+ */
+export interface IGitShowTopLevelResult {
   code: number;
   top_repo_path?: string;
 }
 
 /** Interface for GitShowPrefix request result,
  * has the prefix path of a directory in a repository,
- * with respect to the root directory. */
-export interface GitShowPrefixResult {
+ * with respect to the root directory.
+ */
+export interface IGitShowPrefixResult {
   code: number;
   under_repo_path?: string;
 }
 
 /** Interface for GitShowPrefix request result,
  * has the prefix path of a directory in a repository,
- * with respect to the root directory. */
-export interface GitCheckoutResult {
+ * with respect to the root directory.
+ */
+export interface IGitCheckoutResult {
   code: number;
   message?: string;
 }
 
 /** Interface for GitBranch request result,
- * has the result of changing the current working branch */
-export interface GitBranchResult {
+ * has the result of changing the current working branch
+ */
+export interface IGitBranchResult {
   code: number;
   branches?: Array<{
     is_current_branch: boolean;
@@ -61,8 +64,9 @@ export interface GitBranchResult {
 }
 
 /** Interface for GitStatus request result,
- * has the status of each changed file */
-export interface GitStatusFileResult {
+ * has the status of each changed file
+ */
+export interface IGitStatusFileResult {
   x: string;
   y: string;
   to: string;
@@ -70,15 +74,17 @@ export interface GitStatusFileResult {
 }
 
 /** Interface for GitStatus request result,
- * has the status of the entire repo */
-export interface GitStatusResult {
+ * has the status of the entire repo
+ */
+export interface IGitStatusResult {
   code: number;
-  files?: [GitStatusFileResult];
+  files?: [IGitStatusFileResult];
 }
 
 /** Interface for GitLog request result,
- * has the info of a single past commit */
-export interface SingleCommitInfo {
+ * has the info of a single past commit
+ */
+export interface ISingleCommitInfo {
   commit: string;
   author: string;
   date: string;
@@ -87,8 +93,9 @@ export interface SingleCommitInfo {
 }
 
 /** Interface for GitCommit request result,
- * has the info of a committed file */
-export interface CommitModifiedFile {
+ * has the info of a committed file
+ */
+export interface ICommitModifiedFile {
   modified_file_path: string;
   modified_file_name: string;
   insertion: string;
@@ -96,21 +103,23 @@ export interface CommitModifiedFile {
 }
 
 /** Interface for GitDetailedLog request result,
- * has the detailed info of a single past commit */
-export interface SingleCommitFilePathInfo {
+ * has the detailed info of a single past commit
+ */
+export interface ISingleCommitFilePathInfo {
   code: number;
   modified_file_note?: string;
   modified_files_count?: string;
   number_of_insertions?: string;
   number_of_deletions?: string;
-  modified_files?: [CommitModifiedFile];
+  modified_files?: [ICommitModifiedFile];
 }
 
 /** Interface for GitLog request result,
- * has the info of all past commits */
-export interface GitLogResult {
+ * has the info of all past commits
+ */
+export interface IGitLogResult {
   code: number;
-  commits?: [SingleCommitInfo];
+  commits?: [ISingleCommitInfo];
 }
 
 /** Makes a HTTP request, sending a git command to the backend */
@@ -132,7 +141,7 @@ function httpGitRequest(
 /**
  * Structure for the result of the Git Clone API.
  */
-export interface GitCloneResult {
+export interface IGitCloneResult {
   code: number;
   message?: string;
 }
@@ -182,7 +191,7 @@ export class Git {
   }
 
   /** Make request for the Git Clone API. */
-  async clone(path: string, url: string): Promise<GitCloneResult> {
+  async clone(path: string, url: string): Promise<IGitCloneResult> {
     try {
       let response = await httpGitRequest('/git/clone', 'POST', {
         current_path: path,
@@ -201,7 +210,7 @@ export class Git {
   /** Make request for all git info of repository 'path'
    * (This API is also implicitly used to check if the current repo is a Git repo)
    */
-  async allHistory(path: string): Promise<GitAllHistory> {
+  async allHistory(path: string): Promise<IGitAllHistory> {
     try {
       let response = await httpGitRequest('/git/all_history', 'POST', {
         current_path: path
@@ -217,7 +226,7 @@ export class Git {
   }
 
   /** Make request for top level path of repository 'path' */
-  async showTopLevel(path: string): Promise<GitShowTopLevelResult> {
+  async showTopLevel(path: string): Promise<IGitShowTopLevelResult> {
     try {
       let response = await httpGitRequest('/git/show_top_level', 'POST', {
         current_path: path
@@ -233,8 +242,9 @@ export class Git {
   }
 
   /** Make request for the prefix path of a directory 'path',
-   * with respect to the root directory of repository  */
-  async showPrefix(path: string): Promise<GitShowPrefixResult> {
+   * with respect to the root directory of repository
+   */
+  async showPrefix(path: string): Promise<IGitShowPrefixResult> {
     try {
       let response = await httpGitRequest('/git/show_prefix', 'POST', {
         current_path: path
@@ -250,7 +260,7 @@ export class Git {
   }
 
   /** Make request for git status of repository 'path' */
-  async status(path: string): Promise<GitStatusResult> {
+  async status(path: string): Promise<IGitStatusResult> {
     try {
       let response = await httpGitRequest('/git/status', 'POST', {
         current_path: path
@@ -266,7 +276,7 @@ export class Git {
   }
 
   /** Make request for git commit logs of repository 'path' */
-  async log(path: string): Promise<GitLogResult> {
+  async log(path: string): Promise<IGitLogResult> {
     try {
       let response = await httpGitRequest('/git/log', 'POST', {
         current_path: path
@@ -282,11 +292,12 @@ export class Git {
   }
 
   /** Make request for detailed git commit info of
-   * commit 'hash' in repository 'path' */
+   * commit 'hash' in repository 'path'
+   */
   async detailedLog(
     hash: string,
     path: string
-  ): Promise<SingleCommitFilePathInfo> {
+  ): Promise<ISingleCommitFilePathInfo> {
     try {
       let response = await httpGitRequest('/git/detailed_log', 'POST', {
         selected_hash: hash,
@@ -303,7 +314,7 @@ export class Git {
   }
 
   /** Make request for a list of all git branches in repository 'path' */
-  async branch(path: string): Promise<GitBranchResult> {
+  async branch(path: string): Promise<IGitBranchResult> {
     try {
       let response = await httpGitRequest('/git/branch', 'POST', {
         current_path: path
@@ -319,7 +330,8 @@ export class Git {
   }
 
   /** Make request to add one or all files into
-   * the staging area in repository 'path' */
+   * the staging area in repository 'path'
+   */
   async add(check: boolean, filename: string, path: string): Promise<Response> {
     return httpGitRequest('/git/add', 'POST', {
       add_all: check,
@@ -329,7 +341,8 @@ export class Git {
   }
 
   /** Make request to add all untracked files into
-   * the staging area in repository 'path' */
+   * the staging area in repository 'path'
+   */
   async addAllUntracked(path: string): Promise<Response> {
     try {
       let response = await httpGitRequest('/git/add_all_untracked', 'POST', {
@@ -349,21 +362,22 @@ export class Git {
    * create new branch if needed,
    * or discard all changes,
    * or discard a specific file change
-   * TODO: Refactor into seperate endpoints for each kind of checkout request */
+   * TODO: Refactor into seperate endpoints for each kind of checkout request
+   */
   async checkout(
-    checkout_branch: boolean,
-    new_check: boolean,
+    checkoutBranch: boolean,
+    newCheck: boolean,
     branchname: string,
-    checkout_all: boolean,
+    checkoutAll: boolean,
     filename: string,
     path: string
   ): Promise<Response> {
     try {
       let response = await httpGitRequest('/git/checkout', 'POST', {
-        checkout_branch: checkout_branch,
-        new_check: new_check,
+        checkout_branch: checkoutBranch,
+        new_check: newCheck,
         branchname: branchname,
-        checkout_all: checkout_all,
+        checkout_all: checkoutAll,
         filename: filename,
         top_repo_path: path
       });

--- a/src/gitClone.ts
+++ b/src/gitClone.ts
@@ -57,7 +57,7 @@ export class GitClone extends Widget {
     this.gitApi
       .allHistory(this.fileBrowser.model.path)
       .then(response => {
-        if (response.code == 0) {
+        if (response.code === 0) {
           this.enabledCloneButton.parent = null;
           this.fileBrowser.toolbar.addItem(
             'disabledCloneButton',
@@ -85,7 +85,7 @@ export class GitClone extends Widget {
     this.gitApi
       .clone(this.fileBrowser.model.path, cloneUrl)
       .then(response => {
-        if (response.code != 0) {
+        if (response.code !== 0) {
           this.showErrorDialog(response.message);
         }
       })
@@ -136,7 +136,7 @@ export class GitClone extends Widget {
     const result = await dialog.launch();
     dialog.dispose();
 
-    if (typeof result.value != 'undefined' && result.value) {
+    if (typeof result.value !== 'undefined' && result.value) {
       const cloneUrl: string = result.value;
       this.makeApiCall(cloneUrl);
     } else {

--- a/src/gitMenuCommands.ts
+++ b/src/gitMenuCommands.ts
@@ -67,7 +67,9 @@ export function addCommands(app: JupyterLab, services: ServiceManager) {
           app.shell.activateById(terminal.id);
           terminal.session.send({
             type: 'stdin',
-            content: ['cd "' + currentFileBrowserPath.split('"').join('\\"') + '"\n']
+            content: [
+              'cd "' + currentFileBrowserPath.split('"').join('\\"') + '"\n'
+            ]
           });
           return terminal;
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 export const EXTENSION_ID = 'jupyter.extensions.git_plugin';
 
+// tslint:disable-next-line: variable-name
 export const IGitExtension = new Token<IGitExtension>(EXTENSION_ID);
 
 /** Interface for extension class */

--- a/tests/test-components/HistorySideBar.spec.tsx
+++ b/tests/test-components/HistorySideBar.spec.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
-import { shallow } from "enzyme";
+import * as React from 'react';
+import { shallow } from 'enzyme';
 import {
   HistorySideBar,
   IHistorySideBarProps
-} from "../../src/components/HistorySideBar";
+} from '../../src/components/HistorySideBar';
 import 'jest';
 
-import { PastCommitNode } from "../../src/components/PastCommitNode";
+import { PastCommitNode } from '../../src/components/PastCommitNode';
 
-describe("HistorySideBar", () => {
+describe('HistorySideBar', () => {
   const props: IHistorySideBarProps = {
     pastCommits: [
       {
@@ -26,11 +26,11 @@ describe("HistorySideBar", () => {
     refresh: null,
     diff: null
   };
-  test("renders commit nodes when expanded", () => {
+  test('renders commit nodes when expanded', () => {
     const historySideBar = shallow(<HistorySideBar {...props} />);
     expect(historySideBar.find(PastCommitNode)).toHaveLength(1);
   });
-  test("does not render commit nodes when not expanded", () => {
+  test('does not render commit nodes when not expanded', () => {
     const historySideBar = shallow(
       <HistorySideBar {...props} isExpanded={false} />
     );

--- a/tests/test-components/PastCommitNode.spec.tsx
+++ b/tests/test-components/PastCommitNode.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { SinglePastCommitInfo } from '../../src/components/SinglePastCommitInfo';
 import { PastCommitNode } from '../../src/components/PastCommitNode';
-import { GitBranchResult } from '../../src/git';
+import { IGitBranchResult } from '../../src/git';
 import { collapseStyle } from '../../src/componentsStyle/PastCommitNodeStyle';
 import 'jest';
 
@@ -43,7 +43,7 @@ describe('PastCommitNode', () => {
       tag: 'v1.0.5-0-g2414721'
     }
   ];
-  const branches: GitBranchResult['branches'] = notMatchingBranches.concat(
+  const branches: IGitBranchResult['branches'] = notMatchingBranches.concat(
     matchingBranches
   );
   const props = {

--- a/tests/test-components/PastCommitNode.spec.tsx
+++ b/tests/test-components/PastCommitNode.spec.tsx
@@ -1,27 +1,27 @@
-import * as React from "react";
-import { shallow } from "enzyme";
-import { SinglePastCommitInfo } from "../../src/components/SinglePastCommitInfo";
-import { PastCommitNode } from "../../src/components/PastCommitNode";
-import { GitBranchResult } from "../../src/git";
-import {  collapseStyle} from "../../src/componentsStyle/PastCommitNodeStyle";
-import "jest";
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { SinglePastCommitInfo } from '../../src/components/SinglePastCommitInfo';
+import { PastCommitNode } from '../../src/components/PastCommitNode';
+import { GitBranchResult } from '../../src/git';
+import { collapseStyle } from '../../src/componentsStyle/PastCommitNodeStyle';
+import 'jest';
 
-describe("PastCommitNode", () => {
+describe('PastCommitNode', () => {
   const notMatchingBranches = [
     {
       is_current_branch: false,
       is_remote_branch: false,
-      name: "name1",
-      upstream: "upstream",
-      top_commit: "abcdefghijklmnopqrstuvwxyz01234567890123",
-      tag: "v1.0.4"
+      name: 'name1',
+      upstream: 'upstream',
+      top_commit: 'abcdefghijklmnopqrstuvwxyz01234567890123',
+      tag: 'v1.0.4'
     },
     {
       is_current_branch: false,
       is_remote_branch: true,
-      name: "name2",
-      upstream: "upstream",
-      top_commit: "abcdefghijklmnopqrstuvwxyz01234567890123",
+      name: 'name2',
+      upstream: 'upstream',
+      top_commit: 'abcdefghijklmnopqrstuvwxyz01234567890123',
       tag: null
     }
   ];
@@ -29,21 +29,21 @@ describe("PastCommitNode", () => {
     {
       is_current_branch: false,
       is_remote_branch: false,
-      name: "name3",
-      upstream: "upstream",
-      top_commit: "2414721b194453f058079d897d13c4e377f92dc6",
-      tag: "v1.0.4-14-g2414721"
+      name: 'name3',
+      upstream: 'upstream',
+      top_commit: '2414721b194453f058079d897d13c4e377f92dc6',
+      tag: 'v1.0.4-14-g2414721'
     },
     {
       is_current_branch: false,
       is_remote_branch: true,
-      name: "name4",
-      upstream: "upstream",
-      top_commit: "2414721b194453f058079d897d13c4e377f92dc6",
-      tag: "v1.0.5-0-g2414721"
+      name: 'name4',
+      upstream: 'upstream',
+      top_commit: '2414721b194453f058079d897d13c4e377f92dc6',
+      tag: 'v1.0.5-0-g2414721'
     }
   ];
-  const branches: GitBranchResult["branches"] = notMatchingBranches.concat(
+  const branches: GitBranchResult['branches'] = notMatchingBranches.concat(
     matchingBranches
   );
   const props = {
@@ -52,38 +52,38 @@ describe("PastCommitNode", () => {
     diff: null,
     refresh: null,
     pastCommit: {
-      commit: "2414721b194453f058079d897d13c4e377f92dc6",
-      author: "author",
-      date: "date",
-      commit_msg: "message",
-      pre_commit: "pre_commit"
+      commit: '2414721b194453f058079d897d13c4e377f92dc6',
+      author: 'author',
+      date: 'date',
+      commit_msg: 'message',
+      pre_commit: 'pre_commit'
     },
     branches: branches
   };
-  test("Includes commit info", () => {
+  test('Includes commit info', () => {
     const pastCommitNode = shallow(<PastCommitNode {...props} />);
     expect(pastCommitNode.text()).toMatch(props.pastCommit.author);
     expect(pastCommitNode.text()).toMatch(props.pastCommit.commit.slice(0, 7));
     expect(pastCommitNode.text()).toMatch(props.pastCommit.date);
     expect(pastCommitNode.text()).toMatch(props.pastCommit.commit_msg);
   });
-  test("Includes only relevent branch info", () => {
+  test('Includes only relevent branch info', () => {
     const pastCommitNode = shallow(<PastCommitNode {...props} />);
-    expect(pastCommitNode.text()).toMatch("name3");
-    expect(pastCommitNode.text()).toMatch("name4");
-    expect(pastCommitNode.text()).not.toMatch("name1");
-    expect(pastCommitNode.text()).not.toMatch("name2");
+    expect(pastCommitNode.text()).toMatch('name3');
+    expect(pastCommitNode.text()).toMatch('name4');
+    expect(pastCommitNode.text()).not.toMatch('name1');
+    expect(pastCommitNode.text()).not.toMatch('name2');
   });
-  test("Doesnt include details at first", () => {
+  test('Doesnt include details at first', () => {
     const pastCommitNode = shallow(<PastCommitNode {...props} />);
     expect(pastCommitNode.find(SinglePastCommitInfo)).toHaveLength(0);
   });
-  test("includes details after click", () => {
+  test('includes details after click', () => {
     const pastCommitNode = shallow(<PastCommitNode {...props} />);
     pastCommitNode.simulate('click');
     expect(pastCommitNode.find(SinglePastCommitInfo)).toHaveLength(1);
   });
-  test("hides details after collapse", () => {
+  test('hides details after collapse', () => {
     const pastCommitNode = shallow(<PastCommitNode {...props} />);
     pastCommitNode.simulate('click');
     pastCommitNode.find(`.${collapseStyle}`).simulate('click');

--- a/tests/test-components/PathHeader.spec.tsx
+++ b/tests/test-components/PathHeader.spec.tsx
@@ -1,19 +1,23 @@
-import * as React from "react";
-import {shallow} from "enzyme";
-import {IPathHeaderProps, PathHeader} from "../../src/components/PathHeader";
-import {gitPullStyle, gitPushStyle, repoRefreshStyle} from "../../src/componentsStyle/PathHeaderStyle";
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { IPathHeaderProps, PathHeader } from '../../src/components/PathHeader';
+import {
+  gitPullStyle,
+  gitPushStyle,
+  repoRefreshStyle
+} from '../../src/componentsStyle/PathHeaderStyle';
 import 'jest';
-import {Git} from '../../src/git';
+import { Git } from '../../src/git';
 
-describe('PathHeader', function () {
+describe('PathHeader', function() {
   const props: IPathHeaderProps = {
     currentFileBrowserPath: '/path/to/repo',
     topRepoPath: '/foo',
     refresh: null,
-    currentBranch: 'bar',
+    currentBranch: 'bar'
   };
 
-  it('should have repo and branch details', function () {
+  it('should have repo and branch details', function() {
     // When
     const node = shallow(<PathHeader {...props} />);
 
@@ -21,7 +25,7 @@ describe('PathHeader', function () {
     expect(node.text()).toEqual('repo / bar');
   });
 
-  it('should have all buttons', function () {
+  it('should have all buttons', function() {
     // When
     const node = shallow(<PathHeader {...props} />);
 
@@ -29,14 +33,17 @@ describe('PathHeader', function () {
     const buttons = node.find('button');
     expect(buttons).toHaveLength(3);
     expect(buttons.find(`.${gitPullStyle}`)).toHaveLength(1);
-    expect(buttons.find(`.${gitPullStyle}`).prop('title')).toEqual('Pull latest changes');
+    expect(buttons.find(`.${gitPullStyle}`).prop('title')).toEqual(
+      'Pull latest changes'
+    );
     expect(buttons.find(`.${gitPushStyle}`)).toHaveLength(1);
-    expect(buttons.find(`.${gitPushStyle}`).prop('title')).toEqual('Push committed changes');
+    expect(buttons.find(`.${gitPushStyle}`).prop('title')).toEqual(
+      'Push committed changes'
+    );
     expect(buttons.find(`.${repoRefreshStyle}`)).toHaveLength(1);
   });
 
-
-  it('should call API on button click', function () {
+  it('should call API on button click', function() {
     // Given
     const spyPull = jest.spyOn(Git.prototype, 'pull');
     const spyPush = jest.spyOn(Git.prototype, 'push');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "outDir": "lib",
     "lib": ["es5", "es2015.promise", "es2015.collection", "dom"],
     "types": [],
-    "jsx": "react"
+    "jsx": "react",
+    "plugins": [{ "name": "typescript-tslint-plugin" }]
   },
   "include": ["src/*"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -31,7 +31,6 @@
     "no-debugger": true,
     "no-default-export": false,
     "no-duplicate-variable": true,
-    "no-empty": true,
     "no-eval": true,
     "no-inferrable-types": false,
     "no-internal-module": true,

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,7 @@
   "rulesDirectory": ["tslint-plugin-prettier"],
   "extends": ["tslint-config-prettier"],
   "rules": {
-    "prettier": [true, { "singleQuote": true }],
+    "prettier": [true],
     "ban": [
       true,
       ["_", "forEach"],

--- a/tslint.json
+++ b/tslint.json
@@ -1,8 +1,8 @@
 {
   "rulesDirectory": ["tslint-plugin-prettier"],
+  "extends": ["tslint-config-prettier"],
   "rules": {
     "prettier": [true, { "singleQuote": true }],
-    "align": [true, "parameters", "statements"],
     "ban": [
       true,
       ["_", "forEach"],
@@ -13,16 +13,13 @@
     "class-name": true,
     "comment-format": [true, "check-space"],
     "curly": true,
-    "eofline": true,
     "forin": false,
-    "indent": [true, "spaces", 2],
     "interface-name": [true, "always-prefix"],
     "jsdoc-format": true,
     "label-position": true,
     "max-line-length": [false],
     "member-access": false,
     "member-ordering": [false],
-    "new-parens": true,
     "no-angle-bracket-type-assertion": true,
     "no-any": false,
     "no-arg": true,
@@ -45,24 +42,13 @@
     "no-shadowed-variable": false,
     "no-string-literal": false,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-use-before-declare": false,
     "no-var-keyword": true,
     "no-var-requires": true,
     "object-literal-sort-keys": false,
-    "one-line": [
-      true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-finally",
-      "check-whitespace"
-    ],
     "one-variable-per-declaration": [true, "ignore-for-loop"],
-    "quotemark": [true, "single", "avoid-escape"],
     "radix": true,
-    "semicolon": [true, "always", "ignore-bound-class-methods"],
     "switch-default": true,
     "trailing-comma": [
       false,
@@ -97,13 +83,6 @@
       "check-format",
       "allow-leading-underscore",
       "ban-keywords"
-    ],
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-operator",
-      "check-separator",
-      "check-type"
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,13 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/runtime@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  integrity sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@jupyterlab/application@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/application/-/application-0.19.1.tgz#2f976a2e140041543f1dcf14a52eb081f7729739"
@@ -420,6 +427,13 @@
     "@phosphor/signaling" "^1.2.2"
     "@phosphor/virtualdom" "^1.1.2"
 
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  dependencies:
+    any-observable "^0.3.0"
+
 "@types/cheerio@*":
   version "0.22.9"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.9.tgz#b5990152604c2ada749b7f88cab3476f21f39d7b"
@@ -547,6 +561,11 @@ ansi_up@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi_up/-/ansi_up-3.0.0.tgz#27f45d8f457d9ceff59e4ea03c8e6f13c1a303e8"
   integrity sha1-J/Rdj0V9nO/1nk6gPI5vE8GjA+g=
 
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
+  integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -609,7 +628,14 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
-array-uniq@^1.0.2:
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1, array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
@@ -972,6 +998,20 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
+
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
@@ -994,7 +1034,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -1009,6 +1049,15 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.3.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -1036,6 +1085,11 @@ ci-info@^1.5.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
   integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
 
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -1045,6 +1099,21 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+cli-cursor@^2.0.0, cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -1114,6 +1183,11 @@ commander@^2.12.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
+commander@^2.14.1, commander@^2.9.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
 commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
@@ -1168,12 +1242,33 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cosmiconfig@^5.0.2, cosmiconfig@^5.0.7:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
+  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.0"
+    parse-json "^4.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -1225,6 +1320,11 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.1.0"
     whatwg-url "^7.0.0"
 
+date-fns@^1.27.2:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1239,6 +1339,13 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1248,6 +1355,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1294,6 +1406,18 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+del@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+  integrity sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=
+  dependencies:
+    globby "^6.1.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    p-map "^1.1.1"
+    pify "^3.0.0"
+    rimraf "^2.2.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1388,12 +1512,24 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
   dependencies:
     iconv-lite "~0.4.13"
+
+end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
 
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
@@ -1448,7 +1584,7 @@ enzyme@3.7.0:
     rst-selector-parser "^2.2.3"
     string.prototype.trim "^1.1.2"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
@@ -1475,7 +1611,7 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -1539,6 +1675,19 @@ execa@^0.7.0:
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
@@ -1680,6 +1829,21 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -1714,6 +1878,11 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -1728,6 +1897,18 @@ find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
+fn-name@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
+  integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -1801,6 +1982,15 @@ function.prototype.name@^1.1.0:
     function-bind "^1.1.1"
     is-callable "^1.1.3"
 
+g-status@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/g-status/-/g-status-2.0.2.tgz#270fd32119e8fc9496f066fe5fe88e0a6bc78b97"
+  integrity sha512-kQoE9qH+T1AHKgSSD0Hkv98bobE90ILQcXAF4wvGgsr7uFqNvwmh8j+Lq3l0RVt3E3HjSbv2B9biEGcEtpHLCA==
+  dependencies:
+    arrify "^1.0.1"
+    matcher "^1.0.0"
+    simple-git "^1.85.0"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1820,10 +2010,27 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
+  integrity sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -1852,7 +2059,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -1868,6 +2075,17 @@ globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  integrity sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
@@ -2026,6 +2244,22 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.3.1.tgz#26823e399300388ca2afff11cfa8a86b0033fae0"
+  integrity sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==
+  dependencies:
+    cosmiconfig "^5.0.7"
+    execa "^1.0.0"
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    is-ci "^2.0.0"
+    pkg-dir "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^4.0.1"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -2047,6 +2281,14 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -2059,6 +2301,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -2138,6 +2385,13 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.5.0"
 
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -2175,6 +2429,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -2203,6 +2462,11 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
   integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
+
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
 is-finite@^1.0.0:
   version "1.0.2"
@@ -2235,6 +2499,13 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-glob@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-number-object@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
@@ -2259,6 +2530,37 @@ is-number@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+  dependencies:
+    symbol-observable "^1.1.0"
+
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+  integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -2276,12 +2578,22 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -2765,6 +3077,14 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
+js-yaml@^3.13.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.7.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -2814,6 +3134,11 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
   integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-parser@^1.0.0:
   version "1.1.5"
@@ -2925,6 +3250,81 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lint-staged@8.1.5:
+  version "8.1.5"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-8.1.5.tgz#372476fe1a58b8834eb562ed4c99126bd60bdd79"
+  integrity sha512-e5ZavfnSLcBJE1BTzRTqw6ly8OkqVyO3GL2M6teSmTBYQ/2BuueD5GIt2RPsP31u/vjKdexUyDCxSyK75q4BDA==
+  dependencies:
+    chalk "^2.3.1"
+    commander "^2.14.1"
+    cosmiconfig "^5.0.2"
+    debug "^3.1.0"
+    dedent "^0.7.0"
+    del "^3.0.0"
+    execa "^1.0.0"
+    find-parent-dir "^0.3.0"
+    g-status "^2.0.2"
+    is-glob "^4.0.0"
+    is-windows "^1.0.2"
+    listr "^0.14.2"
+    listr-update-renderer "^0.5.0"
+    lodash "^4.17.11"
+    log-symbols "^2.2.0"
+    micromatch "^3.1.8"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    path-is-inside "^1.0.2"
+    pify "^3.0.0"
+    please-upgrade-node "^3.0.2"
+    staged-git-files "1.1.2"
+    string-argv "^0.0.2"
+    stringify-object "^3.2.2"
+    yup "^0.26.10"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
+
+listr-update-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
+  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
+  integrity sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+  dependencies:
+    chalk "^2.4.1"
+    cli-cursor "^2.1.0"
+    date-fns "^1.27.2"
+    figures "^2.0.0"
+
+listr@^0.14.2:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
+  integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.5.0"
+    p-map "^2.0.0"
+    rxjs "^6.3.3"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2942,6 +3342,14 @@ locate-path@^2.0.0:
   integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
   dependencies:
     p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
     path-exists "^3.0.0"
 
 lodash.clonedeep@^4.5.0:
@@ -2989,10 +3397,33 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4:
+lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
+
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
+
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.4.0"
@@ -3038,6 +3469,13 @@ marked@~0.4.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
   integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
 
+matcher@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/matcher/-/matcher-1.1.1.tgz#51d8301e138f840982b338b116bb0c09af62c1c2"
+  integrity sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==
+  dependencies:
+    escape-string-regexp "^1.0.4"
+
 math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
@@ -3081,7 +3519,7 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.4:
+micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -3255,6 +3693,11 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -3340,12 +3783,28 @@ npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
+npm-path@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
+  integrity sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==
+  dependencies:
+    which "^1.2.10"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  integrity sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -3379,7 +3838,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -3468,12 +3927,19 @@ object.values@^1.0.4:
     function-bind "^1.1.0"
     has "^1.0.1"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -3534,6 +4000,13 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -3541,10 +4014,32 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
+
+p-map@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -3562,6 +4057,14 @@ parse-json@^2.2.0:
   integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
   dependencies:
     error-ex "^1.2.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parse5@4.0.0:
   version "4.0.0"
@@ -3597,7 +4100,12 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-key@^2.0.0:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
@@ -3631,6 +4139,11 @@ pify@^2.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -3649,6 +4162,20 @@ pkg-dir@^2.0.0:
   integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   dependencies:
     find-up "^2.1.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
+
+please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
+  dependencies:
+    semver-compare "^1.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -3679,10 +4206,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
-  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+prettier@1.16.4:
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
 pretty-format@^23.6.0:
   version "23.6.0"
@@ -3730,6 +4257,11 @@ prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+property-expr@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
+  integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -3739,6 +4271,14 @@ psl@^1.1.24:
   version "1.1.29"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
   integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -3858,6 +4398,15 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -3891,6 +4440,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regex-cache@^0.4.2:
   version "0.4.4"
@@ -4015,10 +4569,25 @@ resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+rimraf@^2.2.8:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
@@ -4039,6 +4608,18 @@ rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
   integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
+
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
+rxjs@^6.3.3:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -4102,6 +4683,11 @@ scheduler@^0.11.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
@@ -4159,6 +4745,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+simple-git@^1.85.0:
+  version "1.110.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.110.0.tgz#54eb179089d055a7783d32399246cebc9d9933e9"
+  integrity sha512-UYY0rQkknk0P5eb+KW+03F4TevZ9ou0H+LoGaj7iiVgpnZH4wdj/HTViy/1tNNkmIPcmtxuBqXWiYt2YwlRKOQ==
+  dependencies:
+    debug "^4.0.1"
+
 sisteransi@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
@@ -4168,6 +4761,16 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4306,6 +4909,11 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
   integrity sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=
 
+staged-git-files@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.2.tgz#4326d33886dc9ecfa29a6193bf511ba90a46454b"
+  integrity sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -4318,6 +4926,11 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+string-argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
+  integrity sha1-2sMECGkMIfPDYwo/86BYd73L1zY=
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -4359,6 +4972,15 @@ string_decoder@^1.1.1, string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-object@^3.2.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -4415,10 +5037,20 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   dependencies:
     has-flag "^3.0.0"
 
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
+
+synchronous-promise@^2.0.5:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.7.tgz#3574b3d2fae86b145356a4b89103e1577f646fe3"
+  integrity sha512-16GbgwTmFMYFyQMLvtQjvNWh30dsFe1cAW5Fg1wm5+dg84L9Pe36mftsIRU95/W2YsISxsz/xq4VB23sqpgb/A==
 
 tar@^4:
   version "4.4.6"
@@ -4484,6 +5116,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+
 tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
@@ -4518,10 +5155,15 @@ ts-jest@^23.10.4:
     semver "^5.5"
     yargs-parser "10.x"
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslint-config-prettier@1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
+  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
 
 tslint-plugin-prettier@^2.0.0:
   version "2.0.0"
@@ -4744,7 +5386,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.12, which@^1.2.9, which@^1.3.0:
+which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -4775,6 +5417,14 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
 
 wrappy@1:
   version "1.0.2"
@@ -4858,3 +5508,15 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yup@^0.26.10:
+  version "0.26.10"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.26.10.tgz#3545839663289038faf25facfc07e11fd67c0cb1"
+  integrity sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==
+  dependencies:
+    "@babel/runtime" "7.0.0"
+    fn-name "~2.0.1"
+    lodash "^4.17.10"
+    property-expr "^1.5.0"
+    synchronous-promise "^2.0.5"
+    toposort "^2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2005,7 +2005,7 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-get-caller-file@^1.0.1:
+get-caller-file@^1.0.1, get-caller-file@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
@@ -3606,6 +3606,14 @@ mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mock-require@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-3.0.3.tgz#ccd544d9eae81dd576b3f219f69ec867318a1946"
+  integrity sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==
+  dependencies:
+    get-caller-file "^1.0.2"
+    normalize-path "^2.1.1"
 
 moment@~2.21.0:
   version "2.21.0"
@@ -5217,6 +5225,15 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+typescript-tslint-plugin@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/typescript-tslint-plugin/-/typescript-tslint-plugin-0.3.1.tgz#d86ae0342c9e8f9ecfcbcc47f7a7c2b5ab0e86f9"
+  integrity sha512-h8HEPBm36UEs901ld1x6m5eY/UFb4mF+A0nvERr4BWMww5wnV5nfcm9ZFt18foYL0GQ5NVMt1Tb3466WUU8dRQ==
+  dependencies:
+    minimatch "^3.0.4"
+    mock-require "^3.0.2"
+    vscode-languageserver "^5.1.0"
+
 typescript@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.2.tgz#c03a5d16f30bb60ad8bb6fe8e7cb212eedeec950"
@@ -5318,6 +5335,37 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vscode-jsonrpc@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
+  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
+
+vscode-languageserver-protocol@3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
+  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
+  dependencies:
+    vscode-jsonrpc "^4.0.0"
+    vscode-languageserver-types "3.14.0"
+
+vscode-languageserver-types@3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
+  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
+
+vscode-languageserver@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz#0d2feddd33f92aadf5da32450df498d52f6f14eb"
+  integrity sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==
+  dependencies:
+    vscode-languageserver-protocol "3.14.1"
+    vscode-uri "^1.0.6"
+
+vscode-uri@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.6.tgz#6b8f141b0bbc44ad7b07e94f82f168ac7608ad4d"
+  integrity sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
* Make tslint rules compatible with prettier
* run linting in CI
* run linting on commit on touched files
* integrate tslint into typescript compilation pipeline so that errors appear in vscode (after changing typescript interpreter to use workspace one)
* fix all other linting errors manually