### PR TITLE
Minimize git access upon changed path

### DIFF
--- a/src/gitClone.ts
+++ b/src/gitClone.ts
@@ -55,7 +55,7 @@ export class GitClone extends Widget {
    */
   disableIfInGitDirectory(): void {
     this.gitApi
-      .allHistory(this.fileBrowser.model.path)
+      .showTopLevel(this.fileBrowser.model.path)
       .then(response => {
         if (response.code === 0) {
           this.enabledCloneButton.parent = null;


### PR DESCRIPTION
Upon path change, disableIfInGitDirectory unnecessarily invokes all_history which ends up running 4 git commands instead of 1, just to check if the new path is a git repo.

This results in performance impact in some configurations (as "git status" goes over the whole file sub tree).

all_history verifies first show_top_level's result and only then proceeds to the other commands, so it should be enough in this case.

Addresses #349 