### PR TITLE
Identity feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ cache:
   pip: true
   directories:
     - /home/travis/.yarn-cache/
-install: pip install pytest jupyterlab
+install: pip install pytest "jupyterlab>=1.0.3"
 script:
   - pytest tests/unit
   - yarn
   - yarn build
   - yarn test
   - pip install .
+  - jupyter serverextension enable --py jupyterlab_git
   - jupyter labextension install .
   - python -m jupyterlab.browser_check
   - yarn run lint

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -18,6 +18,44 @@ class Git:
         super(Git, self).__init__(*args, **kwargs)
         self.root_dir = os.path.realpath(os.path.expanduser(root_dir))
 
+    def config(self, **kwargs):
+        """Get or set Git options.
+        
+        If no kwargs, all options are returned. Otherwise kwargs are set.
+        """
+        response = {"code": 1}
+
+        if len(kwargs):
+            output = []
+            for k, v in kwargs.items():
+                cmd = ["git", "config", "--global", "--add", k, v]
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                out, err = p.communicate()
+                output.append(out.decode("utf-8").strip())
+                response["code"] = p.returncode
+                if p.returncode != 0:
+                    response["command"] = " ".join(cmd)
+                    response["message"] = err.decode("utf-8").strip()
+                    return response
+
+            response["message"] = "\n".join(output).strip()
+        else:
+            cmd = ["git", "config", "--global", "--list"]
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            output, error = p.communicate()
+
+            response = {"code": p.returncode}
+
+            if p.returncode != 0:
+                response["command"] = " ".join(cmd)
+                response["message"] = error.decode("utf-8").strip()
+            else:
+                raw = output.decode("utf-8").strip()
+                response["options"] = dict(
+                    [l.split("=", maxsplit=1) for l in raw.split("\n")]
+                )
+
+        return response
 
     def changed_files(self, base=None, remote=None, single_commit=None):
         """Gets the list of changed files between two Git refs, or the files changed in a single commit
@@ -75,9 +113,9 @@ class Git:
         :return: response with status code and error message.
         """
         env = os.environ.copy()
-        env['GIT_TERMINAL_PROMPT'] = '0'
+        env["GIT_TERMINAL_PROMPT"] = "0"
         p = subprocess.Popen(
-            ['git', 'clone', unquote(repo_url)],
+            ["git", "clone", unquote(repo_url)],
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, current_path),
@@ -85,12 +123,10 @@ class Git:
         )
         _, error = p.communicate()
 
-        response = {
-            'code': p.returncode
-        }
+        response = {"code": p.returncode}
 
         if p.returncode != 0:
-            response['message'] = error.decode('utf-8').strip()
+            response["message"] = error.decode("utf-8").strip()
 
         return response
 
@@ -265,7 +301,7 @@ class Git:
         Execute 'git show-ref' command & return the result.
         """
         p = subprocess.Popen(
-            ['git', 'show-ref'],
+            ["git", "show-ref"],
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, current_path),
@@ -275,7 +311,7 @@ class Git:
             results = []
             try:
                 current_branch = self.get_current_branch(current_path)
-                for line in output.decode('utf-8').splitlines():
+                for line in output.decode("utf-8").splitlines():
                     # The format for git show-ref is '<SHA-1 ID> <space> <reference name>'
                     # For this method we are only interested in reference name.
                     # Reference : https://git-scm.com/docs/git-show-ref#_output
@@ -283,46 +319,54 @@ class Git:
                     reference_name = line.strip().split()[1].strip()
                     if self._is_branch(reference_name):
                         branch_name = self._get_branch_name(reference_name)
-                        is_current_branch = self._is_current_branch(branch_name, current_branch)
+                        is_current_branch = self._is_current_branch(
+                            branch_name, current_branch
+                        )
                         is_remote_branch = self._is_remote_branch(reference_name)
                         upstream_branch_name = None
                         if not is_remote_branch:
-                            upstream_branch_name = self.get_upstream_branch(current_path, branch_name)
+                            upstream_branch_name = self.get_upstream_branch(
+                                current_path, branch_name
+                            )
                         tag = self._get_tag(current_path, commit_sha)
-                        results.append({
-                            'is_current_branch': is_current_branch,
-                            'is_remote_branch': is_remote_branch,
-                            'name': branch_name,
-                            'upstream': upstream_branch_name,
-                            'top_commit': commit_sha,
-                            'tag': tag,
-                        })
-                
-                # Remote branch is seleted use 'git branch -a' as fallback machanism 
+                        results.append(
+                            {
+                                "is_current_branch": is_current_branch,
+                                "is_remote_branch": is_remote_branch,
+                                "name": branch_name,
+                                "upstream": upstream_branch_name,
+                                "top_commit": commit_sha,
+                                "tag": tag,
+                            }
+                        )
+
+                # Remote branch is seleted use 'git branch -a' as fallback machanism
                 # to get add detached head on remote branch to preserve older functionality
-                # TODO : Revisit this to checkout new local branch with same name as remote 
+                # TODO : Revisit this to checkout new local branch with same name as remote
                 # when the remote branch is seleted, VS Code git does the same thing.
-                if current_branch == 'HEAD':
-                    results.append({
-                        'is_current_branch': True,
-                        'is_remote_branch': False,
-                        'name': self._get_detached_head_name(current_path),
-                        'upstream': None,
-                        'top_commit': None,
-                        'tag': None,
-                    })
-                return {'code': p.returncode, 'branches': results}
+                if current_branch == "HEAD":
+                    results.append(
+                        {
+                            "is_current_branch": True,
+                            "is_remote_branch": False,
+                            "name": self._get_detached_head_name(current_path),
+                            "upstream": None,
+                            "top_commit": None,
+                            "tag": None,
+                        }
+                    )
+                return {"code": p.returncode, "branches": results}
             except Exception as downstream_error:
                 return {
-                    'code': p.returncode,
-                    'command': 'git show-ref',
-                    'message': str(downstream_error),
+                    "code": p.returncode,
+                    "command": "git show-ref",
+                    "message": str(downstream_error),
                 }
         else:
             return {
-                'code': p.returncode,
-                'command': 'git show-ref',
-                'message': error.decode('utf-8'),
+                "code": p.returncode,
+                "command": "git show-ref",
+                "message": error.decode("utf-8"),
             }
 
     def show_top_level(self, current_path):
@@ -377,16 +421,14 @@ class Git:
         """
         Execute git add<filename> command & return the result.
         """
-        my_output = subprocess.check_output(
-            ["git", "add", filename], cwd=top_repo_path)
+        my_output = subprocess.check_output(["git", "add", filename], cwd=top_repo_path)
         return my_output
 
     def add_all(self, top_repo_path):
         """
         Execute git add all command & return the result.
         """
-        my_output = subprocess.check_output(
-            ["git", "add", "-A"], cwd=top_repo_path)
+        my_output = subprocess.check_output(["git", "add", "-A"], cwd=top_repo_path)
         return my_output
 
     def add_all_untracked(self, top_repo_path):
@@ -410,8 +452,7 @@ class Git:
         """
         Execute git reset command & return the result.
         """
-        my_output = subprocess.check_output(
-            ["git", "reset"], cwd=top_repo_path)
+        my_output = subprocess.check_output(["git", "reset"], cwd=top_repo_path)
         return my_output
 
     def delete_commit(self, commit_id, top_repo_path):
@@ -419,7 +460,8 @@ class Git:
         Delete a specified commit from the repository.
         """
         my_output = subprocess.check_output(
-            ["git", "revert", "--no-commit", commit_id], cwd=top_repo_path)
+            ["git", "revert", "--no-commit", commit_id], cwd=top_repo_path
+        )
         return my_output
 
     def reset_to_commit(self, commit_id, top_repo_path):
@@ -427,7 +469,8 @@ class Git:
         Reset the current branch to a specific past commit.
         """
         my_output = subprocess.check_output(
-            ["git", "reset", "--hard", commit_id], cwd=top_repo_path)
+            ["git", "reset", "--hard", commit_id], cwd=top_repo_path
+        )
         return my_output
 
     def checkout_new_branch(self, branchname, current_path):
@@ -503,9 +546,9 @@ class Git:
         for auth.
         """
         env = os.environ.copy()
-        env['GIT_TERMINAL_PROMPT'] = '0'
+        env["GIT_TERMINAL_PROMPT"] = "0"
         p = subprocess.Popen(
-            ['git', 'pull', '--no-commit'],
+            ["git", "pull", "--no-commit"],
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, curr_fb_path),
@@ -513,12 +556,10 @@ class Git:
         )
         _, error = p.communicate()
 
-        response = {
-            'code': p.returncode
-        }
+        response = {"code": p.returncode}
 
         if p.returncode != 0:
-            response['message'] = error.decode('utf-8').strip()
+            response["message"] = error.decode("utf-8").strip()
 
         return response
 
@@ -527,9 +568,9 @@ class Git:
         Execute `git push $UPSTREAM $BRANCH`. The choice of upstream and branch is up to the caller.
         """
         env = os.environ.copy()
-        env['GIT_TERMINAL_PROMPT'] = '0'
+        env["GIT_TERMINAL_PROMPT"] = "0"
         p = subprocess.Popen(
-            ['git', 'push', remote, branch],
+            ["git", "push", remote, branch],
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, curr_fb_path),
@@ -537,12 +578,10 @@ class Git:
         )
         _, error = p.communicate()
 
-        response = {
-            'code': p.returncode
-        }
+        response = {"code": p.returncode}
 
         if p.returncode != 0:
-            response['message'] = error.decode('utf-8').strip()
+            response["message"] = error.decode("utf-8").strip()
 
         return response
 
@@ -558,7 +597,9 @@ class Git:
     def _is_branch(self, reference_name):
         """Check if the given reference is a branch
         """
-        return reference_name.startswith('refs/heads/') or reference_name.startswith('refs/remotes/')
+        return reference_name.startswith("refs/heads/") or reference_name.startswith(
+            "refs/remotes/"
+        )
 
     def _is_current_branch(self, branch_name, current_branch_name):
         """Check if given branch is current branch
@@ -569,24 +610,23 @@ class Git:
         """Check if given branch is remote branch by comparing with 'remotes/',
         TODO : Consider a better way to check remote branch
         """
-        return branch_reference.startswith('refs/remotes/')
+        return branch_reference.startswith("refs/remotes/")
 
     def _get_branch_name(self, branch_reference):
         """Get branch name for given branch
         """
-        if branch_reference.startswith('refs/heads/'):
-            return branch_reference.split('refs/heads/')[1]
-        if branch_reference.startswith('refs/remotes/'):
-            return branch_reference.split('refs/remotes/')[1]
+        if branch_reference.startswith("refs/heads/"):
+            return branch_reference.split("refs/heads/")[1]
+        if branch_reference.startswith("refs/remotes/"):
+            return branch_reference.split("refs/remotes/")[1]
 
-        raise ValueError(
-            'Reference [{}] is not a valid branch.', branch_reference)
+        raise ValueError("Reference [{}] is not a valid branch.", branch_reference)
 
     def get_current_branch(self, current_path):
         """Execute 'git rev-parse --abbrev-ref HEAD' to
         check if given branch is current branch
         """
-        command = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
+        command = ["git", "rev-parse", "--abbrev-ref", "HEAD"]
         p = subprocess.Popen(
             command,
             stdout=PIPE,
@@ -595,17 +635,18 @@ class Git:
         )
         output, error = p.communicate()
         if p.returncode == 0:
-            return output.decode('utf-8').strip()
+            return output.decode("utf-8").strip()
         else:
-            raise Exception('Error [{}] occurred while executing [{}] command to get current branch.'.format(
-                error.decode('utf-8'),
-                ' '.join(command)
-            ))
-    
+            raise Exception(
+                "Error [{}] occurred while executing [{}] command to get current branch.".format(
+                    error.decode("utf-8"), " ".join(command)
+                )
+            )
+
     def _get_detached_head_name(self, current_path):
         """Execute 'git branch -a' to get current branch details in case of detached HEAD
         """
-        command = ['git', 'branch', '-a']
+        command = ["git", "branch", "-a"]
         p = subprocess.Popen(
             command,
             stdout=PIPE,
@@ -614,22 +655,28 @@ class Git:
         )
         output, error = p.communicate()
         if p.returncode == 0:
-            for branch in output.decode('utf-8').splitlines():
+            for branch in output.decode("utf-8").splitlines():
                 branch = branch.strip()
-                if branch.startswith('*'):
-                    return branch.lstrip('* ')
+                if branch.startswith("*"):
+                    return branch.lstrip("* ")
         else:
-            raise Exception('Error [{}] occurred while executing [{}] command to get detached HEAD name.'.format(
-                error.decode('utf-8'),
-                ' '.join(command)
-            ))
+            raise Exception(
+                "Error [{}] occurred while executing [{}] command to get detached HEAD name.".format(
+                    error.decode("utf-8"), " ".join(command)
+                )
+            )
 
     def get_upstream_branch(self, current_path, branch_name):
         """Execute 'git rev-parse --abbrev-ref branch_name@{upstream}' to get
         upstream branch name tracked by given local branch.
         Reference : https://git-scm.com/docs/git-rev-parse#git-rev-parse-emltbranchnamegtupstreamemegemmasterupstreamememuem
         """
-        command = ['git', 'rev-parse', '--abbrev-ref', '{}@{{upstream}}'.format(branch_name)]
+        command = [
+            "git",
+            "rev-parse",
+            "--abbrev-ref",
+            "{}@{{upstream}}".format(branch_name),
+        ]
         p = subprocess.Popen(
             command,
             stdout=PIPE,
@@ -638,21 +685,22 @@ class Git:
         )
         output, error = p.communicate()
         if p.returncode == 0:
-            return output.decode('utf-8').strip()
-        elif 'fatal: no upstream configured for branch' in error.decode('utf-8'):
+            return output.decode("utf-8").strip()
+        elif "fatal: no upstream configured for branch" in error.decode("utf-8"):
             return None
         else:
-            raise Exception('Error [{}] occurred while executing [{}] command to get upstream branch.'.format(
-                error.decode('utf-8'),
-                ' '.join(command)
-            ))
-    
+            raise Exception(
+                "Error [{}] occurred while executing [{}] command to get upstream branch.".format(
+                    error.decode("utf-8"), " ".join(command)
+                )
+            )
+
     def _get_tag(self, current_path, commit_sha):
         """Execute 'git describe commit_sha' to get
         nearest tag associated with lastest commit in branch.
         Reference : https://git-scm.com/docs/git-describe#git-describe-ltcommit-ishgt82308203
         """
-        command = ['git', 'describe', '--tags', commit_sha]
+        command = ["git", "describe", "--tags", commit_sha]
         p = subprocess.Popen(
             command,
             stdout=PIPE,
@@ -661,13 +709,17 @@ class Git:
         )
         output, error = p.communicate()
         if p.returncode == 0:
-            return output.decode('utf-8').strip()
-        elif "fatal: No tags can describe '{}'.".format(commit_sha) in error.decode('utf-8'):
+            return output.decode("utf-8").strip()
+        elif "fatal: No tags can describe '{}'.".format(commit_sha) in error.decode(
+            "utf-8"
+        ):
             return None
-        elif "fatal: No names found" in error.decode('utf-8'):
+        elif "fatal: No names found" in error.decode("utf-8"):
             return None
         else:
-            raise Exception('Error [{}] occurred while executing [{}] command to get nearest tag associated with branch.'.format(
-                error.decode('utf-8'),
-                ' '.join(command)
-            ))
+            raise Exception(
+                "Error [{}] occurred while executing [{}] command to get nearest tag associated with branch.".format(
+                    error.decode("utf-8"), " ".join(command)
+                )
+            )
+

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -427,21 +427,15 @@ class GitConfigHandler(GitHandler):
     Handler for 'git config' commands
     """
 
-    def get(self):
-        """
-        GET all global configuration options
-        """
-        response = self.git.config()
-        if response["code"] != 0:
-            self.set_status(500)
-        self.finish(json.dumps(response))
-
     def post(self):
         """
-        POST add global configuration options
+        POST get (if no options are passed) or set configuration options
         """
-        data = self.get_json_body()["options"]
-        response = self.git.config(**data)
+        data = self.get_json_body()
+        top_repo_path = data["top_repo_path"]
+        options = data.get("options", {})
+        response = self.git.config(top_repo_path, **options)
+
         if response["code"] != 0:
             self.set_status(500)
         else:

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -3,7 +3,6 @@ Module with all the individual handlers, which execute git commands and return t
 """
 import json
 
-
 from notebook.utils import url_path_join as ujoin
 from notebook.base.handlers import APIHandler
 
@@ -29,8 +28,8 @@ class GitCloneHandler(GitHandler):
               'repo_url': 'https://github.com/path/to/myrepo'
             }
         """
-        data = json.loads(self.request.body.decode('utf-8'))
-        response = self.git.clone(data['current_path'], data['clone_url'])
+        data = json.loads(self.request.body.decode("utf-8"))
+        response = self.git.clone(data["current_path"], data["clone_url"])
         self.finish(json.dumps(response))
 
 
@@ -290,9 +289,7 @@ class GitCheckoutHandler(GitHandler):
                 )
             else:
                 print("switch to an old branch")
-                my_output = self.git.checkout_branch(
-                    data["branchname"], top_repo_path
-                )
+                my_output = self.git.checkout_branch(data["branchname"], top_repo_path)
         elif data["checkout_all"]:
             my_output = self.git.checkout_all(top_repo_path)
         else:
@@ -327,12 +324,10 @@ class GitUpstreamHandler(GitHandler):
               'current_path': 'current_file_browser_path',
             }
         """
-        current_path = self.get_json_body()['current_path']
+        current_path = self.get_json_body()["current_path"]
         current_branch = self.git.get_current_branch(current_path)
         upstream = self.git.get_upstream_branch(current_path, current_branch)
-        self.finish(json.dumps({
-            'upstream': upstream
-        }))
+        self.finish(json.dumps({"upstream": upstream}))
 
 
 class GitPullHandler(GitHandler):
@@ -344,7 +339,7 @@ class GitPullHandler(GitHandler):
         """
         POST request handler, pulls files from a remote branch to your current branch.
         """
-        output = self.git.pull(self.get_json_body()['current_path'])
+        output = self.git.pull(self.get_json_body()["current_path"])
         self.finish(json.dumps(output))
 
 
@@ -359,28 +354,32 @@ class GitPushHandler(GitHandler):
         POST request handler,
         pushes committed files from your current branch to a remote branch
         """
-        current_path = self.get_json_body()['current_path']
+        current_path = self.get_json_body()["current_path"]
 
         current_local_branch = self.git.get_current_branch(current_path)
-        current_upstream_branch = self.git.get_upstream_branch(current_path, current_local_branch)
+        current_upstream_branch = self.git.get_upstream_branch(
+            current_path, current_local_branch
+        )
 
         if current_upstream_branch and current_upstream_branch.strip():
-            upstream = current_upstream_branch.split('/')
+            upstream = current_upstream_branch.split("/")
             if len(upstream) == 1:
                 # If upstream is a local branch
-                remote = '.'
-                branch = ':'.join(['HEAD', upstream[0]])
+                remote = "."
+                branch = ":".join(["HEAD", upstream[0]])
             else:
                 # If upstream is a remote branch
                 remote = upstream[0]
-                branch = ':'.join(['HEAD', upstream[1]])
+                branch = ":".join(["HEAD", upstream[1]])
 
             response = self.git.push(remote, branch, current_path)
 
         else:
             response = {
-                'code': 128,
-                'message': 'fatal: The current branch {} has no upstream branch.'.format(current_local_branch)
+                "code": 128,
+                "message": "fatal: The current branch {} has no upstream branch.".format(
+                    current_local_branch
+                ),
             }
         self.finish(json.dumps(response))
 
@@ -423,6 +422,33 @@ class GitChangedFilesHandler(GitHandler):
         )
 
 
+class GitConfigHandler(GitHandler):
+    """
+    Handler for 'git config' commands
+    """
+
+    def get(self):
+        """
+        GET all global configuration options
+        """
+        response = self.git.config()
+        if response["code"] != 0:
+            self.set_status(500)
+        self.finish(json.dumps(response))
+
+    def post(self):
+        """
+        POST add global configuration options
+        """
+        data = self.get_json_body()["options"]
+        response = self.git.config(**data)
+        if response["code"] != 0:
+            self.set_status(500)
+        else:
+            self.set_status(201)
+        self.finish(json.dumps(response))
+
+
 def setup_handlers(web_app):
     """
     Setups all of the git command handlers.
@@ -450,6 +476,7 @@ def setup_handlers(web_app):
         ("/git/add_all_untracked", GitAddAllUntrackedHandler),
         ("/git/clone", GitCloneHandler),
         ("/git/upstream", GitUpstreamHandler),
+        ("/git/config", GitConfigHandler),
         ("/git/changed_files", GitChangedFilesHandler)
     ]
 

--- a/specification/Git_REST_API.md
+++ b/specification/Git_REST_API.md
@@ -1,25 +1,33 @@
 # Specification of jupyterlab-git REST API
+
 A description of all jupyterlab-git REST API endpoints
 Contents for each call include:
+
 1. URLS
-3. Request JSON
-4. Reply JSON
-5. How errors are handled (HTTP success codes, error JSON)
+2. Request JSON
+3. Reply JSON
+4. How errors are handled (HTTP success codes, error JSON)
 
 ### /all_history - Get all git information of current repository
-Request with a current_path. If the current_path is a git repository, return all the git repository information. This request contains 4 seperate requests on server side (show_top_level, branch, log, status) 
+
+Request with a current_path. If the current_path is a git repository, return all the git repository information. This request contains 4 seperate requests on server side (show_top_level, branch, log, status)
 and may fail individually, so each request has its own code to indicate execution status (zero for success, non-zero for failure)
 URL:
-```bash 
+
+```bash
     POST /git/all_history
 ```
+
 Request JSON:
+
 ```bash
     {
         "current_path": "current/path/in/filebrowser/widget"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -27,12 +35,13 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
     	"data":{
             "show_top_level": {
-                "code": 0, 
+                "code": 0,
                 "top_repo_path": "/absolute/path/to/root/of/repo"
             }
             "branch"?: {
@@ -47,22 +56,22 @@ On success
                         "tag":"branch-tag"
                     }
                 ]
-            } 
-            "log"?: { 
+            }
+            "log"?: {
                 "code": 0,
                 "commits": [
                     {
-                        "commit":"1234567890987654321", 
+                        "commit":"1234567890987654321",
                         "author": "person0",
                         "date": "3-hourss-ago",
-                        "commit_msg": "update-file-changes" 
+                        "commit_msg": "update-file-changes"
                     }
                 ]
-            } 
+            }
             "status"?: {
                 "code": 0,
                 "files": {
-                    "x": "CHECK-bit-X", 
+                    "x": "CHECK-bit-X",
                     "y": "CHECK-bit-Y",
                     "to": "file/or/folder/path",
                     "from": "original/path/for/copied/file/or/folder"
@@ -71,7 +80,9 @@ On success
         }
     }
 ```
+
 On failure
+
 ```bash
     {
         "code": 128,
@@ -81,19 +92,25 @@ On failure
 ```
 
 ### /show_top_level - Show the absolute path of the top-level directory
+
 Request with a current_path. If the current_path is a git repository, return the absolute path of the top-level directory.
 
 URL:
-```bash 
-    POST /git/showtoplevel 
+
+```bash
+    POST /git/showtoplevel
 ```
+
 Request JSON:
+
 ```bash
     {
         "current_path": "current/path/in/filebrowser/widget"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -101,14 +118,17 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
-        "code": 0, 
+        "code": 0,
         "top_repo_path": "/absolute/path/to/root/of/repo"
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 128,
@@ -118,19 +138,25 @@ On failure
 ```
 
 ### /show_prefix - Show the relative path of the current directory
+
 Request with a current_path. Show the path of the current directory relative to the top-level directory.
 
 URL:
-```bash 
-    POST /git/showprefix 
+
+```bash
+    POST /git/showprefix
 ```
+
 Request JSON:
+
 ```bash
     {
         "current_path": "current/path/in/filebrowser/widget"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -138,14 +164,17 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
-        "code": 0, 
+        "code": 0,
         "under_repo_path": "/relative/path/to/top/level/of/repo"
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,
@@ -155,19 +184,25 @@ On failure
 ```
 
 ### /branch - List all branches
+
 Request with a current_path. Get a list of all the branches.
 
 URL:
-```bash 
-    POST /git/branch 
+
+```bash
+    POST /git/branch
 ```
+
 Request JSON:
+
 ```bash
     {
         "current_path": "current/path/in/filebrowser/widget"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -175,6 +210,7 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
@@ -191,7 +227,9 @@ On success
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,
@@ -201,19 +239,25 @@ On failure
 ```
 
 ### /log - Show past commit logs
+
 Request with a current_path. Get general info on all past commits.
 
 URL:
-```bash 
-    POST /git/log 
+
+```bash
+    POST /git/log
 ```
+
 Request JSON:
+
 ```bash
     {
         "current_path": "current/path/in/filebrowser/widget"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -221,21 +265,24 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
         "commits": [
             {
-                "commit":"1234567890987654321", 
+                "commit":"1234567890987654321",
                 "author": "person0",
                 "date": "3-hourss-ago",
-                "commit_msg": "update-file-changes" 
+                "commit_msg": "update-file-changes"
             }
         ]
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,
@@ -244,21 +291,16 @@ On failure
     }
 ```
 
-### /detailed_log - Get detailed information of a specific past commit
-Request with a specified selected_hash and a current_path. Get the detailed info of the selected commit.
+### /config - Get or add global configuration options
 
 URL:
-```bash 
-    POST /git/detailed_log 
-```
-Request JSON:
+
 ```bash
-    {
-        "selected_hash": "1234567890987654321"
-        "current_path": "current/path/in/filebrowser/widget"
-    }
+    GET /git/config
 ```
-HTTP response
+
+HTTP Response
+
 ```bash
 Status: 200 OK
 ```
@@ -266,6 +308,100 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
+```bash
+{
+    "code": "0",
+    "options": {
+        "key1": "value1",
+        "keyI": "valueI"
+    }
+}
+```
+
+On failure
+
+```bash
+    {
+        "code": 128,
+        "command": "git config --global --list"
+        "message": "Git command error info"
+    }
+```
+
+URL:
+
+```bash
+    POST /git/config
+```
+
+Request JSON:
+
+```bash
+    {
+        "options": {
+            "key1": "value1",
+            "keyI": "valueI"
+        }
+    }
+```
+
+HTTP Response
+
+```bash
+Status: 201 OK
+```
+
+Reply JSON:
+
+On success
+
+```bash
+{
+    "code": "0",
+    "message": "Git command output"
+}
+```
+
+On failure
+
+```bash
+    {
+        "code": 128,
+        "command": "git config --global --add name value"
+        "message": "Git command error info"
+    }
+```
+
+### /detailed_log - Get detailed information of a specific past commit
+
+Request with a specified selected_hash and a current_path. Get the detailed info of the selected commit.
+
+URL:
+
+```bash
+    POST /git/detailed_log
+```
+
+Request JSON:
+
+```bash
+    {
+        "selected_hash": "1234567890987654321"
+        "current_path": "current/path/in/filebrowser/widget"
+    }
+```
+
+HTTP response
+
+```bash
+Status: 200 OK
+```
+
+Reply JSON:
+
+On success
+
 ```bash
     {
 	"code": 0;
@@ -274,7 +410,7 @@ On success
         "number_of_insertions": "100",
         "number_of_deletions": "200",
         "modified_files": [
-            { 
+            {
                 "modified_file_path": "file/path",
 		"modified_file_name": "filename",
                 "insertion": "49";
@@ -284,7 +420,9 @@ On success
     }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,
@@ -294,19 +432,25 @@ On failure
 ```
 
 ### /status - Show the working tree's status
+
 Request with a current_path. Get the full status of the current working tree.
 
 URL:
-```bash 
-    POST /git/status 
+
+```bash
+    POST /git/status
 ```
+
 Request JSON:
+
 ```bash
     {
         "current_path": "current/path/in/filebrowser/widget"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -314,6 +458,7 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
@@ -327,7 +472,9 @@ On success
         ]
     }
 ```
+
 On failure
+
 ```bash
     {
         "code": 10001,
@@ -337,21 +484,27 @@ On failure
 ```
 
 ### /add - Add new file or existing file's changes to git
+
 Request with add_all (check if add all changes), a target filename, and a top_repo_path. Add a new file or an existing file's changes to the current repository.
 
 URL:
-```bash 
+
+```bash
     POST /git/add
 ```
+
 Request JSON:
+
 ```bash
     {
-        "add_all": false, 
-        "file_name": "file/or/folder/path", 
+        "add_all": false,
+        "file_name": "file/or/folder/path",
         "top_repo_path": "/absolute/path/to/root/of/repo"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -359,13 +512,16 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,
@@ -375,19 +531,25 @@ On failure
 ```
 
 ### /add_all_untracked - Add all the untracked files to git
+
 Request with a top_repo_path. Add only all of the untracked files to git.
 
 URL:
-```bash 
+
+```bash
     POST /git/add_all_untracked
 ```
+
 Request JSON:
+
 ```bash
     {
         "top_repo_path": "/absolute/path/to/root/of/repo"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -395,13 +557,16 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,
@@ -411,24 +576,30 @@ On failure
 ```
 
 ### /checkout - Switch branches or restore working tree files
+
 Request with a checkout_branch (boolean for if it's a switch branch request), a new_check (boolean for if the target branch needs to be created), a branch target branch_name, a checkout_all (boolean for if discarding all changes), a restore target file_name and a top_repo_path. Performs either a branch change, branch creation and change, checkout of all files, or checkout of a single file.
 
 URL:
-```bash 
+
+```bash
     POST /git/checkout
 ```
+
 Request JSON:
+
 ```bash
     {
         "checkout_branch": false,
         "new_check": false,
         "branch_name": "target-branch-name",
-        "checkout_all": false, 
-        "file_name": "file/or/folder/path", 
+        "checkout_all": false,
+        "file_name": "file/or/folder/path",
         "top_repo_path": "/absolute/path/to/root/of/repo"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -436,13 +607,16 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,
@@ -452,21 +626,27 @@ On failure
 ```
 
 ### /reset - Reset current HEAD to the specified state
+
 Request with a reset_all (boolean for if reset all changes), a target file_name, and a top_repo_path to reset the specificed file to the last stored version.
 
 URL:
-```bash 
+
+```bash
     POST /git/reset
 ```
+
 Request JSON:
+
 ```bash
     {
-        "reset_all": false, 
-        "file_name": "file/or/folder/path", 
+        "reset_all": false,
+        "file_name": "file/or/folder/path",
         "top_repo_path": "/absolute/path/to/root/of/repo"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -474,13 +654,16 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,
@@ -490,20 +673,26 @@ On failure
 ```
 
 ### /commit - Commit working changes to the repository
+
 Request with a commit_msg and a top_repo_path. Commit changes to the repository.
 
 URL:
-```bash 
+
+```bash
     POST /git/commit
 ```
+
 Request JSON:
+
 ```bash
     {
-        "commit_msg": "typed-in-message-for-commit", 
+        "commit_msg": "typed-in-message-for-commit",
         "top_repo_path": "/absolute/path/to/root/of/repo"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -511,13 +700,16 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,
@@ -527,19 +719,25 @@ On failure
 ```
 
 ### /init - Create an empty Git repository or reinitialize an existing one
+
 Request with a currrent_path. Create an empty git repository in the current directory or reinitalize the current git repository. WARNING: this will completely wipe your existing local repository.
 
 URL:
-```bash 
+
+```bash
     POST /git/init
 ```
+
 Request JSON:
+
 ```bash
     {
         "current_path": "current/path/in/filebrowser/widget"
     }
 ```
+
 HTTP response
+
 ```bash
 Status: 200 OK
 ```
@@ -547,13 +745,16 @@ Status: 200 OK
 Reply JSON:
 
 On success
+
 ```bash
     {
         "code": 0,
      }
 
 ```
+
 On failure
+
 ```bash
     {
         "code": 11,

--- a/specification/Git_REST_API.md
+++ b/specification/Git_REST_API.md
@@ -291,43 +291,7 @@ On failure
     }
 ```
 
-### /config - Get or add global configuration options
-
-URL:
-
-```bash
-    GET /git/config
-```
-
-HTTP Response
-
-```bash
-Status: 200 OK
-```
-
-Reply JSON:
-
-On success
-
-```bash
-{
-    "code": "0",
-    "options": {
-        "key1": "value1",
-        "keyI": "valueI"
-    }
-}
-```
-
-On failure
-
-```bash
-    {
-        "code": 128,
-        "command": "git config --global --list"
-        "message": "Git command error info"
-    }
-```
+### /config - Get or set configuration options
 
 URL:
 
@@ -339,6 +303,7 @@ Request JSON:
 
 ```bash
     {
+        "top_repo_path": "/absolute/path/to/root/of/repo",
         "options": {
             "key1": "value1",
             "keyI": "valueI"
@@ -368,7 +333,7 @@ On failure
 ```bash
     {
         "code": 128,
-        "command": "git config --global --add name value"
+        "command": "git config --add name value"
         "message": "Git command error info"
     }
 ```

--- a/specification/Git_REST_API.md
+++ b/specification/Git_REST_API.md
@@ -293,6 +293,9 @@ On failure
 
 ### /config - Get or set configuration options
 
+If no `options` in the request, get the `options` in the response.
+Otherwise set the provided options (if allowed) and return `message`.
+
 URL:
 
 ```bash
@@ -324,7 +327,11 @@ On success
 ```bash
 {
     "code": "0",
-    "message": "Git command output"
+    "message"?: "Git command output",
+    "options"?: {
+        "key1": "value1",
+        "keyI": "valueI"
+    }
 }
 ```
 

--- a/specification/Git_REST_API.yml
+++ b/specification/Git_REST_API.yml
@@ -249,6 +249,54 @@ on git command failure
     }
 ```
 
+### /config - Get or set configuration options
+Request or set configuration options for the repository provided by its path
+
+URL:
+
+```bash
+    POST /git/config
+```
+
+Request JSON:
+
+```bash
+    {
+        "top_repo_path": "/absolute/path/to/root/of/repo",
+        "options": {
+            "key1": "value1",
+            "keyI": "valueI"
+        }
+    }
+```
+
+HTTP Response
+
+```bash
+Status: 201 OK
+```
+
+Reply JSON:
+
+On success
+
+```bash
+{
+    "code": "0",
+    "message": "Git command output"
+}
+```
+
+On failure
+
+```bash
+    {
+        "code": 128,
+        "command": "git config --add name value"
+        "message": "Git command error info"
+    }
+```
+
 ### git detailed_log - Get detailed information of a selected past commit
 Request with a specified "selected_hash" and a "current_path" to get the detail info of this commit.
 

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -29,7 +29,9 @@ import {
 
 import { classes } from 'typestyle';
 
-import { showErrorMessage } from '@jupyterlab/apputils';
+import { showErrorMessage, showDialog } from '@jupyterlab/apputils';
+import { GitAuthorForm } from '../widgets/AuthorBox';
+import { JSONObject } from '@phosphor/coreutils';
 
 export interface IBranchHeaderState {
   dropdownOpen: boolean;
@@ -63,17 +65,26 @@ export class BranchHeader extends React.Component<
       showCommitBox: true,
       showNewBranchBox: false
     };
+
+    this.commitAllStagedFiles = this.commitAllStagedFiles.bind(this);
   }
 
   /** Commit all staged files */
-  commitAllStagedFiles = (message: string, path: string): void => {
-    if (message && message !== '') {
-      let gitApi = new Git();
-      gitApi.commit(message, path).then(response => {
-        this.props.refresh();
-      });
+  async commitAllStagedFiles(message: string, path: string): Promise<void> {
+    try {
+      if (message && message !== '' && (await this._hasIdentity())) {
+        let gitApi = new Git();
+        const response = await gitApi.commit(message, path);
+
+        if (response.ok) {
+          this.props.refresh();
+        }
+      }
+    } catch (error) {
+      console.error(error);
+      showErrorMessage('Fail to commit', error);
     }
-  };
+  }
 
   /** Update state of commit message input box */
   updateCommitBoxState(disable: boolean, numberOfFiles: number) {
@@ -273,4 +284,51 @@ export class BranchHeader extends React.Component<
       </div>
     );
   }
+
+  /**
+   * Does the user have an known git identity.
+   *
+   * @returns Success status
+   */
+  private async _hasIdentity(): Promise<boolean> {
+    // If the repository path changes, check the identity
+    if (this.props.topRepoPath !== this._previousTopRepoPath) {
+      let gitApi = new Git();
+      try {
+        const apiResponse = await gitApi.config(this.props.topRepoPath);
+        if (apiResponse.ok) {
+          const options: JSONObject = (await apiResponse.json()).options;
+          const keys = Object.keys(options);
+          // If the user name or email is unknown, ask the user to set it.
+          if (keys.indexOf('user.name') < 0 || keys.indexOf('user.email') < 0) {
+            let result = await showDialog({
+              title: 'Who is committing?',
+              body: new GitAuthorForm()
+            });
+            if (!result.button.accept) {
+              console.log('User refuses to set his identity.');
+              return false;
+            }
+            const identity = result.value;
+            const response = await gitApi.config(this.props.topRepoPath, {
+              'user.name': identity.name,
+              'user.email': identity.email
+            });
+
+            if (!response.ok) {
+              console.log(await response.text());
+              return false;
+            }
+          }
+          this._previousTopRepoPath = this.props.topRepoPath;
+        }
+      } catch (error) {
+        throw new Error('Fail to set your identity. ' + error.message);
+      }
+    }
+
+    return true;
+  }
+
+  private _previousTopRepoPath: string = null;
 }

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -72,7 +72,7 @@ export class BranchHeader extends React.Component<
   /** Commit all staged files */
   async commitAllStagedFiles(message: string, path: string): Promise<void> {
     try {
-      if (message && message !== '' && (await this._hasIdentity())) {
+      if (message && message !== '' && (await this._hasIdentity(path))) {
         let gitApi = new Git();
         const response = await gitApi.commit(message, path);
 
@@ -288,14 +288,15 @@ export class BranchHeader extends React.Component<
   /**
    * Does the user have an known git identity.
    *
+   * @param path Top repository path
    * @returns Success status
    */
-  private async _hasIdentity(): Promise<boolean> {
+  private async _hasIdentity(path: string): Promise<boolean> {
     // If the repository path changes, check the identity
-    if (this.props.topRepoPath !== this._previousTopRepoPath) {
+    if (path !== this._previousTopRepoPath) {
       let gitApi = new Git();
       try {
-        const apiResponse = await gitApi.config(this.props.topRepoPath);
+        const apiResponse = await gitApi.config(path);
         if (apiResponse.ok) {
           const options: JSONObject = (await apiResponse.json()).options;
           const keys = Object.keys(options);
@@ -310,7 +311,7 @@ export class BranchHeader extends React.Component<
               return false;
             }
             const identity = result.value;
-            const response = await gitApi.config(this.props.topRepoPath, {
+            const response = await gitApi.config(path, {
               'user.name': identity.name,
               'user.email': identity.email
             });
@@ -320,7 +321,7 @@ export class BranchHeader extends React.Component<
               return false;
             }
           }
-          this._previousTopRepoPath = this.props.topRepoPath;
+          this._previousTopRepoPath = path;
         }
       } catch (error) {
         throw new Error('Fail to set your identity. ' + error.message);

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
+import { showDialog, showErrorMessage } from '@jupyterlab/apputils';
 
 import {
   Git,
@@ -13,6 +14,8 @@ import {
   IGitStatusFileResult,
   IDiffCallback
 } from '../git';
+
+import { GitAuthorForm } from '../widgets/AuthorBox';
 
 import { PathHeader } from './PathHeader';
 
@@ -27,12 +30,14 @@ import {
   panelWarningStyle,
   findRepoButtonStyle
 } from '../componentsStyle/GitPanelStyle';
+import { JSONObject } from '@phosphor/coreutils';
 
 /** Interface for GitPanel component state */
 export interface IGitSessionNodeState {
   currentFileBrowserPath: string;
   topRepoPath: string;
   showWarning: boolean;
+  identityUnset: boolean;
 
   branches: any;
   currentBranch: string;
@@ -67,6 +72,7 @@ export class GitPanel extends React.Component<
       currentFileBrowserPath: '',
       topRepoPath: '',
       showWarning: false,
+      identityUnset: true,
       branches: [],
       currentBranch: '',
       upstreamBranch: '',
@@ -79,6 +85,8 @@ export class GitPanel extends React.Component<
       untrackedFiles: [],
       sideBarExpanded: false
     };
+
+    this._setIdentity = this._setIdentity.bind(this);
   }
 
   setShowList = (state: boolean) => {
@@ -90,12 +98,31 @@ export class GitPanel extends React.Component<
    */
   refresh = async () => {
     try {
+      let gitApi = new Git();
+
+      // Look if the user identity is set
+      //  If the user have an identity set previously, we assume is not gonna remove it
+      if (this.state.identityUnset) {
+        const apiResponse = await gitApi.config();
+        if (apiResponse.ok) {
+          const options: JSONObject = (await apiResponse.json()).options;
+          const keys = Object.keys(options);
+          if (
+            keys.indexOf('user.name') >= 0 &&
+            keys.indexOf('user.email') >= 0
+          ) {
+            this.setState({
+              identityUnset: false
+            });
+          }
+        }
+      }
+
       let leftSidebarItems = this.props.app.shell.widgets('left');
       let fileBrowser = leftSidebarItems.next();
       while (fileBrowser && fileBrowser.id !== 'filebrowser') {
         fileBrowser = leftSidebarItems.next();
       }
-      let gitApi = new Git();
       // If fileBrowser has loaded, make API request
       if (fileBrowser) {
         // Make API call to get all git info for repo
@@ -211,6 +238,72 @@ export class GitPanel extends React.Component<
   };
 
   render() {
+    let main = (
+      <div>
+        <BranchHeader
+          currentFileBrowserPath={this.state.currentFileBrowserPath}
+          topRepoPath={this.state.topRepoPath}
+          refresh={this.refresh}
+          currentBranch={this.state.currentBranch}
+          upstreamBranch={this.state.upstreamBranch}
+          stagedFiles={this.state.stagedFiles}
+          data={this.state.branches}
+          disabled={this.state.disableSwitchBranch}
+          toggleSidebar={this.toggleSidebar}
+          showList={this.state.showList}
+          sideBarExpanded={this.state.sideBarExpanded}
+        />
+        <HistorySideBar
+          isExpanded={this.state.sideBarExpanded}
+          branches={this.state.branches}
+          pastCommits={this.state.pastCommits}
+          topRepoPath={this.state.topRepoPath}
+          app={this.props.app}
+          refresh={this.refresh}
+          diff={this.props.diff}
+        />
+        <PastCommits
+          currentFileBrowserPath={this.state.currentFileBrowserPath}
+          topRepoPath={this.state.topRepoPath}
+          inNewRepo={this.state.inNewRepo}
+          showList={this.state.showList}
+          stagedFiles={this.state.stagedFiles}
+          unstagedFiles={this.state.unstagedFiles}
+          untrackedFiles={this.state.untrackedFiles}
+          app={this.props.app}
+          refresh={this.refresh}
+          diff={this.props.diff}
+          sideBarExpanded={this.state.sideBarExpanded}
+        />
+      </div>
+    );
+
+    // Overwrite main
+    if (this.state.identityUnset) {
+      main = (
+        <div className={panelWarningStyle}>
+          <div>No identity set to commit.</div>
+          <button className={findRepoButtonStyle} onClick={this._setIdentity}>
+            Set identity
+          </button>
+        </div>
+      );
+    } else if (!this.state.showWarning) {
+      main = (
+        <div className={panelWarningStyle}>
+          <div>You aren’t in a git repository.</div>
+          <button
+            className={findRepoButtonStyle}
+            onClick={() =>
+              this.props.app.commands.execute('filebrowser:toggle-main')
+            }
+          >
+            Go find a repo
+          </button>
+        </div>
+      );
+    }
+
     return (
       <div className={panelContainerStyle}>
         <PathHeader
@@ -219,61 +312,34 @@ export class GitPanel extends React.Component<
           refresh={this.refresh}
           currentBranch={this.state.currentBranch}
         />
-        <div>
-          {this.state.showWarning && (
-            <div>
-              <BranchHeader
-                currentFileBrowserPath={this.state.currentFileBrowserPath}
-                topRepoPath={this.state.topRepoPath}
-                refresh={this.refresh}
-                currentBranch={this.state.currentBranch}
-                upstreamBranch={this.state.upstreamBranch}
-                stagedFiles={this.state.stagedFiles}
-                data={this.state.branches}
-                disabled={this.state.disableSwitchBranch}
-                toggleSidebar={this.toggleSidebar}
-                showList={this.state.showList}
-                sideBarExpanded={this.state.sideBarExpanded}
-              />
-              <HistorySideBar
-                isExpanded={this.state.sideBarExpanded}
-                branches={this.state.branches}
-                pastCommits={this.state.pastCommits}
-                topRepoPath={this.state.topRepoPath}
-                app={this.props.app}
-                refresh={this.refresh}
-                diff={this.props.diff}
-              />
-              <PastCommits
-                currentFileBrowserPath={this.state.currentFileBrowserPath}
-                topRepoPath={this.state.topRepoPath}
-                inNewRepo={this.state.inNewRepo}
-                showList={this.state.showList}
-                stagedFiles={this.state.stagedFiles}
-                unstagedFiles={this.state.unstagedFiles}
-                untrackedFiles={this.state.untrackedFiles}
-                app={this.props.app}
-                refresh={this.refresh}
-                diff={this.props.diff}
-                sideBarExpanded={this.state.sideBarExpanded}
-              />
-            </div>
-          )}
-          {!this.state.showWarning && (
-            <div className={panelWarningStyle}>
-              <div>You aren’t in a git repository.</div>
-              <button
-                className={findRepoButtonStyle}
-                onClick={() =>
-                  this.props.app.commands.execute('filebrowser:toggle-main')
-                }
-              >
-                Go find a repo
-              </button>
-            </div>
-          )}
-        </div>
+        <div>{main}</div>
       </div>
     );
+  }
+
+  /**
+   * Set user identity
+   */
+  private async _setIdentity(): Promise<void> {
+    let result = await showDialog({
+      title: 'Who is committing?',
+      body: new GitAuthorForm()
+    });
+    if (result.button.accept) {
+      const identity = result.value;
+      let gitApi = new Git();
+      try {
+        await gitApi.config({
+          'user.name': identity.name,
+          'user.email': identity.email
+        });
+        this.refresh().catch(error => {
+          console.error(error);
+        });
+      } catch (error) {
+        console.error(error);
+        showErrorMessage('Fail to set your identity.', error);
+      }
+    }
   }
 }

--- a/src/components/PathHeader.tsx
+++ b/src/components/PathHeader.tsx
@@ -14,7 +14,7 @@ import { Git } from '../git';
 
 import { Dialog } from '@jupyterlab/apputils';
 
-import { GitPullPushDialog, Operation } from '../gitPushPull';
+import { GitPullPushDialog, Operation } from '../widgets/gitPushPull';
 
 export interface IPathHeaderState {
   refresh: any;

--- a/src/git.ts
+++ b/src/git.ts
@@ -418,12 +418,13 @@ export class Git {
   /**
    * Get or set Git configuration options
    *
-   * @param options
+   * @param path Top repository path
+   * @param options Configuration options to set (undefined to get)
    */
-  async config(options?: JSONObject): Promise<Response> {
+  async config(path: string, options?: JSONObject): Promise<Response> {
     try {
-      let method = options ? 'POST' : 'GET';
-      let body = options ? { options: options } : undefined;
+      let method = 'POST';
+      let body = { path, options };
 
       let response = await httpGitRequest('/git/config', method, body);
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,7 @@
 import { ServerConnection } from '@jupyterlab/services';
 
 import { URLExt } from '@jupyterlab/coreutils';
+import { JSONObject } from '@phosphor/coreutils';
 
 /** Function type for diffing a file's revisions */
 export type IDiffCallback = (
@@ -120,6 +121,11 @@ export interface ISingleCommitFilePathInfo {
 export interface IGitLogResult {
   code: number;
   commits?: [ISingleCommitInfo];
+}
+
+export interface IIdentity {
+  name: string;
+  email: string;
 }
 
 /** Makes a HTTP request, sending a git command to the backend */
@@ -406,6 +412,29 @@ export class Git {
       return response;
     } catch (err) {
       throw ServerConnection.NetworkError;
+    }
+  }
+
+  /**
+   * Get or set Git configuration options
+   *
+   * @param options
+   */
+  async config(options?: JSONObject): Promise<Response> {
+    try {
+      let method = options ? 'POST' : 'GET';
+      let body = options ? { options: options } : undefined;
+
+      let response = await httpGitRequest('/git/config', method, body);
+
+      if (!response.ok) {
+        const jsonData = await response.json();
+        throw new ServerConnection.ResponseError(response, jsonData.message);
+      }
+
+      return response;
+    } catch (err) {
+      throw new ServerConnection.NetworkError(err);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import { IDiffCallback } from './git';
 export { IDiffCallback } from './git';
 
 import '../style/variables.css';
-import { GitClone } from './gitClone';
+import { GitClone } from './widgets/gitClone';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 export const EXTENSION_ID = 'jupyter.extensions.git_plugin';

--- a/src/widgets/AuthorBox.ts
+++ b/src/widgets/AuthorBox.ts
@@ -1,0 +1,45 @@
+import { Dialog } from '@jupyterlab/apputils';
+import { Widget } from '@phosphor/widgets';
+import { IIdentity } from '../git';
+
+/**
+ * The UI for the commit author form
+ */
+export class GitAuthorForm extends Widget
+  implements Dialog.IBodyWidget<IIdentity> {
+  constructor() {
+    super();
+    this.node.appendChild(this.createBody());
+  }
+
+  private createBody(): HTMLElement {
+    const node = document.createElement('div');
+    const text = document.createElement('span');
+    this._name = document.createElement('input');
+    this._email = document.createElement('input');
+
+    node.className = 'jp-RedirectForm';
+    text.textContent = 'Enter your name and email for commit';
+    this._name.placeholder = 'Name';
+    this._email.placeholder = 'Email';
+
+    node.appendChild(text);
+    node.appendChild(this._name);
+    node.appendChild(this._email);
+    return node;
+  }
+
+  /**
+   * Returns the input value.
+   */
+  getValue(): IIdentity {
+    let credentials = {
+      name: this._name.value,
+      email: this._email.value
+    };
+    return credentials;
+  }
+
+  private _name: HTMLInputElement;
+  private _email: HTMLInputElement;
+}

--- a/src/widgets/gitClone.ts
+++ b/src/widgets/gitClone.ts
@@ -6,7 +6,7 @@ import { FileBrowser, IFileBrowserFactory } from '@jupyterlab/filebrowser';
 
 import { style } from 'typestyle';
 
-import { Git } from './git';
+import { Git } from '../git';
 
 /**
  * The widget encapsulating the Git Clone UI:

--- a/src/widgets/gitPushPull.ts
+++ b/src/widgets/gitPushPull.ts
@@ -1,6 +1,6 @@
 import { Spinner } from '@jupyterlab/apputils';
 import { Widget } from '@phosphor/widgets';
-import { Git, IGitPushPullResult } from './git';
+import { Git, IGitPushPullResult } from '../git';
 
 export enum Operation {
   Pull = 'Pull',

--- a/tests/test-browser/chrome-test.js
+++ b/tests/test-browser/chrome-test.js
@@ -1,44 +1,19 @@
 const assert = require('assert');
 const puppeteer = require('puppeteer');
 const inspect = require('util').inspect;
-
-function getUrl() {
-  return process.argv[2];
-}
-
-function testJupyterLabPage(html) {
-  if (inspect(html).indexOf('jupyter-config-data') === -1) {
-    console.error('Error loading JupyterLab page:');
-    console.error(html);
-  }
-}
-
-async function testApplication(page) {
-  const el = await page.waitForSelector('#browserTest', { timeout: 100000 });
-  console.log('Waiting for application to start...');
-
-  await page.waitForSelector('.completed');
-
-  const textContent = await el.getProperty('textContent');
-  const errors = JSON.parse(await textContent.jsonValue());
-
-  for (let error of errors) {
-    console.error(`Parsed an error from text content: ${error.message}`, error);
-    throw error;
-  }
-}
+const URL = process.argv[2];
 
 function testGitExtension(html) {
-    // Test git icons are present
-    assert(html.includes('--jp-icon-git-clone'), 'Could not find git clone icon.');
-    assert(html.includes('--jp-icon-git-pull'), 'Could not find git pull icon.');
-    assert(html.includes('--jp-icon-git-push'), 'Could not find git push icon.');
+  // Test git icons are present
+  assert(html.includes('--jp-icon-git-clone'), 'Could not find git clone icon.');
+  assert(html.includes('--jp-icon-git-pull'), 'Could not find git pull icon.');
+  assert(html.includes('--jp-icon-git-push'), 'Could not find git push icon.');
 }
 
 async function main() {
+  /* eslint-disable no-console */
   console.info('Starting Chrome Headless');
 
-  const URL = getUrl();
   const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
   const page = await browser.newPage();
 
@@ -46,13 +21,38 @@ async function main() {
   await page.goto(URL);
   console.info('Waiting for page to load...');
 
-  const html = await page.content();
-  testJupyterLabPage(html);
+  // Wait for the local file to redirect on notebook >= 6.0
+  await page.waitForNavigation();
 
-  await testApplication(page);
+  const html = await page.content();
+  if (inspect(html).indexOf('jupyter-config-data') === -1) {
+    console.error('Error loading JupyterLab page:');
+    console.error(html);
+  }
+
+  const el = await page.waitForSelector('#browserTest', { timeout: 100000 });
+  console.log('Waiting for application to start...');
+  let testError = null;
+
+  try {
+    await page.waitForSelector('.completed');
+  } catch (e) {
+    testError = e;
+  }
+  const textContent = await el.getProperty('textContent');
+  const errors = JSON.parse(await textContent.jsonValue());
+
+  for (let error of errors) {
+    console.error(`Parsed an error from text content: ${error.message}`, error);
+  }
+
   testGitExtension(html);
 
   await browser.close();
+
+  if (testError) {
+    throw testError;
+  }
   console.info('Chrome test complete');
 }
 

--- a/tests/test-browser/run_browser_test.py
+++ b/tests/test-browser/run_browser_test.py
@@ -1,71 +1,14 @@
 # -*- coding: utf-8 -*-
-# This file is copied from https://github.com/jupyterlab/jupyterlab/blob/master/jupyterlab/browser_check.py
-from concurrent.futures import ThreadPoolExecutor
+# This file reproduces https://github.com/jupyterlab/jupyterlab/blob/master/jupyterlab/browser_check.py
+# but patch the global `here` to use the local chrome-test.js
 import os
-import shutil
-import sys
-import subprocess
+from unittest.mock import patch
 
-from jupyterlab.labapp import LabApp, get_app_dir
-from notebook.notebookapp import flags, aliases
-from tornado.ioloop import IOLoop
-from traitlets import Bool
-
+from jupyterlab.browser_check import BrowserApp
 
 here = os.path.abspath(os.path.dirname(__file__))
-test_flags = dict(flags)
-test_flags['core-mode'] = (
-    {'BrowserApp': {'core_mode': True}},
-    "Start the app in core mode."
-)
-test_flags['dev-mode'] = (
-    {'BrowserApp': {'dev_mode': True}},
-    "Start the app in dev mode."
-)
-
-
-test_aliases = dict(aliases)
-test_aliases['app-dir'] = 'BrowserApp.app_dir'
-
-
-class BrowserApp(LabApp):
-
-    open_browser = Bool(False)
-    base_url = '/lab/'
-    ip = '127.0.0.1'
-    flags = test_flags
-    aliases = test_aliases
-
-    def start(self):
-        web_app = self.web_app
-        web_app.settings.setdefault('page_config_data', dict())
-        web_app.settings['page_config_data']['browserTest'] = True
-        web_app.settings['page_config_data']['buildAvailable'] = False
-
-        pool = ThreadPoolExecutor()
-        future = pool.submit(run_browser, self.display_url)
-        IOLoop.current().add_future(future, self._browser_finished)
-        super(BrowserApp, self).start()
-
-    def _browser_finished(self, future):
-        try:
-            sys.exit(future.result())
-        except Exception as e:
-            self.log.error(str(e))
-            sys.exit(1)
-
-
-def run_browser(url):
-    """Run the browser test and return an exit code.
-    """
-    target = os.path.join(get_app_dir(), 'browser_test')
-    if not os.path.exists(os.path.join(target, 'node_modules')):
-        os.makedirs(target)
-        subprocess.call(["yarn"], cwd=target)
-        subprocess.call(["yarn", "add", "puppeteer"], cwd=target)
-    shutil.copy(os.path.join(here, 'chrome-test.js'), os.path.join(target, 'chrome-test.js'))
-    return subprocess.check_call(["node", "chrome-test.js", url], cwd=target)
 
 
 if __name__ == '__main__':
-    BrowserApp.launch_instance()
+    with patch('jupyterlab.browser_check.here', here):
+        BrowserApp.launch_instance()

--- a/tests/test-components/BranchHeader.spec.tsx
+++ b/tests/test-components/BranchHeader.spec.tsx
@@ -14,6 +14,9 @@ import {
   smallBranchStyle
 } from '../../src/componentsStyle/BranchHeaderStyle';
 
+// Mock jupyterlab package
+jest.mock('@jupyterlab/apputils');
+
 describe('BranchHeader', () => {
   let props: IBranchHeaderProps = {
     currentFileBrowserPath: '/current/absolute/path',
@@ -55,17 +58,16 @@ describe('BranchHeader', () => {
     it('should commit when commit message is provided', async () => {
       const spy = jest.spyOn(Git.prototype, 'commit');
       // Mock identity look up
-      const identity = jest.spyOn(Git.prototype, 'config').mockImplementation(
-        () =>
-          new Response(
-            JSON.stringify({
-              options: {
-                'user.name': 'John Snow',
-                'user.email': 'john.snow@winteris.com'
-              }
-            }),
-            { status: 201 }
-          )
+      const identity = jest.spyOn(Git.prototype, 'config').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            options: {
+              'user.name': 'John Snow',
+              'user.email': 'john.snow@winteris.com'
+            }
+          }),
+          { status: 201 }
+        )
       );
       await branchHeader.commitAllStagedFiles(
         'Initial commit',
@@ -93,8 +95,9 @@ describe('BranchHeader', () => {
       const identity = jest
         .spyOn(Git.prototype, 'config')
         .mockImplementation((path, options) => {
+          let response: Response = null;
           if (options === undefined) {
-            return new Response(
+            response = new Response(
               JSON.stringify({
                 options: {
                   'user.email': 'john.snow@winteris.com'
@@ -103,20 +106,26 @@ describe('BranchHeader', () => {
               { status: 201 }
             );
           } else {
-            return new Response('', { status: 201 });
+            response = new Response('', { status: 201 });
           }
+          return Promise.resolve(response);
         });
-      jest.spyOn(apputils, 'showDialog').mockReturnValue(
-        Promise.resolve({
-          button: {
-            accept: true
-          },
-          value: {
-            name: 'John Snow',
-            email: 'john.snow@winteris.com'
-          }
-        })
-      );
+      const mockApputils = apputils as jest.Mocked<typeof apputils>;
+      mockApputils.showDialog.mockResolvedValue({
+        button: {
+          accept: true,
+          caption: '',
+          className: '',
+          displayType: 'default',
+          iconClass: '',
+          iconLabel: '',
+          label: ''
+        },
+        value: {
+          name: 'John Snow',
+          email: 'john.snow@winteris.com'
+        }
+      });
 
       await branchHeader.commitAllStagedFiles(
         'Initial commit',
@@ -145,8 +154,9 @@ describe('BranchHeader', () => {
       const identity = jest
         .spyOn(Git.prototype, 'config')
         .mockImplementation((path, options) => {
+          let response: Response = null;
           if (options === undefined) {
-            return new Response(
+            response = new Response(
               JSON.stringify({
                 options: {
                   'user.name': 'John Snow'
@@ -155,12 +165,20 @@ describe('BranchHeader', () => {
               { status: 201 }
             );
           } else {
-            return new Response('', { status: 201 });
+            response = new Response('', { status: 201 });
           }
+          return Promise.resolve(response);
         });
-      jest.spyOn(apputils, 'showDialog').mockReturnValue({
+      const mockApputils = apputils as jest.Mocked<typeof apputils>;
+      mockApputils.showDialog.mockResolvedValue({
         button: {
-          accept: true
+          accept: true,
+          caption: '',
+          className: '',
+          displayType: 'default',
+          iconClass: '',
+          iconLabel: '',
+          label: ''
         },
         value: {
           name: 'John Snow',
@@ -195,21 +213,31 @@ describe('BranchHeader', () => {
       const identity = jest
         .spyOn(Git.prototype, 'config')
         .mockImplementation((path, options) => {
+          let response: Response = null;
           if (options === undefined) {
-            return new Response(
+            response = new Response(
               JSON.stringify({
                 options: {}
               }),
               { status: 201 }
             );
           } else {
-            return new Response('', { status: 201 });
+            response = new Response('', { status: 201 });
           }
+          return Promise.resolve(response);
         });
-      jest.spyOn(apputils, 'showDialog').mockReturnValue({
+      const mockApputils = apputils as jest.Mocked<typeof apputils>;
+      mockApputils.showDialog.mockResolvedValue({
         button: {
-          accept: false
-        }
+          accept: false,
+          caption: '',
+          className: '',
+          displayType: 'default',
+          iconClass: '',
+          iconLabel: '',
+          label: ''
+        },
+        value: null
       });
 
       await branchHeader.commitAllStagedFiles(

--- a/tests/test-components/BranchHeader.spec.tsx
+++ b/tests/test-components/BranchHeader.spec.tsx
@@ -1,3 +1,4 @@
+import * as apputils from '@jupyterlab/apputils';
 import {
   BranchHeader,
   IBranchHeaderProps
@@ -22,7 +23,7 @@ describe('BranchHeader', () => {
     upstreamBranch: 'origin/master',
     stagedFiles: ['test-1', 'test-2'],
     data: ['master', 'feature-1', 'feature-2', 'patch-007'],
-    refresh: 'update all content',
+    refresh: function() {},
     disabled: false,
     toggleSidebar: function() {
       return true;
@@ -32,9 +33,11 @@ describe('BranchHeader', () => {
 
   describe('#constructor()', () => {
     const branchHeader = new BranchHeader(props);
+
     it('should construct a new branch header', () => {
       expect(branchHeader).toBeInstanceOf(BranchHeader);
     });
+
     it('should set default values correctly', () => {
       expect(branchHeader.state.dropdownOpen).toEqual(false);
       expect(branchHeader.state.showCommitBox).toEqual(true);
@@ -43,25 +46,180 @@ describe('BranchHeader', () => {
   });
 
   describe('#commitAllStagedFiles()', () => {
-    const branchHeader = new BranchHeader(props);
-    it('should commit when commit message is provided', () => {
+    let branchHeader = null;
+
+    beforeEach(() => {
+      branchHeader = new BranchHeader(props);
+    });
+
+    it('should commit when commit message is provided', async () => {
       const spy = jest.spyOn(Git.prototype, 'commit');
-      branchHeader.commitAllStagedFiles(
+      // Mock identity look up
+      const identity = jest.spyOn(Git.prototype, 'config').mockImplementation(
+        () =>
+          new Response(
+            JSON.stringify({
+              options: {
+                'user.name': 'John Snow',
+                'user.email': 'john.snow@winteris.com'
+              }
+            }),
+            { status: 201 }
+          )
+      );
+      await branchHeader.commitAllStagedFiles(
         'Initial commit',
         '/absolute/path/to/git/repo'
       );
+      expect(identity).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(
         'Initial commit',
         '/absolute/path/to/git/repo'
       );
-      spy.mockRestore();
+      jest.restoreAllMocks();
     });
-    it('should NOT commit when commit message is empty', () => {
+
+    it('should NOT commit when commit message is empty', async () => {
       const spy = jest.spyOn(Git.prototype, 'commit');
-      branchHeader.commitAllStagedFiles('', props.topRepoPath);
+      await branchHeader.commitAllStagedFiles('', props.topRepoPath);
       expect(spy).not.toHaveBeenCalled();
       spy.mockRestore();
+    });
+
+    it('should prompt for user identity if user.name is unset', async () => {
+      const spy = jest.spyOn(Git.prototype, 'commit');
+      // Mock identity look up
+      const identity = jest
+        .spyOn(Git.prototype, 'config')
+        .mockImplementation((path, options) => {
+          if (options === undefined) {
+            return new Response(
+              JSON.stringify({
+                options: {
+                  'user.email': 'john.snow@winteris.com'
+                }
+              }),
+              { status: 201 }
+            );
+          } else {
+            return new Response('', { status: 201 });
+          }
+        });
+      jest.spyOn(apputils, 'showDialog').mockReturnValue(
+        Promise.resolve({
+          button: {
+            accept: true
+          },
+          value: {
+            name: 'John Snow',
+            email: 'john.snow@winteris.com'
+          }
+        })
+      );
+
+      await branchHeader.commitAllStagedFiles(
+        'Initial commit',
+        '/absolute/path/to/git/repo'
+      );
+      expect(identity).toHaveBeenCalledTimes(2);
+      expect(identity.mock.calls[0]).toEqual(['/absolute/path/to/git/repo']);
+      expect(identity.mock.calls[1]).toEqual([
+        '/absolute/path/to/git/repo',
+        {
+          'user.name': 'John Snow',
+          'user.email': 'john.snow@winteris.com'
+        }
+      ]);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(
+        'Initial commit',
+        '/absolute/path/to/git/repo'
+      );
+      jest.restoreAllMocks();
+    });
+
+    it('should prompt for user identity if user.email is unset', async () => {
+      const spy = jest.spyOn(Git.prototype, 'commit');
+      // Mock identity look up
+      const identity = jest
+        .spyOn(Git.prototype, 'config')
+        .mockImplementation((path, options) => {
+          if (options === undefined) {
+            return new Response(
+              JSON.stringify({
+                options: {
+                  'user.name': 'John Snow'
+                }
+              }),
+              { status: 201 }
+            );
+          } else {
+            return new Response('', { status: 201 });
+          }
+        });
+      jest.spyOn(apputils, 'showDialog').mockReturnValue({
+        button: {
+          accept: true
+        },
+        value: {
+          name: 'John Snow',
+          email: 'john.snow@winteris.com'
+        }
+      });
+
+      await branchHeader.commitAllStagedFiles(
+        'Initial commit',
+        '/absolute/path/to/git/repo'
+      );
+      expect(identity).toHaveBeenCalledTimes(2);
+      expect(identity.mock.calls[0]).toEqual(['/absolute/path/to/git/repo']);
+      expect(identity.mock.calls[1]).toEqual([
+        '/absolute/path/to/git/repo',
+        {
+          'user.name': 'John Snow',
+          'user.email': 'john.snow@winteris.com'
+        }
+      ]);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(
+        'Initial commit',
+        '/absolute/path/to/git/repo'
+      );
+      jest.restoreAllMocks();
+    });
+
+    it('should NOT commit if no user identity is set and the user reject the dialog', async () => {
+      const spy = jest.spyOn(Git.prototype, 'commit');
+      // Mock identity look up
+      const identity = jest
+        .spyOn(Git.prototype, 'config')
+        .mockImplementation((path, options) => {
+          if (options === undefined) {
+            return new Response(
+              JSON.stringify({
+                options: {}
+              }),
+              { status: 201 }
+            );
+          } else {
+            return new Response('', { status: 201 });
+          }
+        });
+      jest.spyOn(apputils, 'showDialog').mockReturnValue({
+        button: {
+          accept: false
+        }
+      });
+
+      await branchHeader.commitAllStagedFiles(
+        'Initial commit',
+        '/absolute/path/to/git/repo'
+      );
+      expect(identity).toHaveBeenCalledTimes(1);
+      expect(identity).toHaveBeenCalledWith('/absolute/path/to/git/repo');
+      expect(spy).not.toHaveBeenCalled();
+      jest.restoreAllMocks();
     });
   });
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,106 @@
+import json
+import subprocess
+
+from mock import patch, call, Mock
+import pytest
+
+from jupyterlab_git.git import Git
+from jupyterlab_git.handlers import GitConfigHandler
+
+
+@patch("jupyterlab_git.handlers.GitConfigHandler.__init__", Mock(return_value=None))
+@patch("jupyterlab_git.handlers.GitConfigHandler.git", Git("/bin"))
+@patch("jupyterlab_git.handlers.GitConfigHandler.finish")
+@patch("subprocess.Popen")
+def test_git_get_config_success(popen, finish):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        "communicate": Mock(
+            return_value=(
+                b"user.name=John Snow\nuser.email=john.snow@iscoming.com",
+                b"",
+            )
+        ),
+        "returncode": 0,
+    }
+    process_mock.configure_mock(**attrs)
+    popen.return_value = process_mock
+
+    # When
+    GitConfigHandler().get()
+
+    # Then
+    popen.assert_called_once_with(
+        ["git", "config", "--global", "--list"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    process_mock.communicate.assert_called_once_with()
+
+    finish.assert_called_once_with(
+        json.dumps(
+            {
+                "code": 0,
+                "options": {
+                    "user.name": "John Snow",
+                    "user.email": "john.snow@iscoming.com",
+                },
+            }
+        )
+    )
+
+
+@patch("jupyterlab_git.handlers.GitConfigHandler.__init__", Mock(return_value=None))
+@patch(
+    "jupyterlab_git.handlers.GitConfigHandler.get_json_body",
+    Mock(
+        return_value={
+            "options": {
+                "user.name": "John Snow",
+                "user.email": "john.snow@iscoming.com",
+            }
+        }
+    ),
+)
+@patch("jupyterlab_git.handlers.GitConfigHandler.git", Git("/bin"))
+@patch("jupyterlab_git.handlers.GitConfigHandler.finish")
+@patch("subprocess.Popen")
+def test_git_set_config_success(popen, finish):
+    # Given
+    process_mock = Mock()
+    attrs = {"communicate": Mock(return_value=(b"", b"")), "returncode": 0}
+    process_mock.configure_mock(**attrs)
+    popen.return_value = process_mock
+
+    # When
+    GitConfigHandler().post()
+
+    # Then
+    assert popen.call_count == 2
+    assert (
+        call(
+            [
+                "git",
+                "config",
+                "--global",
+                "--add",
+                "user.email",
+                "john.snow@iscoming.com",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        in popen.call_args_list
+    )
+    assert (
+        call(
+            ["git", "config", "--global", "--add", "user.name", "John Snow"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        in popen.call_args_list
+    )
+    assert process_mock.communicate.call_count == 2
+
+    finish.assert_called_once_with(json.dumps({"code": 0, "message": ""}))


### PR DESCRIPTION
Fixes #351 and will imply simplification in #345.

## User changes

If the user has no `user.name` and no `user.email` defined in Git global configuration, the GitPanel will be replaced by a warning and a button prompting the user for a name and an email.

![image](https://user-images.githubusercontent.com/8435071/59848004-64e12480-9364-11e9-86b9-3ddbc7fd6011.png)

If the user provides them, they will be added as global configuration options in git. Then the extension will behave as previously.

Note;

* The email is not verified to be a valid email string
* If the user removes his identity after opening JupyterLab (very unlikely), the extension is never checking again if an identity is set.

## Backward incompatibilities

None