### PR TITLE
Update clone to not use shell=True

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -78,7 +78,6 @@ class Git:
         env['GIT_TERMINAL_PROMPT'] = '0'
         p = subprocess.Popen(
             ['git', 'clone', unquote(repo_url)],
-            shell=True,
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, current_path),

--- a/tests/unit/test_clone.py
+++ b/tests/unit/test_clone.py
@@ -27,7 +27,6 @@ def test_git_clone_success(mock_subproc_popen):
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path',
-            shell=True,
             env={'TEST': 'test', 'GIT_TERMINAL_PROMPT': '0'},
         ),
         call().communicate()
@@ -62,7 +61,6 @@ def test_git_clone_failure_from_git(mock_subproc_popen):
             stdout=PIPE,
             stderr=PIPE,
             cwd='/bin/test_curr_path',
-            shell=True,
             env={'TEST': 'test', 'GIT_TERMINAL_PROMPT': '0'},
         ),
         call().communicate()


### PR DESCRIPTION
Related to
* Similar fix made for push/pull https://github.com/jupyterlab/jupyterlab-git/pull/362
* Related issue https://github.com/jupyterlab/jupyterlab-git/pull/344 #367 


Tested by running locally and doing a "clone" from the UI