### PR TITLE
Use the full path when opening the terminal from the Git menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,6 @@ node_modules/
 
 #editors
 .vscode/
+.idea/
 
 package-lock.json

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,31 +1,21 @@
-import { addCommands, CommandIDs } from './gitMenuCommands';
-
-import { PathExt } from '@jupyterlab/coreutils';
-
-import { GitWidget } from './components/GitWidget';
-
 import {
   ILayoutRestorer,
   JupyterLab,
   JupyterLabPlugin
 } from '@jupyterlab/application';
-
+import { PathExt } from '@jupyterlab/coreutils';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
-
 import { IMainMenu } from '@jupyterlab/mainmenu';
-
-import { Menu } from '@phosphor/widgets';
-
-import { Token } from '@phosphor/coreutils';
-
-import { gitTabStyle } from './componentsStyle/GitWidgetStyle';
-
-import { IDiffCallback } from './git';
-export { IDiffCallback } from './git';
-
-import '../style/variables.css';
-import { GitClone } from './gitClone';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { Token } from '@phosphor/coreutils';
+import '../style/variables.css';
+import { GitWidget } from './components/GitWidget';
+import { gitTabStyle } from './componentsStyle/GitWidgetStyle';
+import { IDiffCallback } from './git';
+import { GitClone } from './gitClone';
+import { addCommands, addMenuItems } from './gitMenuCommands';
+
+export { IDiffCallback } from './git';
 
 export const EXTENSION_ID = 'jupyter.extensions.git_plugin';
 
@@ -119,26 +109,11 @@ function activate(
 ): IGitExtension {
   const { commands } = app;
   let gitExtension = new GitExtension(app, restorer, factory);
-  const category = 'Git';
 
   // Rank has been chosen somewhat arbitrarily to give priority to the running
   // sessions widget in the sidebar.
   addCommands(app, app.serviceManager);
-  let menu = new Menu({ commands });
-  let tutorial = new Menu({ commands });
-  tutorial.title.label = ' Tutorial ';
-  menu.title.label = category;
-  [CommandIDs.gitUI, CommandIDs.gitTerminal, CommandIDs.gitInit].forEach(
-    command => {
-      menu.addItem({ command });
-    }
-  );
-
-  [CommandIDs.setupRemotes, CommandIDs.googleLink].forEach(command => {
-    tutorial.addItem({ command });
-  });
-  menu.addItem({ type: 'submenu', submenu: tutorial });
-  mainMenu.addMenu(menu, { rank: 60 });
+  addMenuItems(commands, mainMenu);
 
   return gitExtension;
 }


### PR DESCRIPTION
**Description**

Currently, the menu item opens a terminal based on the path of the current working directory relative to the server root. In some cases, the terminal starts from a directory other than the server root so this "cd $PATH" fails.

To avoid this, just construct the full path and "cd $SERVER_ROOT/$PATH" while executing the command

Other changes
* Moved the addMenuItems code into the gitMenuCommands file
* Removed unused command.

Addresses #346 