### PR TITLE
Server API to list changed files in Git

### DIFF
--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -413,6 +413,15 @@ class GitAddAllUntrackedHandler(GitHandler):
         print(my_output)
         self.finish(my_output)
 
+class GitChangedFilesHandler(GitHandler):
+
+    def post(self):
+        self.finish(
+            json.dumps(
+                self.git.changed_files(**self.get_json_body())
+            )
+        )
+
 
 def setup_handlers(web_app):
     """
@@ -440,7 +449,8 @@ def setup_handlers(web_app):
         ("/git/all_history", GitAllHistoryHandler),
         ("/git/add_all_untracked", GitAddAllUntrackedHandler),
         ("/git/clone", GitCloneHandler),
-        ("/git/upstream", GitUpstreamHandler)
+        ("/git/upstream", GitUpstreamHandler),
+        ("/git/changed_files", GitChangedFilesHandler)
     ]
 
     # add the baseurl to our paths

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -1,0 +1,98 @@
+from subprocess import PIPE, STDOUT, CalledProcessError
+
+from mock import Mock, call, patch
+import pytest
+from tornado.web import HTTPError
+
+
+from jupyterlab_git.git import Git
+
+
+def test_changed_files_invalid_input():
+    with pytest.raises(HTTPError):
+        actual_response = Git(root_dir="/bin").changed_files(
+            base="64950a634cd11d1a01ddfedaeffed67b531cb11e"
+        )
+
+
+@patch("subprocess.check_output")
+def test_changed_files_single_commit(mock_call):
+    # Given
+    mock_call.return_value = b"file1.ipynb\nfile2.py"
+
+    # When
+    actual_response = Git(root_dir="/bin").changed_files(
+        single_commit="64950a634cd11d1a01ddfedaeffed67b531cb11e"
+    )
+
+    # Then
+    mock_call.assert_called_with(
+        ["git", "diff", "64950a634cd11d1a01ddfedaeffed67b531cb11e^!", "--name-only"],
+        cwd="/bin",
+        stderr=STDOUT,
+    )
+    assert {"code": 0, "files": ["file1.ipynb", "file2.py"]} == actual_response
+
+
+@patch("subprocess.check_output")
+def test_changed_files_working_tree(mock_call):
+    # Given
+    mock_call.return_value = b"file1.ipynb\nfile2.py"
+
+    # When
+    actual_response = Git(root_dir="/bin").changed_files(base="WORKING", remote="HEAD")
+
+    # Then
+    mock_call.assert_called_with(
+        ["git", "diff", "HEAD", "--name-only"], cwd="/bin", stderr=STDOUT
+    )
+    assert {"code": 0, "files": ["file1.ipynb", "file2.py"]} == actual_response
+
+
+@patch("subprocess.check_output")
+def test_changed_files_index(mock_call):
+    # Given
+    mock_call.return_value = b"file1.ipynb\nfile2.py"
+
+    # When
+    actual_response = Git(root_dir="/bin").changed_files(base="INDEX", remote="HEAD")
+
+    # Then
+    mock_call.assert_called_with(
+        ["git", "diff", "--staged", "HEAD", "--name-only"], cwd="/bin", stderr=STDOUT
+    )
+    assert {"code": 0, "files": ["file1.ipynb", "file2.py"]} == actual_response
+
+
+@patch("subprocess.check_output")
+def test_changed_files_two_commits(mock_call):
+    # Given
+    mock_call.return_value = b"file1.ipynb\nfile2.py"
+
+    # When
+    actual_response = Git(root_dir="/bin").changed_files(
+        base="HEAD", remote="origin/HEAD"
+    )
+
+    # Then
+    mock_call.assert_called_with(
+        ["git", "diff", "HEAD", "origin/HEAD", "--name-only"], cwd="/bin", stderr=STDOUT
+    )
+    assert {"code": 0, "files": ["file1.ipynb", "file2.py"]} == actual_response
+
+
+@patch("subprocess.check_output")
+def test_changed_files_git_diff_error(mock_call):
+    # Given
+    mock_call.side_effect = CalledProcessError(128, "cmd", b"error message")
+
+    # When
+    actual_response = Git(root_dir="/bin").changed_files(
+        base="HEAD", remote="origin/HEAD"
+    )
+
+    # Then
+    mock_call.assert_called_with(
+        ["git", "diff", "HEAD", "origin/HEAD", "--name-only"], cwd="/bin", stderr=STDOUT
+    )
+    assert {"code": 128, "message": "error message"} == actual_response


### PR DESCRIPTION
This change adds a endpoint to the server to list the files changed in the working tree, staging area, between two commits, or in a single commit.

This will be used by the "DiffComponent" to call the sub-components based on the file extension, i.e, all ipynb files will be delegated to the NBDiffComponent and all other files will be delegated to the PlainTextDiffComponent.