### PR TITLE
Fix push/pull to not use shell=True

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -456,7 +456,6 @@ class Git:
         env['GIT_TERMINAL_PROMPT'] = '0'
         p = subprocess.Popen(
             ['git', 'pull', '--no-commit'],
-            shell=True,
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, curr_fb_path),
@@ -481,7 +480,6 @@ class Git:
         env['GIT_TERMINAL_PROMPT'] = '0'
         p = subprocess.Popen(
             ['git', 'push', remote, branch],
-            shell=True,
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, curr_fb_path),

--- a/tests/unit/test_pushpull.py
+++ b/tests/unit/test_pushpull.py
@@ -27,7 +27,6 @@ def test_git_pull_fail(mock_subproc_popen):
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path',
-            shell=True,
             env={'TEST': 'test', 'GIT_TERMINAL_PROMPT': '0'},
         ),
         call().communicate()
@@ -57,7 +56,6 @@ def test_git_pull_success(mock_subproc_popen):
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path',
-            shell=True,
             env={'TEST': 'test', 'GIT_TERMINAL_PROMPT': '0'},
         ),
         call().communicate()
@@ -87,7 +85,6 @@ def test_git_push_fail(mock_subproc_popen):
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path',
-            shell=True,
             env={'TEST': 'test', 'GIT_TERMINAL_PROMPT': '0'},
         ),
         call().communicate()
@@ -117,7 +114,6 @@ def test_git_push_success(mock_subproc_popen):
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path',
-            shell=True,
             env={'TEST': 'test', 'GIT_TERMINAL_PROMPT': '0'},
         ),
         call().communicate()


### PR DESCRIPTION
A previous commit, https://github.com/jupyterlab/jupyterlab-git/pull/344, started passing env variables as a parameter.

This broke the behaviour of "shell=True" which expects a string and all the push/pull commands would fail.

### Testing

* Manually tested via JupyterLab as well as the REST API to check that push/pull is working successfully 