### PR TITLE
Visual diff for Notebook files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@jupyterlab/services": "^4.0.0",
     "@jupyterlab/terminal": "^1.0.0",
     "@phosphor/widgets": "^1.8.0",
+    "nbdime": "~5.0.1",
     "react": "~16.8.4",
     "react-dom": "~16.8.4",
     "typestyle": "^2.0.1"

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -115,14 +115,12 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       label: 'Open',
       caption: 'Open selected file',
       execute: async () => {
-        try {
-          await this.openListedFile(
-            this.state.contextMenuTypeX,
-            this.state.contextMenuTypeY,
-            this.state.contextMenuFile,
-            this.props.app
-          );
-        } catch (err) {}
+        await this.openListedFile(
+          this.state.contextMenuTypeX,
+          this.state.contextMenuTypeY,
+          this.state.contextMenuFile,
+          this.props.app
+        );
       }
     });
 

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -110,84 +110,90 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       disableFiles: false
     };
 
-    commands.addCommand(CommandIDs.gitFileOpen, {
-      label: 'Open',
-      caption: 'Open selected file',
-      execute: async () => {
-        await this.openListedFile(
-          this.state.contextMenuTypeX,
-          this.state.contextMenuTypeY,
-          this.state.contextMenuFile,
-          this.props.app
-        );
-      }
-    });
+    if (!commands.hasCommand(CommandIDs.gitFileOpen)) {
+      commands.addCommand(CommandIDs.gitFileOpen, {
+        label: 'Open',
+        caption: 'Open selected file',
+        execute: async () => {
+          await this.openListedFile(
+            this.state.contextMenuTypeX,
+            this.state.contextMenuTypeY,
+            this.state.contextMenuFile,
+            this.props.app
+          );
+        }
+      });
+    }
 
-    commands.addCommand(CommandIDs.gitFileDiffWorking, {
-      label: 'Diff',
-      caption: 'Diff selected file',
-      execute: () => {
-        openDiffView(
-          this.state.contextMenuFile,
-          this.props.app,
-          {
-            currentRef: { specialRef: 'WORKING' },
-            previousRef: { gitRef: 'HEAD' }
-          },
-          this.props.renderMime
-        );
-      }
-    });
+    if (!commands.hasCommand(CommandIDs.gitFileDiffWorking)) {
+      commands.addCommand(CommandIDs.gitFileDiffWorking, {
+        label: 'Diff',
+        caption: 'Diff selected file',
+        execute: () => {
+          openDiffView(
+            this.state.contextMenuFile,
+            this.props.app,
+            {
+              currentRef: { specialRef: 'WORKING' },
+              previousRef: { gitRef: 'HEAD' }
+            },
+            this.props.renderMime
+          );
+        }
+      });
+    }
 
-    commands.addCommand(CommandIDs.gitFileDiffIndex, {
-      label: 'Diff',
-      caption: 'Diff selected file',
-      execute: () => {
-        openDiffView(
-          this.state.contextMenuFile,
-          this.props.app,
-          {
-            currentRef: { specialRef: 'INDEX' },
-            previousRef: { gitRef: 'HEAD' }
-          },
-          this.props.renderMime
-        );
-      }
-    });
+    if (!commands.hasCommand(CommandIDs.gitFileDiffIndex)) {
+      commands.addCommand(CommandIDs.gitFileDiffIndex, {
+        label: 'Diff',
+        caption: 'Diff selected file',
+        execute: () => {
+          openDiffView(
+            this.state.contextMenuFile,
+            this.props.app,
+            {
+              currentRef: { specialRef: 'INDEX' },
+              previousRef: { gitRef: 'HEAD' }
+            },
+            this.props.renderMime
+          );
+        }
+      });
+    }
 
-    commands.addCommand(CommandIDs.gitFileStage, {
-      label: 'Stage',
-      caption: 'Stage the changes of selected file',
-      execute: () => {
-        try {
+    if (!commands.hasCommand(CommandIDs.gitFileStage)) {
+      commands.addCommand(CommandIDs.gitFileStage, {
+        label: 'Stage',
+        caption: 'Stage the changes of selected file',
+        execute: () => {
           this.addUnstagedFile(
             this.state.contextMenuFile,
             this.props.topRepoPath,
             this.props.refresh
           );
-        } catch (err) {}
-      }
-    });
+        }
+      });
+    }
 
-    commands.addCommand(CommandIDs.gitFileTrack, {
-      label: 'Track',
-      caption: 'Start tracking selected file',
-      execute: () => {
-        try {
+    if (!commands.hasCommand(CommandIDs.gitFileTrack)) {
+      commands.addCommand(CommandIDs.gitFileTrack, {
+        label: 'Track',
+        caption: 'Start tracking selected file',
+        execute: () => {
           this.addUntrackedFile(
             this.state.contextMenuFile,
             this.props.topRepoPath,
             this.props.refresh
           );
-        } catch (err) {}
-      }
-    });
+        }
+      });
+    }
 
-    commands.addCommand(CommandIDs.gitFileUnstage, {
-      label: 'Unstage',
-      caption: 'Unstage the changes of selected file',
-      execute: () => {
-        try {
+    if (!commands.hasCommand(CommandIDs.gitFileUnstage)) {
+      commands.addCommand(CommandIDs.gitFileUnstage, {
+        label: 'Unstage',
+        caption: 'Unstage the changes of selected file',
+        execute: () => {
           if (this.state.contextMenuTypeX !== 'D') {
             this.resetStagedFile(
               this.state.contextMenuFile,
@@ -195,24 +201,24 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               this.props.refresh
             );
           }
-        } catch (err) {}
-      }
-    });
+        }
+      });
+    }
 
-    commands.addCommand(CommandIDs.gitFileDiscard, {
-      label: 'Discard',
-      caption: 'Discard recent changes of selected file',
-      execute: () => {
-        try {
+    if (!commands.hasCommand(CommandIDs.gitFileDiscard)) {
+      commands.addCommand(CommandIDs.gitFileDiscard, {
+        label: 'Discard',
+        caption: 'Discard recent changes of selected file',
+        execute: () => {
           this.updateSelectedFile(
             this.state.contextMenuIndex,
             this.state.contextMenuStage
           );
           this.updateSelectedDiscardFile(this.state.contextMenuIndex);
           this.toggleDisableFiles();
-        } catch (err) {}
-      }
-    });
+        }
+      });
+    }
 
     this.state.contextMenuStaged.addItem({ command: CommandIDs.gitFileOpen });
     this.state.contextMenuStaged.addItem({
@@ -328,6 +334,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   updateSelectedStage = (stage: string): void => {
     this.setState({ selectedStage: stage });
   };
+
   /** Open a file in the git listing */
   async openListedFile(
     typeX: string,

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
@@ -5,45 +6,44 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { Menu } from '@phosphor/widgets';
 
 import { PathExt } from '@jupyterlab/coreutils';
-
-import { Git, IGitShowPrefixResult } from '../git';
-
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import * as React from 'react';
+import { openDiffView } from './diff/DiffWidget';
 import {
-  moveFileUpButtonStyle,
+  folderFileIconSelectedStyle,
+  folderFileIconStyle,
+  genericFileIconSelectedStyle,
+  genericFileIconStyle,
+  imageFileIconSelectedStyle,
+  imageFileIconStyle,
+  jsonFileIconSelectedStyle,
+  jsonFileIconStyle,
+  kernelFileIconSelectedStyle,
+  kernelFileIconStyle,
+  markdownFileIconSelectedStyle,
+  markdownFileIconStyle,
+  moveFileDownButtonSelectedStyle,
   moveFileDownButtonStyle,
   moveFileUpButtonSelectedStyle,
-  moveFileDownButtonSelectedStyle,
-  folderFileIconStyle,
-  genericFileIconStyle,
-  yamlFileIconStyle,
-  markdownFileIconStyle,
-  imageFileIconStyle,
-  spreadsheetFileIconStyle,
-  jsonFileIconStyle,
-  pythonFileIconStyle,
-  kernelFileIconStyle,
-  folderFileIconSelectedStyle,
-  genericFileIconSelectedStyle,
-  yamlFileIconSelectedStyle,
-  markdownFileIconSelectedStyle,
-  imageFileIconSelectedStyle,
-  spreadsheetFileIconSelectedStyle,
-  jsonFileIconSelectedStyle,
+  moveFileUpButtonStyle,
   pythonFileIconSelectedStyle,
-  kernelFileIconSelectedStyle
+  pythonFileIconStyle,
+  spreadsheetFileIconSelectedStyle,
+  spreadsheetFileIconStyle,
+  yamlFileIconSelectedStyle,
+  yamlFileIconStyle
 } from '../componentsStyle/FileListStyle';
-
+import { Git, IGitShowPrefixResult } from '../git';
 import { GitStage } from './GitStage';
-
-import * as React from 'react';
 
 export namespace CommandIDs {
   export const gitFileOpen = 'gf:Open';
   export const gitFileUnstage = 'gf:Unstage';
   export const gitFileStage = 'gf:Stage';
   export const gitFileTrack = 'gf:Track';
-  export const gitFileUntrack = 'gf:Untrack';
   export const gitFileDiscard = 'gf:Discard';
+  export const gitFileDiffWorking = 'gf:DiffWorking';
+  export const gitFileDiffIndex = 'gf:DiffIndex';
 }
 
 export interface IFileListState {
@@ -79,6 +79,7 @@ export interface IFileListProps {
   refresh: any;
   sideBarExpanded: boolean;
   display: boolean;
+  renderMime: IRenderMimeRegistry;
 }
 
 export class FileList extends React.Component<IFileListProps, IFileListState> {
@@ -130,6 +131,43 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         }
       });
     }
+
+    if (!commands.hasCommand(CommandIDs.gitFileDiffWorking)) {
+      commands.addCommand(CommandIDs.gitFileDiffWorking, {
+        label: 'Diff',
+        caption: 'Diff selected file',
+        execute: () => {
+          openDiffView(
+            this.state.contextMenuFile,
+            this.props.app,
+            {
+              currentRef: { specialRef: 'WORKING' },
+              previousRef: { gitRef: 'HEAD' }
+            },
+            this.props.renderMime
+          );
+        }
+      });
+    }
+
+    if (!commands.hasCommand(CommandIDs.gitFileDiffIndex)) {
+      commands.addCommand(CommandIDs.gitFileDiffIndex, {
+        label: 'Diff',
+        caption: 'Diff selected file',
+        execute: () => {
+          openDiffView(
+            this.state.contextMenuFile,
+            this.props.app,
+            {
+              currentRef: { specialRef: 'INDEX' },
+              previousRef: { gitRef: 'HEAD' }
+            },
+            this.props.renderMime
+          );
+        }
+      });
+    }
+
     if (!commands.hasCommand(CommandIDs.gitFileStage)) {
       commands.addCommand(CommandIDs.gitFileStage, {
         label: 'Stage',
@@ -145,6 +183,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         }
       });
     }
+
     if (!commands.hasCommand(CommandIDs.gitFileTrack)) {
       commands.addCommand(CommandIDs.gitFileTrack, {
         label: 'Track',
@@ -197,6 +236,9 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     this.state.contextMenuStaged.addItem({
       command: CommandIDs.gitFileUnstage
     });
+    this.state.contextMenuStaged.addItem({
+      command: CommandIDs.gitFileDiffIndex
+    });
 
     this.state.contextMenuUnstaged.addItem({ command: CommandIDs.gitFileOpen });
     this.state.contextMenuUnstaged.addItem({
@@ -204,6 +246,9 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     });
     this.state.contextMenuUnstaged.addItem({
       command: CommandIDs.gitFileDiscard
+    });
+    this.state.contextMenuUnstaged.addItem({
+      command: CommandIDs.gitFileDiffWorking
     });
 
     this.state.contextMenuUntracked.addItem({
@@ -301,7 +346,6 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   updateSelectedStage = (stage: string): void => {
     this.setState({ selectedStage: stage });
   };
-
   /** Open a file in the git listing */
   async openListedFile(
     typeX: string,
@@ -497,6 +541,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               disableOthers={null}
               isDisabled={this.state.disableStaged}
               sideBarExpanded={this.props.sideBarExpanded}
+              renderMime={this.props.renderMime}
             />
             <GitStage
               heading={'Changed'}
@@ -530,6 +575,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               disableOthers={this.disableStagesForDiscardAll}
               isDisabled={this.state.disableUnstaged}
               sideBarExpanded={this.props.sideBarExpanded}
+              renderMime={this.props.renderMime}
             />
             <GitStage
               heading={'Untracked'}
@@ -563,6 +609,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               disableOthers={null}
               isDisabled={this.state.disableUntracked}
               sideBarExpanded={this.props.sideBarExpanded}
+              renderMime={this.props.renderMime}
             />
           </div>
         )}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -111,127 +111,112 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       disableFiles: false
     };
 
-    /** Add right-click menu options for files in repo
-     *
-     */
-
-    if (!commands.hasCommand(CommandIDs.gitFileOpen)) {
-      commands.addCommand(CommandIDs.gitFileOpen, {
-        label: 'Open',
-        caption: 'Open selected file',
-        execute: () => {
-          try {
-            this.openListedFile(
-              this.state.contextMenuTypeX,
-              this.state.contextMenuTypeY,
-              this.state.contextMenuFile,
-              this.props.app
-            );
-          } catch (err) {}
-        }
-      });
-    }
-
-    if (!commands.hasCommand(CommandIDs.gitFileDiffWorking)) {
-      commands.addCommand(CommandIDs.gitFileDiffWorking, {
-        label: 'Diff',
-        caption: 'Diff selected file',
-        execute: () => {
-          openDiffView(
+    commands.addCommand(CommandIDs.gitFileOpen, {
+      label: 'Open',
+      caption: 'Open selected file',
+      execute: async () => {
+        try {
+          await this.openListedFile(
+            this.state.contextMenuTypeX,
+            this.state.contextMenuTypeY,
             this.state.contextMenuFile,
-            this.props.app,
-            {
-              currentRef: { specialRef: 'WORKING' },
-              previousRef: { gitRef: 'HEAD' }
-            },
-            this.props.renderMime
+            this.props.app
           );
-        }
-      });
-    }
+        } catch (err) {}
+      }
+    });
 
-    if (!commands.hasCommand(CommandIDs.gitFileDiffIndex)) {
-      commands.addCommand(CommandIDs.gitFileDiffIndex, {
-        label: 'Diff',
-        caption: 'Diff selected file',
-        execute: () => {
-          openDiffView(
+    commands.addCommand(CommandIDs.gitFileDiffWorking, {
+      label: 'Diff',
+      caption: 'Diff selected file',
+      execute: () => {
+        openDiffView(
+          this.state.contextMenuFile,
+          this.props.app,
+          {
+            currentRef: { specialRef: 'WORKING' },
+            previousRef: { gitRef: 'HEAD' }
+          },
+          this.props.renderMime
+        );
+      }
+    });
+
+    commands.addCommand(CommandIDs.gitFileDiffIndex, {
+      label: 'Diff',
+      caption: 'Diff selected file',
+      execute: () => {
+        openDiffView(
+          this.state.contextMenuFile,
+          this.props.app,
+          {
+            currentRef: { specialRef: 'INDEX' },
+            previousRef: { gitRef: 'HEAD' }
+          },
+          this.props.renderMime
+        );
+      }
+    });
+
+    commands.addCommand(CommandIDs.gitFileStage, {
+      label: 'Stage',
+      caption: 'Stage the changes of selected file',
+      execute: () => {
+        try {
+          this.addUnstagedFile(
             this.state.contextMenuFile,
-            this.props.app,
-            {
-              currentRef: { specialRef: 'INDEX' },
-              previousRef: { gitRef: 'HEAD' }
-            },
-            this.props.renderMime
+            this.props.topRepoPath,
+            this.props.refresh
           );
-        }
-      });
-    }
+        } catch (err) {}
+      }
+    });
 
-    if (!commands.hasCommand(CommandIDs.gitFileStage)) {
-      commands.addCommand(CommandIDs.gitFileStage, {
-        label: 'Stage',
-        caption: 'Stage the changes of selected file',
-        execute: () => {
-          try {
-            this.addUnstagedFile(
+    commands.addCommand(CommandIDs.gitFileTrack, {
+      label: 'Track',
+      caption: 'Start tracking selected file',
+      execute: () => {
+        try {
+          this.addUntrackedFile(
+            this.state.contextMenuFile,
+            this.props.topRepoPath,
+            this.props.refresh
+          );
+        } catch (err) {}
+      }
+    });
+
+    commands.addCommand(CommandIDs.gitFileUnstage, {
+      label: 'Unstage',
+      caption: 'Unstage the changes of selected file',
+      execute: () => {
+        try {
+          if (this.state.contextMenuTypeX !== 'D') {
+            this.resetStagedFile(
               this.state.contextMenuFile,
               this.props.topRepoPath,
               this.props.refresh
             );
-          } catch (err) {}
-        }
-      });
-    }
+          }
+        } catch (err) {}
+      }
+    });
 
-    if (!commands.hasCommand(CommandIDs.gitFileTrack)) {
-      commands.addCommand(CommandIDs.gitFileTrack, {
-        label: 'Track',
-        caption: 'Start tracking selected file',
-        execute: () => {
-          try {
-            this.addUntrackedFile(
-              this.state.contextMenuFile,
-              this.props.topRepoPath,
-              this.props.refresh
-            );
-          } catch (err) {}
-        }
-      });
-    }
-    if (!commands.hasCommand(CommandIDs.gitFileUnstage)) {
-      commands.addCommand(CommandIDs.gitFileUnstage, {
-        label: 'Unstage',
-        caption: 'Unstage the changes of selected file',
-        execute: () => {
-          try {
-            if (this.state.contextMenuTypeX !== 'D') {
-              this.resetStagedFile(
-                this.state.contextMenuFile,
-                this.props.topRepoPath,
-                this.props.refresh
-              );
-            }
-          } catch (err) {}
-        }
-      });
-    }
-    if (!commands.hasCommand(CommandIDs.gitFileDiscard)) {
-      commands.addCommand(CommandIDs.gitFileDiscard, {
-        label: 'Discard',
-        caption: 'Discard recent changes of selected file',
-        execute: () => {
-          try {
-            this.updateSelectedFile(
-              this.state.contextMenuIndex,
-              this.state.contextMenuStage
-            );
-            this.updateSelectedDiscardFile(this.state.contextMenuIndex);
-            this.toggleDisableFiles();
-          } catch (err) {}
-        }
-      });
-    }
+    commands.addCommand(CommandIDs.gitFileDiscard, {
+      label: 'Discard',
+      caption: 'Discard recent changes of selected file',
+      execute: () => {
+        try {
+          this.updateSelectedFile(
+            this.state.contextMenuIndex,
+            this.state.contextMenuStage
+          );
+          this.updateSelectedDiscardFile(this.state.contextMenuIndex);
+          this.toggleDisableFiles();
+        } catch (err) {}
+      }
+    });
+
     this.state.contextMenuStaged.addItem({ command: CommandIDs.gitFileOpen });
     this.state.contextMenuStaged.addItem({
       command: CommandIDs.gitFileUnstage

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -27,6 +27,7 @@ import {
   panelWarningStyle,
   findRepoButtonStyle
 } from '../componentsStyle/GitPanelStyle';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 /** Interface for GitPanel component state */
 export interface IGitSessionNodeState {
@@ -54,6 +55,7 @@ export interface IGitSessionNodeState {
 export interface IGitSessionNodeProps {
   app: JupyterFrontEnd;
   diff: IDiffCallback;
+  renderMime: IRenderMimeRegistry;
 }
 
 /** A React component for the git extension's main display */
@@ -238,6 +240,7 @@ export class GitPanel extends React.Component<
             app={this.props.app}
             refresh={this.refresh}
             diff={this.props.diff}
+            renderMime={this.props.renderMime}
           />
           <PastCommits
             currentFileBrowserPath={this.state.currentFileBrowserPath}
@@ -251,6 +254,7 @@ export class GitPanel extends React.Component<
             refresh={this.refresh}
             diff={this.props.diff}
             sideBarExpanded={this.state.sideBarExpanded}
+            renderMime={this.props.renderMime}
           />
         </div>
       );

--- a/src/components/GitStage.tsx
+++ b/src/components/GitStage.tsx
@@ -21,6 +21,7 @@ import { classes } from 'typestyle';
 import * as React from 'react';
 
 import { showDialog, Dialog } from '@jupyterlab/apputils';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 export interface IGitStageProps {
   heading: string;
@@ -54,6 +55,7 @@ export interface IGitStageProps {
   isDisabled: boolean;
   disableOthers: Function;
   sideBarExpanded: boolean;
+  renderMime: IRenderMimeRegistry;
 }
 
 export interface IGitStageState {
@@ -187,6 +189,7 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
                     disableFile={this.props.disableFiles}
                     toggleDisableFiles={this.props.toggleDisableFiles}
                     sideBarExpanded={this.props.sideBarExpanded}
+                    renderMime={this.props.renderMime}
                   />
                 );
               }

--- a/src/components/GitWidget.tsx
+++ b/src/components/GitWidget.tsx
@@ -18,6 +18,7 @@ import { gitWidgetStyle } from '../componentsStyle/GitWidgetStyle';
 
 import { IDiffCallback } from '../git';
 
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 /**
  * An options object for creating a running sessions widget.
  */
@@ -69,13 +70,16 @@ export class GitWidget extends Widget {
   constructor(
     app: JupyterFrontEnd,
     options: IOptions,
-    diffFunction: IDiffCallback
+    diffFunction: IDiffCallback,
+    renderMime: IRenderMimeRegistry
   ) {
     super({
       node: (options.renderer || defaultRenderer).createNode()
     });
     this.addClass(gitWidgetStyle);
-    const element = <GitPanel app={app} diff={diffFunction} />;
+    const element = (
+      <GitPanel app={app} diff={diffFunction} renderMime={renderMime} />
+    );
     this.component = ReactDOM.render(element, this.node);
     this.component.refresh();
   }

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { historySideBarStyle } from '../componentsStyle/HistorySideBarStyle';
 import { IGitBranchResult, ISingleCommitInfo, IDiffCallback } from '../git';
 import { PastCommitNode } from './PastCommitNode';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 /** Interface for PastCommits component props */
 export interface IHistorySideBarProps {
@@ -13,6 +14,7 @@ export interface IHistorySideBarProps {
   app: JupyterFrontEnd;
   refresh: () => void;
   diff: IDiffCallback;
+  renderMime: IRenderMimeRegistry;
 }
 
 export class HistorySideBar extends React.Component<IHistorySideBarProps, {}> {
@@ -32,6 +34,7 @@ export class HistorySideBar extends React.Component<IHistorySideBarProps, {}> {
               app={this.props.app}
               refresh={this.props.refresh}
               diff={this.props.diff}
+              renderMime={this.props.renderMime}
             />
           )
         )}

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -16,6 +16,7 @@ import {
 } from '../componentsStyle/PastCommitNodeStyle';
 import { IGitBranchResult, ISingleCommitInfo, IDiffCallback } from '../git';
 import { SinglePastCommitInfo } from './SinglePastCommitInfo';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 export interface IPastCommitNodeProps {
   pastCommit: ISingleCommitInfo;
@@ -24,6 +25,7 @@ export interface IPastCommitNodeProps {
   app: JupyterFrontEnd;
   diff: IDiffCallback;
   refresh: () => void;
+  renderMime: IRenderMimeRegistry;
 }
 
 export interface IPastCommitNodeState {
@@ -115,6 +117,7 @@ export class PastCommitNode extends React.Component<
                 app={this.props.app}
                 diff={this.props.diff}
                 refresh={this.props.refresh}
+                renderMime={this.props.renderMime}
               />
               <div className={collapseStyle} onClick={() => this.collapse()}>
                 Collapse

--- a/src/components/PastCommits.tsx
+++ b/src/components/PastCommits.tsx
@@ -7,6 +7,7 @@ import { pastCommitsContainerStyle } from '../componentsStyle/PastCommitsStyle';
 import { IDiffCallback } from '../git';
 
 import * as React from 'react';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 /** Interface for PastCommits component props */
 export interface IPastCommitsProps {
@@ -21,6 +22,7 @@ export interface IPastCommitsProps {
   refresh: any;
   diff: IDiffCallback;
   sideBarExpanded: boolean;
+  renderMime: IRenderMimeRegistry;
 }
 
 export class PastCommits extends React.Component<IPastCommitsProps, {}> {
@@ -40,6 +42,7 @@ export class PastCommits extends React.Component<IPastCommitsProps, {}> {
           refresh={this.props.refresh}
           sideBarExpanded={this.props.sideBarExpanded}
           display={this.props.showList}
+          renderMime={this.props.renderMime}
         />
       </div>
     );

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -14,6 +14,7 @@ import {
   commitOverviewNumbers,
   commitStyle,
   deletionIconStyle,
+  diffIconStyle,
   floatRightStyle,
   iconStyle,
   insertionIconStyle,
@@ -28,12 +29,16 @@ import {
 } from '../git';
 import { parseFileExtension } from './FileList';
 import { ResetDeleteSingleCommit } from './ResetDeleteSingleCommit';
+import { openDiffView } from './diff/DiffWidget';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { isDiffSupported } from './diff/Diff';
 
 export interface ISinglePastCommitInfoProps {
   topRepoPath: string;
   data: ISingleCommitInfo;
   app: JupyterFrontEnd;
   diff: IDiffCallback;
+  renderMime: IRenderMimeRegistry;
 
   refresh: () => void;
 }
@@ -205,18 +210,26 @@ export class SinglePastCommitInfo extends React.Component<
                       );
                     }}
                   />
-                  <span
-                    className={commitDetailFilePathStyle}
-                    onDoubleClick={() => {
-                      this.props.diff(
-                        modifiedFile.modified_file_path,
-                        this.props.data.commit,
-                        this.props.data.pre_commit
-                      );
-                    }}
-                  >
+                  <span className={commitDetailFilePathStyle}>
                     {modifiedFile.modified_file_name}
                   </span>
+                  {isDiffSupported(modifiedFile.modified_file_path) && (
+                    <button
+                      className={`${diffIconStyle}`}
+                      title={'View file changes'}
+                      onClick={() => {
+                        openDiffView(
+                          modifiedFile.modified_file_path,
+                          this.props.app,
+                          {
+                            previousRef: { gitRef: this.props.data.pre_commit },
+                            currentRef: { gitRef: this.props.data.commit }
+                          },
+                          this.props.renderMime
+                        );
+                      }}
+                    />
+                  )}
                 </li>
               );
             })}

--- a/src/components/diff/Diff.tsx
+++ b/src/components/diff/Diff.tsx
@@ -24,7 +24,6 @@ export function isDiffSupported(path: string): boolean {
 }
 
 export interface IDiffProps {
-  renderMime: IRenderMimeRegistry;
   path: string;
   diffContext: IDiffContext;
 }
@@ -33,22 +32,20 @@ export interface IDiffProps {
  * The parent diff component which maintains a registry of various diff providers.
  * Based on the extension of the file, it delegates to the relevant diff provider.
  */
-export class Diff extends React.Component<IDiffProps, {}> {
-  constructor(props) {
-    super(props);
-  }
+export function Diff(props: IDiffProps) {
+  const fileExtension = PathExt.extname(props.path).toLocaleLowerCase();
 
-  render() {
-    const fileExtension = PathExt.extname(this.props.path).toLocaleLowerCase();
-
-    if (fileExtension in DIFF_PROVIDER_REGISTRY) {
-      const DiffProvider = DIFF_PROVIDER_REGISTRY[fileExtension];
-      return <DiffProvider {...this.props} />;
-    } else {
-      // This will be removed and delegated to a "Plaintext" diff provider for
-      // cases where the file extension does not have a dedicated diff provider.
-      console.log(`Diff is not supported for ${fileExtension} files`);
-      return null;
-    }
+  if (fileExtension in DIFF_PROVIDER_REGISTRY) {
+    const DiffProvider = DIFF_PROVIDER_REGISTRY[fileExtension];
+    return <DiffProvider {...props} />;
+  } else {
+    // This will be removed and delegated to a "Plaintext" diff provider for
+    // cases where the file extension does not have a dedicated diff provider.
+    console.log(`Diff is not supported for ${fileExtension} files`);
+    return null;
   }
 }
+
+const renderMimeContext = React.createContext<IRenderMimeRegistry | null>(null);
+export const RenderMimeProvider = renderMimeContext.Provider;
+export const RenderMimeConsumer = renderMimeContext.Consumer;

--- a/src/components/diff/Diff.tsx
+++ b/src/components/diff/Diff.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { IDiffContext } from './model';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { NBDiff } from './NbDiff';
+import { PathExt } from '@jupyterlab/coreutils';
+
+/**
+ * A registry which maintains mappings of file extension to diff provider components.
+ */
+const DIFF_PROVIDER_REGISTRY = {
+  '.ipynb': NBDiff
+};
+
+/**
+ * Determines if a given file is supported for diffs.
+ *
+ * This will be removed when "Plaintext" diffs are supported since that will be used
+ * for cases where there is not a dedicated diff provider.
+ *
+ * @param path the file path
+ */
+export function isDiffSupported(path: string): boolean {
+  return PathExt.extname(path).toLocaleLowerCase() in DIFF_PROVIDER_REGISTRY;
+}
+
+export interface IDiffProps {
+  renderMime: IRenderMimeRegistry;
+  path: string;
+  diffContext: IDiffContext;
+}
+
+/**
+ * The parent diff component which maintains a registry of various diff providers.
+ * Based on the extension of the file, it delegates to the relevant diff provider.
+ */
+export class Diff extends React.Component<IDiffProps, {}> {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const fileExtension = PathExt.extname(this.props.path).toLocaleLowerCase();
+
+    if (fileExtension in DIFF_PROVIDER_REGISTRY) {
+      const DiffProvider = DIFF_PROVIDER_REGISTRY[fileExtension];
+      return <DiffProvider {...this.props} />;
+    } else {
+      // This will be removed and delegated to a "Plaintext" diff provider for
+      // cases where the file extension does not have a dedicated diff provider.
+      console.log(`Diff is not supported for ${fileExtension} files`);
+      return null;
+    }
+  }
+}

--- a/src/components/diff/DiffWidget.tsx
+++ b/src/components/diff/DiffWidget.tsx
@@ -1,0 +1,98 @@
+import { Widget } from '@phosphor/widgets';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+
+import { getRefValue, IDiffContext } from './model';
+import { Diff, isDiffSupported } from './Diff';
+import { JupyterLab } from '@jupyterlab/application';
+import { showDialog } from '@jupyterlab/apputils';
+import { PathExt } from '@jupyterlab/coreutils';
+import { style } from 'typestyle';
+
+export class DiffWidget extends Widget {
+  private readonly _renderMime: IRenderMimeRegistry;
+  private readonly _path: string;
+  private readonly _gitContext: IDiffContext;
+
+  constructor(
+    renderMime: IRenderMimeRegistry,
+    path: string,
+    gitContext: IDiffContext
+  ) {
+    super();
+    this._renderMime = renderMime;
+    this._path = path;
+    this._gitContext = gitContext;
+
+    this.title.label = PathExt.basename(path);
+    this.title.iconClass = style({
+      backgroundImage: 'var(--jp-icon-diff)'
+    });
+    this.title.closable = true;
+    this.addClass('jp-git-diff-parent-diff-widget');
+
+    ReactDOM.render(
+      <Diff
+        renderMime={this._renderMime}
+        path={this._path}
+        diffContext={this._gitContext}
+      />,
+      this.node
+    );
+  }
+
+  onUpdateRequest(): void {
+    ReactDOM.unmountComponentAtNode(this.node);
+    ReactDOM.render(
+      <Diff
+        renderMime={this._renderMime}
+        path={this._path}
+        diffContext={this._gitContext}
+      />,
+      this.node
+    );
+  }
+}
+
+/**
+ * Method to open a main menu panel to show the diff of a given Notebook file.
+ * If one already exists, just activates the existing one.
+ *
+ * @param path the path relative to the Jupyter server root.
+ * @param app The JupyterLab application instance
+ * @param diffContext the context in which the diff is being requested
+ * @param renderMime the renderMime registry instance from the
+ */
+export function openDiffView(
+  path: string,
+  app: JupyterLab,
+  diffContext: IDiffContext,
+  renderMime: IRenderMimeRegistry
+) {
+  if (isDiffSupported(path)) {
+    const id = `nbdiff-${path}-${getRefValue(diffContext.currentRef)}`;
+    let mainAreaItems = app.shell.widgets('main');
+    let mainAreaItem = mainAreaItems.next();
+    while (mainAreaItem) {
+      if (mainAreaItem.id === id) {
+        app.shell.activateById(id);
+        break;
+      }
+      mainAreaItem = mainAreaItems.next();
+    }
+    if (!mainAreaItem) {
+      const nbDiffWidget = new DiffWidget(renderMime, path, diffContext);
+      nbDiffWidget.id = id;
+      app.shell.addToMainArea(nbDiffWidget);
+      app.shell.activateById(nbDiffWidget.id);
+    }
+  } else {
+    showDialog({
+      title: 'Diff Not Supported',
+      body: `Diff is not supported for ${PathExt.extname(
+        path
+      ).toLocaleLowerCase()} files.`
+    });
+  }
+}

--- a/src/components/diff/DiffWidget.tsx
+++ b/src/components/diff/DiffWidget.tsx
@@ -5,7 +5,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 import { getRefValue, IDiffContext } from './model';
 import { Diff, isDiffSupported, RenderMimeProvider } from './Diff';
-import { JupyterLab } from '@jupyterlab/application';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 import { showDialog } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
 import { style } from 'typestyle';
@@ -62,7 +62,7 @@ export class DiffWidget extends Widget {
  */
 export function openDiffView(
   path: string,
-  app: JupyterLab,
+  app: JupyterFrontEnd,
   diffContext: IDiffContext,
   renderMime: IRenderMimeRegistry
 ) {
@@ -80,7 +80,7 @@ export function openDiffView(
     if (!mainAreaItem) {
       const nbDiffWidget = new DiffWidget(renderMime, path, diffContext);
       nbDiffWidget.id = id;
-      app.shell.addToMainArea(nbDiffWidget);
+      app.shell.add(nbDiffWidget, 'main');
       app.shell.activateById(nbDiffWidget.id);
     }
   } else {

--- a/src/components/diff/DiffWidget.tsx
+++ b/src/components/diff/DiffWidget.tsx
@@ -4,7 +4,7 @@ import * as ReactDOM from 'react-dom';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 import { getRefValue, IDiffContext } from './model';
-import { Diff, isDiffSupported } from './Diff';
+import { Diff, isDiffSupported, RenderMimeProvider } from './Diff';
 import { JupyterLab } from '@jupyterlab/application';
 import { showDialog } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
@@ -13,7 +13,7 @@ import { style } from 'typestyle';
 export class DiffWidget extends Widget {
   private readonly _renderMime: IRenderMimeRegistry;
   private readonly _path: string;
-  private readonly _gitContext: IDiffContext;
+  private readonly _diffContext: IDiffContext;
 
   constructor(
     renderMime: IRenderMimeRegistry,
@@ -23,7 +23,7 @@ export class DiffWidget extends Widget {
     super();
     this._renderMime = renderMime;
     this._path = path;
-    this._gitContext = gitContext;
+    this._diffContext = gitContext;
 
     this.title.label = PathExt.basename(path);
     this.title.iconClass = style({
@@ -33,11 +33,9 @@ export class DiffWidget extends Widget {
     this.addClass('jp-git-diff-parent-diff-widget');
 
     ReactDOM.render(
-      <Diff
-        renderMime={this._renderMime}
-        path={this._path}
-        diffContext={this._gitContext}
-      />,
+      <RenderMimeProvider value={this._renderMime}>
+        <Diff path={this._path} diffContext={this._diffContext} />
+      </RenderMimeProvider>,
       this.node
     );
   }
@@ -45,11 +43,9 @@ export class DiffWidget extends Widget {
   onUpdateRequest(): void {
     ReactDOM.unmountComponentAtNode(this.node);
     ReactDOM.render(
-      <Diff
-        renderMime={this._renderMime}
-        path={this._path}
-        diffContext={this._gitContext}
-      />,
+      <RenderMimeProvider value={this._renderMime}>
+        <Diff path={this._path} diffContext={this._diffContext} />
+      </RenderMimeProvider>,
       this.node
     );
   }

--- a/src/components/diff/DiffWidget.tsx
+++ b/src/components/diff/DiffWidget.tsx
@@ -1,55 +1,12 @@
-import { Widget } from '@phosphor/widgets';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 import { getRefValue, IDiffContext } from './model';
 import { Diff, isDiffSupported, RenderMimeProvider } from './Diff';
 import { JupyterFrontEnd } from '@jupyterlab/application';
-import { showDialog } from '@jupyterlab/apputils';
+import { ReactWidget, showDialog } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
 import { style } from 'typestyle';
-
-export class DiffWidget extends Widget {
-  private readonly _renderMime: IRenderMimeRegistry;
-  private readonly _path: string;
-  private readonly _diffContext: IDiffContext;
-
-  constructor(
-    renderMime: IRenderMimeRegistry,
-    path: string,
-    gitContext: IDiffContext
-  ) {
-    super();
-    this._renderMime = renderMime;
-    this._path = path;
-    this._diffContext = gitContext;
-
-    this.title.label = PathExt.basename(path);
-    this.title.iconClass = style({
-      backgroundImage: 'var(--jp-icon-diff)'
-    });
-    this.title.closable = true;
-    this.addClass('jp-git-diff-parent-diff-widget');
-
-    ReactDOM.render(
-      <RenderMimeProvider value={this._renderMime}>
-        <Diff path={this._path} diffContext={this._diffContext} />
-      </RenderMimeProvider>,
-      this.node
-    );
-  }
-
-  onUpdateRequest(): void {
-    ReactDOM.unmountComponentAtNode(this.node);
-    ReactDOM.render(
-      <RenderMimeProvider value={this._renderMime}>
-        <Diff path={this._path} diffContext={this._diffContext} />
-      </RenderMimeProvider>,
-      this.node
-    );
-  }
-}
 
 /**
  * Method to open a main menu panel to show the diff of a given Notebook file.
@@ -78,8 +35,19 @@ export function openDiffView(
       mainAreaItem = mainAreaItems.next();
     }
     if (!mainAreaItem) {
-      const nbDiffWidget = new DiffWidget(renderMime, path, diffContext);
+      const nbDiffWidget = ReactWidget.create(
+        <RenderMimeProvider value={renderMime}>
+          <Diff path={path} diffContext={diffContext} />
+        </RenderMimeProvider>
+      );
       nbDiffWidget.id = id;
+      nbDiffWidget.title.label = PathExt.basename(path);
+      nbDiffWidget.title.iconClass = style({
+        backgroundImage: 'var(--jp-icon-diff)'
+      });
+      nbDiffWidget.title.closable = true;
+      nbDiffWidget.addClass('jp-git-diff-parent-diff-widget');
+
       app.shell.add(nbDiffWidget, 'main');
       app.shell.activateById(nbDiffWidget.id);
     }

--- a/src/components/diff/NBDiffHeader.tsx
+++ b/src/components/diff/NBDiffHeader.tsx
@@ -11,46 +11,38 @@ export interface INBDiffHeaderProps {
  * being rendered. Shows the path to the file and the previous and current ref
  * being used for the diff.
  */
-export class NBDiffHeader extends React.Component<INBDiffHeaderProps, {}> {
-  constructor(props: INBDiffHeaderProps) {
-    super(props);
-  }
-
-  render() {
-    return (
-      <div>
-        <div className="jp-git-diff-header-path">{this.props.path}</div>
-        <div className="jp-Diff-addremchunk jp-git-diff-header">
-          <div className="jp-Diff-addedchunk">
-            Current:{' '}
-            {this.getRefDisplayValue(this.props.diffContext.currentRef)}
-          </div>
-          <div className="jp-Diff-removedchunk">
-            Previous:{' '}
-            {this.getRefDisplayValue(this.props.diffContext.previousRef)}
-          </div>
+export function NBDiffHeader(props: INBDiffHeaderProps) {
+  return (
+    <div>
+      <div className="jp-git-diff-header-path">{props.path}</div>
+      <div className="jp-Diff-addremchunk jp-git-diff-header">
+        <div className="jp-Diff-addedchunk">
+          Current: {getRefDisplayValue(props.diffContext.currentRef)}
+        </div>
+        <div className="jp-Diff-removedchunk">
+          Previous: {getRefDisplayValue(props.diffContext.previousRef)}
         </div>
       </div>
-    );
-  }
+    </div>
+  );
+}
 
-  /**
-   * Utility method to get a user-friendly display text for a given ref.
-   */
-  private getRefDisplayValue = (ref: ISpecialRef | IGitRef): string => {
-    const SPECIAL_REFS = {
-      WORKING: {
-        displayName: 'Changed'
-      },
-      INDEX: {
-        displayName: 'Staged'
-      }
-    };
-
-    if ('specialRef' in ref) {
-      return SPECIAL_REFS[ref.specialRef].displayName;
-    } else {
-      return ref.gitRef;
+/**
+ * Utility method to get a user-friendly display text for a given ref.
+ */
+function getRefDisplayValue(ref: ISpecialRef | IGitRef): string {
+  const SPECIAL_REFS = {
+    WORKING: {
+      displayName: 'Changed'
+    },
+    INDEX: {
+      displayName: 'Staged'
     }
   };
+
+  if ('specialRef' in ref) {
+    return SPECIAL_REFS[ref.specialRef].displayName;
+  } else {
+    return ref.gitRef;
+  }
 }

--- a/src/components/diff/NBDiffHeader.tsx
+++ b/src/components/diff/NBDiffHeader.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { IDiffContext, IGitRef, ISpecialRef } from './model';
+
+export interface INBDiffHeaderProps {
+  path: string;
+  diffContext: IDiffContext;
+}
+
+/**
+ * A React component to render the header which shows metadata around the diff
+ * being rendered. Shows the path to the file and the previous and current ref
+ * being used for the diff.
+ */
+export class NBDiffHeader extends React.Component<INBDiffHeaderProps, {}> {
+  constructor(props: INBDiffHeaderProps) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="jp-git-diff-header-path">{this.props.path}</div>
+        <div className="jp-Diff-addremchunk jp-git-diff-header">
+          <div className="jp-Diff-addedchunk">
+            Current:{' '}
+            {this.getRefDisplayValue(this.props.diffContext.currentRef)}
+          </div>
+          <div className="jp-Diff-removedchunk">
+            Previous:{' '}
+            {this.getRefDisplayValue(this.props.diffContext.previousRef)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * Utility method to get a user-friendly display text for a given ref.
+   */
+  private getRefDisplayValue = (ref: ISpecialRef | IGitRef): string => {
+    const SPECIAL_REFS = {
+      WORKING: {
+        displayName: 'Changed'
+      },
+      INDEX: {
+        displayName: 'Staged'
+      }
+    };
+
+    if ('specialRef' in ref) {
+      return SPECIAL_REFS[ref.specialRef].displayName;
+    } else {
+      return ref.gitRef;
+    }
+  };
+}

--- a/src/components/diff/NbDiff.tsx
+++ b/src/components/diff/NbDiff.tsx
@@ -1,0 +1,201 @@
+import { nbformat } from '@jupyterlab/coreutils';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ServerConnection } from '@jupyterlab/services/lib/serverconnection';
+import { IDiffEntry } from 'nbdime/lib/diff/diffentries';
+import { CellDiffModel, NotebookDiffModel } from 'nbdime/lib/diff/model';
+import { CellDiffWidget } from 'nbdime/lib/diff/widget';
+import * as React from 'react';
+import { RefObject } from 'react';
+import { httpGitRequest } from '../../git';
+import { IDiffContext } from './model';
+import { NBDiffHeader } from './NBDiffHeader';
+import { IDiffProps } from './Diff';
+
+export interface ICellDiffProps {
+  renderMime: IRenderMimeRegistry;
+  cellChunk: CellDiffModel[];
+  mimeType: string;
+}
+
+/**
+ * A React component which renders the diff is a single Notebook cell.
+ *
+ * This uses the NBDime PhosporJS CellDiffWidget internally. To get around the
+ * PhosporJS <=> ReactJS barrier, it uses React Refs(https://reactjs.org/docs/refs-and-the-dom.html)
+ *
+ * During component render, a Ref is created for the ReactDOM and after the component
+ * is mounted, the PhosporJS widget is created and attached to the Ref.
+ */
+export class CellDiff extends React.Component<ICellDiffProps, {}> {
+  private unAddedOrRemovedRef: RefObject<HTMLDivElement> = React.createRef<
+    HTMLDivElement
+  >();
+  private addedRef: RefObject<HTMLDivElement> = React.createRef<
+    HTMLDivElement
+  >();
+  private removedRef: RefObject<HTMLDivElement> = React.createRef<
+    HTMLDivElement
+  >();
+
+  constructor(props: ICellDiffProps) {
+    super(props);
+    this.state = {};
+  }
+
+  componentDidMount(): void {
+    const chunk = this.props.cellChunk;
+
+    if (chunk.length === 1 && !(chunk[0].added || chunk[0].deleted)) {
+      const widget = new CellDiffWidget(
+        chunk[0],
+        this.props.renderMime,
+        this.props.mimeType
+      );
+      this.unAddedOrRemovedRef.current.appendChild(widget.node);
+    } else {
+      for (let j = 0; j < chunk.length; j++) {
+        const cell = chunk[j];
+        const ref = cell.deleted ? this.removedRef : this.addedRef;
+        const widget = new CellDiffWidget(
+          cell,
+          this.props.renderMime,
+          this.props.mimeType
+        );
+        ref.current.appendChild(widget.node);
+      }
+    }
+  }
+
+  render() {
+    const chunk = this.props.cellChunk;
+    return (
+      <React.Fragment>
+        {chunk.length === 1 && !(chunk[0].added || chunk[0].deleted) ? (
+          <div ref={this.unAddedOrRemovedRef} />
+        ) : (
+          <div className={'jp-Diff-addremchunk'}>
+            <div className={'jp-Diff-addedchunk'} ref={this.addedRef} />
+            <div className={'jp-Diff-removedchunk'} ref={this.removedRef} />
+          </div>
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+export interface INBDiffState {
+  nbdModel: NotebookDiffModel;
+  errorMessage: string;
+}
+
+/**
+ * A React component to render the diff of a single Notebook file.
+ *
+ * 1. It calls the `/nbdime/api/gitdiff` API on the server to get the diff model
+ * 2. Renders the Diff header
+ * 3. For each cell, invokes the CellDiff component
+ */
+export class NBDiff extends React.Component<IDiffProps, INBDiffState> {
+  constructor(props: IDiffProps) {
+    super(props);
+    this.state = {
+      nbdModel: undefined,
+      errorMessage: undefined
+    };
+    this.performDiff(props.diffContext);
+  }
+
+  render() {
+    if (this.state.errorMessage !== undefined) {
+      return (
+        <div>
+          <span className="jp-git-diff-error">
+            Failed to fetch diff with error:
+            <span className="jp-git-diff-error-message">
+              {this.state.errorMessage}
+            </span>
+          </span>
+        </div>
+      );
+    } else if (this.state.nbdModel !== undefined) {
+      const cellComponents = this.state.nbdModel.chunkedCells.map(
+        (cellChunk, index) => (
+          <CellDiff
+            key={index}
+            cellChunk={cellChunk}
+            renderMime={this.props.renderMime}
+            mimeType={this.state.nbdModel.mimetype}
+          />
+        )
+      );
+      return (
+        <div className="jp-git-diff-Widget">
+          <div className="jp-git-diff-root jp-mod-hideunchanged">
+            <div className="jp-git-Notebook-diff">
+              <NBDiffHeader {...this.props} />
+              {cellComponents}
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Based on the Diff Context , calls the server API with the revant paremeters
+   * to
+   * @param diffContext the context in which to perform the diff
+   */
+  private performDiff(diffContext: IDiffContext): void {
+    try {
+      // Resolve what API parameter to call.
+      let currentRefValue;
+      if ('specialRef' in diffContext.currentRef) {
+        currentRefValue = {
+          special: diffContext.currentRef.specialRef
+        };
+      } else {
+        currentRefValue = {
+          git: diffContext.currentRef.gitRef
+        };
+      }
+
+      httpGitRequest('/nbdime/api/gitdiff', 'POST', {
+        file_path: this.props.path,
+        ref_prev: { git: diffContext.previousRef.gitRef },
+        ref_curr: currentRefValue
+      }).then((response: Response) => {
+        response
+          .json()
+          .then((data: any) => {
+            if (response.status !== 200) {
+              // Handle error
+              this.setState({
+                errorMessage:
+                  data.message || 'Unknown error. Please check the server log.'
+              });
+            } else {
+              // Handle response
+              let base = data['base'] as nbformat.INotebookContent;
+              let diff = (data['diff'] as any) as IDiffEntry[];
+              let nbdModel = new NotebookDiffModel(base, diff);
+              this.setState({
+                nbdModel: nbdModel
+              });
+            }
+          })
+          .catch(reason => {
+            // Handle error
+            this.setState({
+              errorMessage:
+                reason.message || 'Unknown error. Please check the server log.'
+            });
+          });
+      });
+    } catch (err) {
+      throw ServerConnection.NetworkError;
+    }
+  }
+}

--- a/src/components/diff/NbDiff.tsx
+++ b/src/components/diff/NbDiff.tsx
@@ -173,8 +173,8 @@ export class NBDiff extends React.Component<IDiffProps, INBDiffState> {
 
       httpGitRequest('/nbdime/api/gitdiff', 'POST', {
         file_path: this.props.path,
-        ref_prev: { git: diffContext.previousRef.gitRef },
-        ref_curr: currentRefValue
+        ref_local: { git: diffContext.previousRef.gitRef },
+        ref_remote: currentRefValue
       }).then((response: Response) => {
         response
           .json()

--- a/src/components/diff/model.ts
+++ b/src/components/diff/model.ts
@@ -1,0 +1,36 @@
+/**
+ * Model which indicates the context in which a Git diff is being performed.
+ */
+export interface IDiffContext {
+  currentRef: IGitRef | ISpecialRef;
+  previousRef: IGitRef;
+}
+
+/**
+ * Model which defines a regular Git ref, i.e, https://git-scm.com/book/en/v2/Git-Internals-Git-References
+ */
+export interface IGitRef {
+  gitRef: string;
+}
+
+/**
+ * Model which defines special/reserved references to differentiate them from other Git refs with the
+ * same name. Currently, there are two values
+ *
+ * 1. WORKING: The Working Tree
+ * 2. INDEX: The Staging Area
+ */
+export interface ISpecialRef {
+  specialRef: 'WORKING' | 'INDEX';
+}
+
+/**
+ * Utility method to get the string value of any type of ref.
+ */
+export function getRefValue(ref: ISpecialRef | IGitRef): string {
+  if ('specialRef' in ref) {
+    return ref.specialRef;
+  } else {
+    return ref.gitRef;
+  }
+}

--- a/src/componentsStyle/FileItemStyle.tsx
+++ b/src/componentsStyle/FileItemStyle.tsx
@@ -83,12 +83,6 @@ export const fileChangedLabelInfoStyle = style({
   color: 'var(--jp-info-color0)'
 });
 
-export const discardWarningStyle = style({
-  color: 'var(--jp-ui-font-color1)',
-  marginLeft: '20px',
-  height: '50px'
-});
-
 export const fileGitButtonStyle = style({
   visibility: 'hidden',
   display: 'inline'
@@ -105,17 +99,6 @@ export const discardButtonStyle = style({
 export const discardFileButtonSelectedStyle = style({
   backgroundImage: 'var(--jp-icon-discard-file-selected)',
   marginLeft: '6px'
-});
-
-export const cancelDiscardButtonStyle = style({
-  backgroundColor: 'var(--jp-border-color0)',
-  border: 'none'
-});
-
-export const acceptDiscardButtonStyle = style({
-  backgroundColor: 'var(--jp-error-color0)',
-  border: 'none',
-  marginLeft: '5px'
 });
 
 export const sideBarExpandedFileLabelStyle = style({

--- a/src/componentsStyle/GitStageStyle.tsx
+++ b/src/componentsStyle/GitStageStyle.tsx
@@ -76,12 +76,13 @@ export const changeStageButtonStyle = style({
 
 export const discardFileButtonStyle = style({
   backgroundImage: 'var(--jp-icon-discard-file)',
-  marginLeft: '6px'
+  marginLeft: '6px',
+  paddingRight: '1px'
 });
 
 export const diffFileButtonStyle = style({
   backgroundImage: 'var(--jp-icon-diff)',
-  marginLeft: '6px'
+  paddingLeft: '0px'
 });
 
 export const caretdownImageStyle = style({

--- a/src/componentsStyle/GitStageStyle.tsx
+++ b/src/componentsStyle/GitStageStyle.tsx
@@ -56,7 +56,7 @@ export const changeStageButtonStyle = style({
   lineHeight: 'var(--jp-private-running-shutdown-button-height)',
   transition: 'background-color 0.1s ease',
   borderRadius: '2px',
-  height: '12px',
+  height: '13px',
   width: '12px',
   border: 'none',
   outline: 'none',
@@ -79,14 +79,9 @@ export const discardFileButtonStyle = style({
   marginLeft: '6px'
 });
 
-export const discardAllWarningStyle = style({
-  height: '40px !important',
-
-  $nest: {
-    '& button': {
-      marginTop: '5px'
-    }
-  }
+export const diffFileButtonStyle = style({
+  backgroundImage: 'var(--jp-icon-diff)',
+  marginLeft: '6px'
 });
 
 export const caretdownImageStyle = style({

--- a/src/componentsStyle/SinglePastCommitInfoStyle.tsx
+++ b/src/componentsStyle/SinglePastCommitInfoStyle.tsx
@@ -56,7 +56,6 @@ export const commitDetailFileStyle = style({
 
 export const commitDetailFilePathStyle = style({
   fontSize: 'var(--jp-ui-font-size1)',
-  flex: '1 1 auto',
   marginRight: '4px',
   paddingLeft: '4px',
   textOverflow: 'ellipsis',
@@ -86,6 +85,15 @@ export const insertionIconStyle = style({
 
 export const deletionIconStyle = style({
   backgroundImage: 'var(--jp-icon-deletions-made)'
+});
+
+export const diffIconStyle = style({
+  backgroundColor: 'transparent',
+  backgroundPosition: 'center',
+  backgroundRepeat: 'no-repeat',
+  backgroundImage: 'var(--jp-icon-diff)',
+  border: 'none',
+  outline: 'none'
 });
 
 export const revertButtonStyle = style({

--- a/src/git.ts
+++ b/src/git.ts
@@ -129,7 +129,7 @@ export interface IIdentity {
 }
 
 /** Makes a HTTP request, sending a git command to the backend */
-function httpGitRequest(
+export function httpGitRequest(
   url: string,
   method: string,
   request: Object

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ import { IDiffCallback } from './git';
 export { IDiffCallback } from './git';
 
 import '../style/variables.css';
+import '../style/diff.css';
+import '../style/diff.css';
 import { GitClone } from './widgets/gitClone';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
@@ -65,13 +67,15 @@ export class GitExtension implements IGitExtension {
   constructor(
     app: JupyterFrontEnd,
     restorer: ILayoutRestorer,
-    factory: IFileBrowserFactory
+    factory: IFileBrowserFactory,
+    renderMime: IRenderMimeRegistry
   ) {
     this.app = app;
     this.gitPlugin = new GitWidget(
       app,
       { manager: app.serviceManager },
-      this.performDiff.bind(this)
+      this.performDiff.bind(this),
+      renderMime
     );
     this.gitPlugin.id = 'jp-git-sessions';
     this.gitPlugin.title.iconClass = `jp-SideBar-tabIcon ${gitTabStyle}`;
@@ -115,12 +119,13 @@ function activate(
   app: JupyterFrontEnd,
   mainMenu: IMainMenu,
   restorer: ILayoutRestorer,
-  factory: IFileBrowserFactory
+  factory: IFileBrowserFactory,
+  renderMime: IRenderMimeRegistry
 ): IGitExtension {
   const { commands } = app;
-  let gitExtension = new GitExtension(app, restorer, factory);
-  const category = 'Git';
+  let gitExtension = new GitExtension(app, restorer, factory, renderMime);
 
+  const category = 'Git';
   // Rank has been chosen somewhat arbitrarily to give priority to the running
   // sessions widget in the sidebar.
   addCommands(app, app.serviceManager);

--- a/style/diff.css
+++ b/style/diff.css
@@ -76,7 +76,7 @@
     background-size: 20px;
     background-position: center;
     background-repeat: no-repeat;
-    height: 15px;
+    height: 10px;
     width: 15px;
     font-size: var(--jp-ui-font-size1);
     line-height: var(--jp-private-toolbar-height);
@@ -87,6 +87,7 @@
     text-decoration: none;
     transition: background-color 0.1s ease;
     margin-left: 5px;
+    border: transparent;
 }
 
 .jp-git-diff-Widget {
@@ -451,4 +452,57 @@
 
 .jp-git-Notebook-diff .jp-Diff-renderedOutput {
     min-height: 2em;
+}
+
+.jp-git-Notebook-diff .jp-CollapsiblePanel {
+    border: var(--jp-git-diff-output-border-color) solid 1pt;
+}
+
+.jp-git-Notebook-diff button.jp-CollapsiblePanel-header-icon::-moz-focus-inner {
+    border: none;
+}
+
+.jp-git-Notebook-diff .jp-CollapsiblePanel-header-icon-opened {
+    background-image: var(--jp-icon-caretup);
+}
+
+.jp-git-Notebook-diff .jp-CollapsiblePanel-header-icon-closed {
+    background-image: var(--jp-icon-caretdown);
+}
+
+.jp-git-Notebook-diff .jp-CollapsiblePanel-header {
+    padding-top: .2em;
+    padding-bottom: .2em;
+    background-color: var(--jp-git-diff-output-color);
+    padding-left: 2em;
+    padding-right: 2em;
+    color: var(--jp-ui-font-color1);
+}
+
+.jp-git-Notebook-diff .jp-CollapsiblePanel-container {
+    overflow: hidden;
+}
+
+.jp-git-Notebook-diff .jp-CollapsiblePanel-slider {
+    height:100%;
+    -webkit-transition: -webkit-transform .3s ease, height 0.3s;
+    -moz-transition:    -moz-transform .3s ease, height 0.3s;
+    -ms-transition:     -ms-transform .3s ease, height 0.3s;
+    transition:         transform .3s ease, height 0.3s;
+}
+
+.jp-git-Notebook-diff .jp-CollapsiblePanel-opened {
+    -webkit-transform: translate(0, 0%);
+    -moz-transform: translate(0, 0%);
+    -ms-transform: translate(0, 0%);
+    transform: translate(0, 0%);
+    height: 100%;
+}
+
+.jp-git-Notebook-diff .jp-CollapsiblePanel-closed {
+    -webkit-transform: translate(0, -100%);
+    -moz-transform: translate(0, -100%);
+    -ms-transform: translate(0, -100%);
+    transform: translate(0, -100%);
+    height: 0;
 }

--- a/style/diff.css
+++ b/style/diff.css
@@ -1,0 +1,454 @@
+.jp-git-Notebook-diff .CodeMirror-gutter.CodeMirror-linenumbers[style] {
+    width: 29px !important;
+}
+
+.jp-git-Notebook-diff .CodeMirror-sizer[style] {
+    margin-left: 47px !important;
+}
+
+.jp-git-diff-parent-diff-widget {
+    overflow: auto;
+}
+
+.jp-git-diff-error {
+    width: auto;
+    padding: 16px;
+    left: 10px;
+    top: 5px;
+    color: var(--jp-ui-font-color1);
+    font-size: var(--jp-ui-font-size1);
+    background: var(--jp-error-color3);
+    position: absolute;
+}
+
+.jp-git-diff-error-message {
+    color: var(--jp-error-color1);
+    margin-left: 5px;
+}
+
+.jp-git-diff-header-path {
+    background: rgba(204, 204, 204, .25);
+    border: 1px solid rgba(173, 173, 173, 0.5);
+    box-sizing: border-box;
+    margin-bottom: 5px;
+    font-size: var(--jp-ui-font-size0);
+    padding: 5px;
+}
+
+.jp-git-diff-header {
+    font-family: var(--jp-ui-font-color2);
+    font-size: var(--jp-ui-font-size0);
+    margin-bottom: 10px;
+}
+
+.jp-git-diff-header > .jp-Diff-addedchunk {
+    background: var(--jp-git-diff-added-color);
+    box-sizing: border-box;
+    padding: 5px;
+}
+
+.jp-git-diff-header > .jp-Diff-removedchunk {
+    background: var(--jp-git-diff-deleted-color);
+    box-sizing: border-box;
+    padding: 5px
+}
+
+.jp-git-Notebook-diff .CodeMirror pre {
+    font-size: var(--jp-ui-font-size0);
+}
+
+.jp-git-Notebook-diff .jp-CollapsiblePanel {
+    font-size: var(--jp-ui-font-size0);
+}
+
+.jp-git-Notebook-diff pre {
+    font-size: var(--jp-ui-font-size0);
+}
+
+.jp-git-Notebook-diff .jp-Diff-outputMenu {
+    font-size: var(--jp-ui-font-size0);
+}
+
+
+/* Begin styles imported from NBDime */
+
+.jp-git-Notebook-diff button.jp-CollapsiblePanel-header-icon {
+    background-size: 20px;
+    background-position: center;
+    background-repeat: no-repeat;
+    height: 15px;
+    width: 15px;
+    font-size: var(--jp-ui-font-size1);
+    line-height: var(--jp-private-toolbar-height);
+    margin-top: .1em;
+    font-weight: 500;
+    color: var(--jp-ui-font-color1);
+    background-color: transparent;
+    text-decoration: none;
+    transition: background-color 0.1s ease;
+    margin-left: 5px;
+}
+
+.jp-git-diff-Widget {
+    display: flex;
+    flex-direction: column;
+}
+
+.jp-git-diff-root {
+    padding: var(--jp-notebook-padding);
+    min-width: 50px;
+    min-height: 50px;
+    outline: none;
+    overflow: auto;
+    background: var(--jp-layout-color0);
+    color: var(--jp-ui-font-color0);
+    flex: 1 1 auto;
+}
+
+
+.jp-git-diff-root .CodeMirror-merge {
+    position: relative;
+    white-space: pre;
+    border: var(--codemirror-border);
+    border-radius: 0px;
+    background: var(--jp-cell-editor-background);
+}
+
+.jp-git-diff-root .CodeMirror.cm-s-jupyter {
+    background: transparent;
+}
+
+.jp-git-diff-root .CodeMirror-merge, .CodeMirror-merge .CodeMirror {
+    height: auto;
+}
+
+.jp-git-diff-root .CodeMirror-merge-4pane .CodeMirror-merge-pane-deleted {
+    display: none;
+}
+
+.jp-git-diff-root .CodeMirror-merge-pane-unchanged {
+    width: 100%;
+}
+
+.jp-git-diff-root .CodeMirror-merge-1pane .CodeMirror-merge-gap {
+    width: 6%;
+}
+
+.jp-git-diff-root .CodeMirror-merge-2pane .CodeMirror-merge-pane {
+    width: 47%;
+}
+
+.jp-git-diff-root .CodeMirror-merge-2pane .CodeMirror-merge-gap {
+    width: 6%;
+}
+
+.jp-git-diff-root .CodeMirror-merge-3pane .CodeMirror-merge-pane {
+    width: 31%;
+}
+
+.jp-git-diff-root .CodeMirror-merge-3pane .CodeMirror-merge-gap {
+    width: 3.5%;
+}
+
+.jp-git-diff-root .CodeMirror-merge-pane {
+    display: inline-block;
+    white-space: normal;
+    vertical-align: top;
+    width: 100%;
+}
+
+.jp-git-diff-root .CodeMirror-merge-pane-rightmost {
+    position: absolute;
+    right: 0px;
+    z-index: 1;
+}
+
+.jp-git-diff-root .p-Widget.CodeMirror-merge-gap {
+    z-index: 2;
+    display: inline-block;
+    height: 100%;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    overflow: hidden;
+    border-left: var(--codemirror-border);
+    border-right: var(--codemirror-border);
+    position: absolute;
+    color: var(--jp-ui-font-color2);
+    background: var(--jp-layout-color2);
+}
+
+.jp-git-diff-root .CodeMirror-merge-scrolllock-wrap {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+}
+
+.jp-git-diff-root .CodeMirror-merge-scrolllock {
+    position: relative;
+    left: -50%;
+    cursor: pointer;
+    line-height: 1;
+}
+
+.jp-git-diff-root .CodeMirror-merge-r-inserted, .CodeMirror-merge-l-inserted {
+    background-color: var(--jp-diff-added-color1);
+}
+
+.jp-git-diff-root .CodeMirror-merge-r-deleted, .CodeMirror-merge-l-deleted {
+    background-color: var(--jp-diff-deleted-color1);
+}
+
+.jp-git-diff-root .CodeMirror-merge-collapsed-widget:before {
+    content: "(...)";
+}
+
+.jp-git-diff-root .CodeMirror-merge-collapsed-widget {
+    cursor: pointer;
+    color: var(--jp-ui-font-color1);
+    background: var(--jp-layout-color2);
+    border: 1px solid var(--jp-border-color1);
+    font-size: 90%;
+    padding: 0 3px;
+    border-radius: 4px;
+}
+
+.jp-git-diff-root .CodeMirror-merge-collapsed-line .CodeMirror-gutter-elt {
+    display: none;
+}
+
+.jp-git-diff-root .CodeMirror-merge-spacer {
+    background-image: repeating-linear-gradient(45deg, transparent, transparent 5px, rgba(255, 255, 255, .5) 5px, rgba(255, 255, 255, .5) 10px);
+}
+
+
+.jp-git-Notebook-diff .jp-Diff-unchanged .jp-Output *:first-child {
+    margin-left: auto;
+}
+
+.jp-git-Notebook-diff .jp-Diff-unchanged .jp-Output *:last-child {
+    margin-right: auto;
+}
+
+.jp-git-Notebook-diff .jp-Diff-unchanged {
+    margin-left: 10%;
+    width: 80%;
+}
+
+.jp-git-Notebook-diff .jp-Diff-unchanged .jp-Diff-unchanged {
+    margin-left: 0;
+    width: 100%;
+}
+
+.jp-git-Notebook-diff .jp-Diff-unchanged .CodeMirror-merge-pane-unchanged {
+    border: var(--jp-border-width) solid var(--jp-private-notebook-cell-editor-border);
+}
+
+.jp-git-Notebook-diff .jp-Diff-unchanged + .jp-Diff-unchanged > div:first-of-type {
+    border: none;
+}
+
+.jp-git-Notebook-diff .jp-Diff-unchanged .jp-Cellrow-executionCount {
+    float: left;
+}
+
+.jp-git-Notebook-diff .jp-Metadata-diff {
+    margin-bottom: 20px;
+    border: solid black thin;
+}
+
+.jp-git-Notebook-diff .jp-Cell-diff {
+    margin-bottom: 20px;
+}
+
+/* Border on top of cell */
+.jp-git-Notebook-diff .jp-Cell-diff > div:first-of-type {
+    border-top: solid #ccc 1px;
+}
+
+
+.jp-git-Notebook-diff .jp-Diff-added .jp-Cellrow-source,
+.jp-git-Notebook-diff .jp-Diff-added .jp-Cellrow-outputs {
+    border-left: var(--codemirror-border);
+}
+
+.jp-git-Notebook-diff .jp-Diff-deleted .jp-Cellrow-source,
+.jp-git-Notebook-diff .jp-Diff-deleted .jp-Cellrow-outputs {
+    border-right: var(--codemirror-border);
+}
+
+/* Add/delete chunks for small width devices (added before delete) */
+.jp-git-Notebook-diff .jp-Diff-addremchunk {
+    display: flex;
+    flex-direction: column-reverse;
+    justify-content: space-between;
+}
+
+.jp-git-Notebook-diff .jp-Diff-addremchunk .jp-Diff-addedchunk,
+.jp-git-Notebook-diff .jp-Diff-addremchunk .jp-Diff-removedchunk {
+    width: 100%;
+}
+
+/* Add/delete chunks should show side-by-side for larger screens */
+@media (min-width: 1000px) {
+    .jp-git-Notebook-diff .jp-Diff-addremchunk {
+        flex-direction: row-reverse;
+    }
+
+    .jp-git-Notebook-diff .jp-Diff-addremchunk .jp-Diff-addedchunk,
+    .jp-git-Notebook-diff .jp-Diff-addremchunk .jp-Diff-removedchunk {
+        width: 49%;
+    }
+}
+
+/* Hide metadata changes by default */
+.jp-git-Notebook-diff .jp-Diff-added .jp-Cellrow-metadata,
+.jp-git-Notebook-diff .jp-Diff-deleted .jp-Cellrow-metadata,
+.jp-git-Notebook-diff .jp-Diff-unchanged .jp-Cellrow-outputs {
+    display: none;
+}
+
+.jp-git-Notebook-diff .jp-Diff-added .jp-Diff-unchanged {
+    margin-left: 25%;
+    width: 75%;
+}
+
+.jp-git-Notebook-diff .jp-Diff-deleted .jp-Diff-unchanged {
+    margin-left: 0;
+    width: 75%;
+}
+
+.jp-git-Notebook-diff .jp-Diff-unchanged .jp-Output-result > * {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.jp-git-Notebook-diff .jp-Cellrow-outputs .jp-Diff-twoway .jp-Diff-base {
+    float: left;
+    width: 47%;
+}
+
+.jp-git-Notebook-diff .jp-Cellrow-outputs .jp-Diff-twoway .jp-Diff-remote {
+    float: right;
+    width: 47%;
+}
+
+.jp-git-Notebook-diff .jp-Output-result img {
+    max-width: 100%;
+}
+
+.jp-git-Notebook-diff .CodeMirror-merge-pane-remote {
+    position: relative;
+    left: 6%;
+}
+
+.jp-git-Notebook-diff .jp-Cellrow-source .CodeMirror-merge-pane-deleted,
+.jp-git-Notebook-diff .jp-Cellrow-source .CodeMirror-merge-pane-added {
+    width: 75%;
+}
+
+.jp-git-Notebook-diff .jp-Diff-twoway .jp-Cellrow-outputs .jp-Diff-unchanged .jp-CodeMirrorWidget {
+    width: initial;
+    max-width: 100%;
+}
+
+.jp-git-Notebook-diff .jp-Diff-twoway .jp-Cellrow-outputs .jp-Diff-unchanged .jp-RenderedImage {
+    text-align: center;
+}
+
+.jp-git-Notebook-diff .CodeMirror-merge-r-chunk {
+    background-color: var(--jp-git-diff-deleted-color);
+}
+
+.jp-git-Notebook-diff .CodeMirror-merge-r-connect {
+    fill: var(--jp-git-diff-deleted-color);
+    stroke: var(--jp-diff-deleted-color0);
+    stroke-width: 1px;
+}
+
+.jp-git-Notebook-diff .CodeMirror-merge-spacer {
+    background-color: var(--jp-git-diff-deleted-color);
+}
+
+.jp-git-Notebook-diff .CodeMirror-merge-pane-remote .CodeMirror-merge-r-chunk {
+    background-color: var(--jp-git-diff-added-color);
+}
+
+.jp-git-Notebook-diff .CodeMirror-merge-pane-remote .CodeMirror-merge-r-connect {
+    fill: var(--jp-git-diff-added-color);
+    stroke: var(--jp-diff-added-color0);
+    stroke-width: 1px;
+}
+
+.jp-git-Notebook-diff .CodeMirror-merge-pane-remote .CodeMirror-merge-spacer {
+    background-color: var(--jp-git-diff-added-color);
+}
+
+
+.jp-git-Notebook-diff .jp-Diff-deleted .CodeMirror,
+.jp-git-Notebook-diff .jp-Diff-deleted .jp-Diff-renderedOutput,
+.jp-Cellrow-outputs .jp-Diff-twoway .jp-Diff-base {
+    background-color: var(--jp-git-diff-deleted-color);
+}
+
+.jp-git-Notebook-diff .jp-Diff-added .CodeMirror,
+.jp-git-Notebook-diff .jp-Diff-added .jp-Diff-renderedOutput,
+.jp-Cellrow-outputs .jp-Diff-twoway .jp-Diff-remote {
+    background-color: var(--jp-git-diff-added-color);
+}
+
+.jp-git-Notebook-diff .jp-Diff-added .CodeMirror-merge-pane-added,
+.jp-git-Notebook-diff .jp-Diff-deleted .CodeMirror-merge-pane-deleted {
+    width: 100%;
+}
+
+.jp-git-Notebook-diff .jp-Cellrow-source .jp-InputPrompt {
+    text-align: left;
+}
+
+.jp-CollapsiblePanel-container {
+    background-color: var(--jp-layout-color1);
+    color: var(--jp-ui-font-color1);
+}
+
+.jp-git-Notebook-diff .jp-Diff-outputPanel .jp-Diff-outputMenu {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, 0);
+    background-color: var(--jp-layout-color1);
+    color: var(--jp-ui-font-color1);
+    padding: 3px 5px;
+    border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+    z-index: 10;
+}
+
+.jp-git-Notebook-diff .jp-Diff-outputPanel:hover .jp-Diff-outputMenu {
+    display: initial;
+}
+
+.jp-git-Notebook-diff .jp-Diff-trustOutputButton {
+    display: none;
+}
+
+.jp-git-Notebook-diff .jp-Diff-trustCandidate .jp-Diff-trustOutputButton {
+    display: initial;
+}
+
+.jp-git-Notebook-diff .jp-Diff-outputPanel:not(.jp-Diff-trustCandidate) .jp-diff-base64Output + .jp-Diff-outputMenu {
+    display: none;
+}
+
+.jp-git-Notebook-diff .jp-Diff-outputPanel .jp-Diff-outputMenu > :not(:first-child) {
+    margin-left: 5px;
+}
+
+.jp-Diff-outputsContainer > .p-Widget:not(:last-child) {
+    padding-bottom: 6px;
+    min-height: 2em;
+}
+
+.jp-git-Notebook-diff .jp-Diff-renderedOutput {
+    min-height: 2em;
+}

--- a/style/images/diff-hover-dk.svg
+++ b/style/images/diff-hover-dk.svg
@@ -1,0 +1,6 @@
+<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.5 1H3.5C2.675 1 2.0075 1.63 2.0075 2.4L2 13.6C2 14.37 2.6675 15 3.4925 15H12.5C13.325 15 14 14.37 14 13.6V5.2L9.5 1ZM3.5 13.6V2.4H8.75L12.5 5.9V13.6H3.5Z" fill="white"/>
+<rect x="7" y="10.5" width="4" height="0.999998" fill="white"/>
+<rect x="5" y="5.49988" width="4" height="0.999998" fill="white"/>
+<rect x="7.5" y="4" width="4" height="1" transform="rotate(90 7.5 4)" fill="white"/>
+</svg>

--- a/style/images/diff-hover.svg
+++ b/style/images/diff-hover.svg
@@ -1,0 +1,6 @@
+<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.5 1H3.5C2.675 1 2.0075 1.63 2.0075 2.4L2 13.6C2 14.37 2.6675 15 3.4925 15H12.5C13.325 15 14 14.37 14 13.6V5.2L9.5 1ZM3.5 13.6V2.4H8.75L12.5 5.9V13.6H3.5Z" fill="#4F4F4F"/>
+<rect x="7" y="10.5" width="4" height="0.999998" fill="#4F4F4F"/>
+<rect x="5" y="5.49988" width="4" height="0.999998" fill="#4F4F4F"/>
+<rect x="7.5" y="4" width="4" height="1" transform="rotate(90 7.5 4)" fill="#4F4F4F"/>
+</svg>

--- a/style/variables.css
+++ b/style/variables.css
@@ -19,6 +19,8 @@
   --jp-icon-git-clone-disabled: url('./images/git-clone-icon-disabled.svg');
   --jp-icon-git-push-disabled: url('./images/git-clone-icon-disabled.svg');
   --jp-icon-git-pull-disabled: url('./images/git-clone-icon-disabled.svg');
+  --jp-git-diff-deleted-color: rgba(255, 193, 193, 0.5);
+  --jp-git-diff-added-color: rgba(201, 243, 194, 0.5);
 }
 
 [data-jp-theme-light='true'] {
@@ -32,6 +34,7 @@
   --jp-icon-move-file-up: url('./images/move-file-up.svg');
   --jp-icon-plus: url('./images/plus.svg');
   --jp-icon-rewind: url('./images/rewind.svg');
+  --jp-icon-diff: url('./images/diff-hover.svg');
 }
 
 [data-jp-theme-light='false'] {
@@ -45,4 +48,5 @@
   --jp-icon-move-file-up: url('./images/move-file-up-hover.svg');
   --jp-icon-plus: url('./images/plus-white.svg');
   --jp-icon-rewind: url('./images/rewind-white.svg');
+  --jp-icon-diff: url('./images/diff-hover-dk.svg');
 }

--- a/style/variables.css
+++ b/style/variables.css
@@ -21,6 +21,8 @@
   --jp-icon-git-pull-disabled: url('./images/git-clone-icon-disabled.svg');
   --jp-git-diff-deleted-color: rgba(255, 193, 193, 0.5);
   --jp-git-diff-added-color: rgba(201, 243, 194, 0.5);
+  --jp-git-diff-output-color: rgba(0, 141, 255, 0.3);
+  --jp-git-diff-output-border-color: rgba(0, 141, 255, 0.7);
 }
 
 [data-jp-theme-light='true'] {

--- a/tests/test-components/Diff.spec.tsx
+++ b/tests/test-components/Diff.spec.tsx
@@ -12,7 +12,6 @@ describe('Diff', () => {
   it('should render diff provider component when supported', function() {
     // Given
     const props: IDiffProps = {
-      renderMime: null,
       path: '/path/to/File.ipynb',
       diffContext: {
         currentRef: { specialRef: 'WORKING' },
@@ -30,7 +29,6 @@ describe('Diff', () => {
   it('should not render anything when not supported', function() {
     // Given
     const props: IDiffProps = {
-      renderMime: null,
       path: '/path/to/File.py',
       diffContext: {
         currentRef: { specialRef: 'WORKING' },

--- a/tests/test-components/Diff.spec.tsx
+++ b/tests/test-components/Diff.spec.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import 'jest';
+import {
+  Diff,
+  IDiffProps,
+  isDiffSupported
+} from '../../src/components/diff/Diff';
+import { NBDiff } from '../../src/components/diff/NbDiff';
+
+describe('Diff', () => {
+  it('should render diff provider component when supported', function() {
+    // Given
+    const props: IDiffProps = {
+      renderMime: null,
+      path: '/path/to/File.ipynb',
+      diffContext: {
+        currentRef: { specialRef: 'WORKING' },
+        previousRef: { gitRef: '83baee' }
+      }
+    };
+
+    // When
+    const node = shallow(<Diff {...props} />);
+
+    // Then
+    expect(node.find(NBDiff)).toHaveLength(1);
+  });
+
+  it('should not render anything when not supported', function() {
+    // Given
+    const props: IDiffProps = {
+      renderMime: null,
+      path: '/path/to/File.py',
+      diffContext: {
+        currentRef: { specialRef: 'WORKING' },
+        previousRef: { gitRef: '83baee' }
+      }
+    };
+
+    // When
+    const node = shallow(<Diff {...props} />);
+
+    // Then
+    expect(node.html()).toBe(null);
+  });
+
+  it('should not support non-ipynb files', function() {
+    expect(isDiffSupported('/path/to/script.py')).toBeFalsy();
+  });
+});

--- a/tests/test-components/FileItem.spec.tsx
+++ b/tests/test-components/FileItem.spec.tsx
@@ -30,7 +30,8 @@ describe('FileItem', () => {
     updateSelectedDiscardFile: () => {},
     disableFile: false,
     toggleDisableFiles: () => {},
-    sideBarExpanded: false
+    sideBarExpanded: false,
+    renderMime: null
   };
 
   describe('#render()', () => {

--- a/tests/test-components/HistorySideBar.spec.tsx
+++ b/tests/test-components/HistorySideBar.spec.tsx
@@ -24,7 +24,8 @@ describe('HistorySideBar', () => {
     topRepoPath: null,
     app: null,
     refresh: null,
-    diff: null
+    diff: null,
+    renderMime: null
   };
   test('renders commit nodes when expanded', () => {
     const historySideBar = shallow(<HistorySideBar {...props} />);

--- a/tests/test-components/NBDiff.spec.tsx
+++ b/tests/test-components/NBDiff.spec.tsx
@@ -13,7 +13,6 @@ describe('NBDiff', () => {
   it('should render error in if API response is failed', async function() {
     // Given
     const props: IDiffProps = {
-      renderMime: null,
       path: '/path/to/File.ipynb',
       diffContext: {
         currentRef: { specialRef: 'WORKING' },
@@ -51,7 +50,6 @@ describe('NBDiff', () => {
   it('should render header and cell diff components in success case', async function() {
     // Given
     const props: IDiffProps = {
-      renderMime: null,
       path: '/path/to/File.ipynb',
       diffContext: {
         currentRef: { specialRef: 'WORKING' },

--- a/tests/test-components/NBDiff.spec.tsx
+++ b/tests/test-components/NBDiff.spec.tsx
@@ -38,8 +38,8 @@ describe('NBDiff', () => {
       expect(httpGitRequest).toHaveBeenCalled();
       expect(httpGitRequest).toBeCalledWith('/nbdime/api/gitdiff', 'POST', {
         file_path: '/path/to/File.ipynb',
-        ref_curr: { special: 'WORKING' },
-        ref_prev: { git: '83baee' }
+        ref_remote: { special: 'WORKING' },
+        ref_local: { git: '83baee' }
       });
       expect(node.find('.jp-git-diff-error').text()).toContain(
         'TEST_ERROR_MESSAGE'
@@ -75,8 +75,8 @@ describe('NBDiff', () => {
       expect(httpGitRequest).toHaveBeenCalled();
       expect(httpGitRequest).toBeCalledWith('/nbdime/api/gitdiff', 'POST', {
         file_path: '/path/to/File.ipynb',
-        ref_curr: { special: 'WORKING' },
-        ref_prev: { git: '83baee' }
+        ref_remote: { special: 'WORKING' },
+        ref_local: { git: '83baee' }
       });
       expect(node.find('.jp-git-diff-error').html()).toBeNull();
       expect(node.find(NBDiffHeader)).toHaveLength(1);
@@ -99,13 +99,13 @@ function createTestResponse(
     trailer: Promise.resolve(Headers as any),
     type: 'basic',
     url: '/foo/bar',
-    clone: jest.fn<Response>(),
+    clone: jest.fn<Response, []>(),
     body: null,
     bodyUsed: false,
-    arrayBuffer: jest.fn<Promise<ArrayBuffer>>(),
-    blob: jest.fn<Promise<Blob>>(),
-    formData: jest.fn<Promise<FormData>>(),
-    text: jest.fn<Promise<String>>()
+    arrayBuffer: jest.fn<Promise<ArrayBuffer>, []>(),
+    blob: jest.fn<Promise<Blob>, []>(),
+    formData: jest.fn<Promise<FormData>, []>(),
+    text: jest.fn<Promise<string>, []>()
   };
   return Promise.resolve(testResponse);
 }

--- a/tests/test-components/NBDiff.spec.tsx
+++ b/tests/test-components/NBDiff.spec.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import 'jest';
+import { IDiffProps } from '../../src/components/diff/Diff';
+import { CellDiff, NBDiff } from '../../src/components/diff/NbDiff';
+import * as diffResponse from '../test-components/data/diffResponse.json';
+import { httpGitRequest } from '../../src/git';
+import { NBDiffHeader } from '../../src/components/diff/NBDiffHeader';
+
+jest.mock('../../src/git');
+
+describe('NBDiff', () => {
+  it('should render error in if API response is failed', async function() {
+    // Given
+    const props: IDiffProps = {
+      renderMime: null,
+      path: '/path/to/File.ipynb',
+      diffContext: {
+        currentRef: { specialRef: 'WORKING' },
+        previousRef: { gitRef: '83baee' }
+      }
+    };
+
+    const jsonResult: Promise<any> = Promise.resolve({
+      message: 'TEST_ERROR_MESSAGE'
+    });
+
+    (httpGitRequest as jest.Mock).mockReturnValue(
+      createTestResponse(401, jsonResult)
+    );
+
+    // When
+    const node = shallow(<NBDiff {...props} />);
+
+    // Then
+    jsonResult.then(() => {
+      node.update();
+
+      expect(httpGitRequest).toHaveBeenCalled();
+      expect(httpGitRequest).toBeCalledWith('/nbdime/api/gitdiff', 'POST', {
+        file_path: '/path/to/File.ipynb',
+        ref_curr: { special: 'WORKING' },
+        ref_prev: { git: '83baee' }
+      });
+      expect(node.find('.jp-git-diff-error').text()).toContain(
+        'TEST_ERROR_MESSAGE'
+      );
+    });
+  });
+
+  it('should render header and cell diff components in success case', async function() {
+    // Given
+    const props: IDiffProps = {
+      renderMime: null,
+      path: '/path/to/File.ipynb',
+      diffContext: {
+        currentRef: { specialRef: 'WORKING' },
+        previousRef: { gitRef: '83baee' }
+      }
+    };
+
+    const jsonResult: Promise<any> = Promise.resolve({
+      diffResponse
+    });
+
+    (httpGitRequest as jest.Mock).mockReturnValue(
+      createTestResponse(200, jsonResult)
+    );
+
+    // When
+    const node = shallow(<NBDiff {...props} />);
+
+    // Then
+    jsonResult.then(() => {
+      node.update();
+
+      expect(httpGitRequest).toHaveBeenCalled();
+      expect(httpGitRequest).toBeCalledWith('/nbdime/api/gitdiff', 'POST', {
+        file_path: '/path/to/File.ipynb',
+        ref_curr: { special: 'WORKING' },
+        ref_prev: { git: '83baee' }
+      });
+      expect(node.find('.jp-git-diff-error').html()).toBeNull();
+      expect(node.find(NBDiffHeader)).toHaveLength(1);
+      expect(node.find(CellDiff)).toHaveLength(2);
+    });
+  });
+});
+
+function createTestResponse(
+  status: number,
+  json: Promise<any>
+): Promise<Response> {
+  const testResponse: Response = {
+    status: status,
+    json: () => json,
+    headers: Headers as any,
+    ok: true,
+    redirected: false,
+    statusText: 'foo',
+    trailer: Promise.resolve(Headers as any),
+    type: 'basic',
+    url: '/foo/bar',
+    clone: jest.fn<Response>(),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: jest.fn<Promise<ArrayBuffer>>(),
+    blob: jest.fn<Promise<Blob>>(),
+    formData: jest.fn<Promise<FormData>>(),
+    text: jest.fn<Promise<String>>()
+  };
+  return Promise.resolve(testResponse);
+}

--- a/tests/test-components/NBDiffHeader.spec.tsx
+++ b/tests/test-components/NBDiffHeader.spec.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import 'jest';
+import {
+  INBDiffHeaderProps,
+  NBDiffHeader
+} from '../../src/components/diff/NBDiffHeader';
+
+describe('NBDiffHeader', () => {
+  it('should render the Working Tree ref correctly', function() {
+    // Given
+    const props: INBDiffHeaderProps = {
+      path: '/path/to/File.ipynb',
+      diffContext: {
+        currentRef: { specialRef: 'WORKING' },
+        previousRef: { gitRef: '83baee' }
+      }
+    };
+
+    // When
+    const node = shallow(<NBDiffHeader {...props} />);
+
+    // Then
+    expect(node.find('.jp-git-diff-header-path').text()).toContain(
+      '/path/to/File.ipynb'
+    );
+    expect(node.find('.jp-Diff-removedchunk').text()).toContain('83baee');
+    expect(node.find('.jp-Diff-addedchunk').text()).toContain('Changed');
+  });
+
+  it('should render the Index ref correctly', function() {
+    // Given
+    const props: INBDiffHeaderProps = {
+      path: '/path/to/File.py',
+      diffContext: {
+        currentRef: { specialRef: 'INDEX' },
+        previousRef: { gitRef: '83baee' }
+      }
+    };
+
+    // When
+    const node = shallow(<NBDiffHeader {...props} />);
+
+    // Then
+    expect(node.find('.jp-git-diff-header-path').text()).toContain(
+      '/path/to/File.py'
+    );
+    expect(node.find('.jp-Diff-removedchunk').text()).toContain('83baee');
+    expect(node.find('.jp-Diff-addedchunk').text()).toContain('Staged');
+  });
+
+  it('should render regular Git refs correctly', function() {
+    // Given
+    const props: INBDiffHeaderProps = {
+      path: '/path/to/File.py',
+      diffContext: {
+        currentRef: { gitRef: '92carr' },
+        previousRef: { gitRef: '83baee' }
+      }
+    };
+
+    // When
+    const node = shallow(<NBDiffHeader {...props} />);
+
+    // Then
+    expect(node.find('.jp-git-diff-header-path').text()).toContain(
+      '/path/to/File.py'
+    );
+    expect(node.find('.jp-Diff-removedchunk').text()).toContain('83baee');
+    expect(node.find('.jp-Diff-addedchunk').text()).toContain('92carr');
+  });
+});

--- a/tests/test-components/PastCommitNode.spec.tsx
+++ b/tests/test-components/PastCommitNode.spec.tsx
@@ -58,7 +58,8 @@ describe('PastCommitNode', () => {
       commit_msg: 'message',
       pre_commit: 'pre_commit'
     },
-    branches: branches
+    branches: branches,
+    renderMime: null
   };
   test('Includes commit info', () => {
     const pastCommitNode = shallow(<PastCommitNode {...props} />);

--- a/tests/test-components/data/diffResponse.json
+++ b/tests/test-components/data/diffResponse.json
@@ -1,0 +1,140 @@
+{
+  "base": {
+    "cells": [
+      {
+        "cell_type": "code",
+        "execution_count": 1,
+        "metadata": {},
+        "outputs": [
+          {
+            "name": "stdout",
+            "output_type": "stream",
+            "text": "Hello World\n"
+          }
+        ],
+        "source": "print('Hello World')"
+      },
+      {
+        "cell_type": "code",
+        "execution_count": null,
+        "metadata": {},
+        "outputs": [],
+        "source": ""
+      }
+    ],
+    "metadata": {
+      "kernelspec": {
+        "display_name": "Python 3",
+        "language": "python",
+        "name": "python3"
+      },
+      "language_info": {
+        "codemirror_mode": {
+          "name": "ipython",
+          "version": 3
+        },
+        "file_extension": ".py",
+        "mimetype": "text/x-python",
+        "name": "python",
+        "nbconvert_exporter": "python",
+        "pygments_lexer": "ipython3",
+        "version": "3.6.7"
+      },
+      "orig_nbformat": 4
+    },
+    "nbformat": 4,
+    "nbformat_minor": 2
+  },
+  "diff": [
+    {
+      "op": "patch",
+      "key": "cells",
+      "diff": [
+        {
+          "op": "addrange",
+          "key": 0,
+          "valuelist": [
+            {
+              "cell_type": "code",
+              "execution_count": 2,
+              "metadata": {},
+              "outputs": [
+                {
+                  "name": "stdout",
+                  "output_type": "stream",
+                  "text": "Hello Earth\n"
+                }
+              ],
+              "source": "print('Hello Earth')"
+            }
+          ]
+        },
+        {
+          "op": "patch",
+          "key": 0,
+          "diff": [
+            {
+              "op": "replace",
+              "key": "execution_count",
+              "value": 3
+            },
+            {
+              "op": "patch",
+              "key": "outputs",
+              "diff": [
+                {
+                  "op": "addrange",
+                  "key": 0,
+                  "valuelist": [
+                    {
+                      "name": "stdout",
+                      "output_type": "stream",
+                      "text": "Hello Mars\n"
+                    }
+                  ]
+                },
+                {
+                  "op": "removerange",
+                  "key": 0,
+                  "length": 1
+                }
+              ]
+            },
+            {
+              "op": "patch",
+              "key": "source",
+              "diff": [
+                {
+                  "op": "patch",
+                  "key": 0,
+                  "diff": [
+                    {
+                      "op": "addrange",
+                      "key": 13,
+                      "valuelist": "Ma"
+                    },
+                    {
+                      "op": "removerange",
+                      "key": 13,
+                      "length": 2
+                    },
+                    {
+                      "op": "addrange",
+                      "key": 16,
+                      "valuelist": "s"
+                    },
+                    {
+                      "op": "removerange",
+                      "key": 16,
+                      "length": 2
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "outDir": "lib",
     "types": ["jest"],
     "jsx": "react",
-    "plugins": [{ "name": "typescript-tslint-plugin" }]
+    "plugins": [{ "name": "typescript-tslint-plugin" }],
+    "resolveJsonModule": true
   },
   "include": ["src/*"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -81,7 +81,8 @@
       true,
       "check-format",
       "allow-leading-underscore",
-      "ban-keywords"
+      "ban-keywords",
+      "allow-pascal-case"
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,7 +1172,7 @@
     "@blueprintjs/select" "^3.3.0"
     react "~16.8.4"
 
-"@phosphor/algorithm@^1.1.3":
+"@phosphor/algorithm@^1.1.2", "@phosphor/algorithm@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@phosphor/algorithm/-/algorithm-1.1.3.tgz#fb0e974f4e81aadc06f948770b3060c4ec8a1e27"
   integrity sha512-+dkdYTBglR+qGnLVQdCvYojNZMGxf+xSl1Jeksha3pm7niQktSFz2aR5gEPu/nI5LM8T8slTpqE4Pjvq8P+IVA==
@@ -1205,7 +1205,7 @@
     "@phosphor/keyboard" "^1.1.3"
     "@phosphor/signaling" "^1.2.3"
 
-"@phosphor/coreutils@^1.3.1":
+"@phosphor/coreutils@^1.3.0", "@phosphor/coreutils@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@phosphor/coreutils/-/coreutils-1.3.1.tgz#441e34f42340f7faa742a88b2a181947a88d7226"
   integrity sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA==
@@ -1223,7 +1223,7 @@
   resolved "https://registry.yarnpkg.com/@phosphor/domutils/-/domutils-1.1.3.tgz#5aeeaefb4bbfcc7c0942e5287a29d3c7f2b1a2bc"
   integrity sha512-5CtLAhURQXXHhNXfQydDk/luG1cDVnhlu/qw7gz8/9pht0KXIAmNg/M0LKxx2oJ9+YMNCLVWxAnHAU0yrDpWSA==
 
-"@phosphor/dragdrop@^1.3.3":
+"@phosphor/dragdrop@^1.3.0", "@phosphor/dragdrop@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@phosphor/dragdrop/-/dragdrop-1.3.3.tgz#9487d27a6eb8cd54bfe6d91eaffc9d0852817b61"
   integrity sha512-+SrlGsVQwY8OHCWxE/Zvihpk6Rc6bytJDqOUUTZqdL8hvM9QZeopAFioPDxuo1pTj87Um6cR4ekvbTU4KZ/90w==
@@ -1249,7 +1249,7 @@
   resolved "https://registry.yarnpkg.com/@phosphor/properties/-/properties-1.1.3.tgz#63e4355be5e22a411c566fd1860207038f171598"
   integrity sha512-GiglqzU77s6+tFVt6zPq9uuyu/PLQPFcqZt914ZhJ4cN/7yNI/SLyMzpYZ56IRMXvzK9TUgbRna6URE3XAwFUg==
 
-"@phosphor/signaling@^1.2.3":
+"@phosphor/signaling@^1.2.2", "@phosphor/signaling@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@phosphor/signaling/-/signaling-1.2.3.tgz#2fde0ee810b0fab5f3fc765f81ed08ae671e76f1"
   integrity sha512-DMwS0m9OgfY5ljpTsklRQPUQpTyg4obz85FyImRDacUVxUVbas95djIDEbU4s1TMzdHBBO+gfki3V4giXUvXzw==
@@ -1263,7 +1263,7 @@
   dependencies:
     "@phosphor/algorithm" "^1.1.3"
 
-"@phosphor/widgets@^1.8.0", "@phosphor/widgets@^1.8.1":
+"@phosphor/widgets@^1.6.0", "@phosphor/widgets@^1.8.0", "@phosphor/widgets@^1.8.1":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@phosphor/widgets/-/widgets-1.8.1.tgz#e6398984a37b17b0a55417eab5e3f3517af88186"
   integrity sha512-OY5T0nAioYTitPks/lCHm7a6QpjRB/XviIT2j6WtYm5J1U8MluIPpClqZ/NQbZfm23BYpmJeiQQyZA+5YphsDA==
@@ -3823,6 +3823,13 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -3834,6 +3841,11 @@ json5@2.x, json5@^2.1.0:
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -4296,6 +4308,24 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+nbdime@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/nbdime/-/nbdime-5.0.1.tgz#0068da1c7489178efecf88ca8e0636fabc5d3176"
+  integrity sha512-zcIxCfEX0ecEaHCqKIdqZrWz7A8Elce8ALUwDAYVLEmQTjo+Y4E4eFXB5jKXjEkEz6cMnTF9QJnlsju6le+zaA==
+  dependencies:
+    "@jupyterlab/codeeditor" "^1.0.0"
+    "@jupyterlab/codemirror" "^1.0.0"
+    "@jupyterlab/coreutils" "^3.0.0"
+    "@jupyterlab/outputarea" "^1.0.0"
+    "@jupyterlab/rendermime" "^1.0.0"
+    "@jupyterlab/services" "^4.0.0"
+    "@phosphor/algorithm" "^1.1.2"
+    "@phosphor/coreutils" "^1.3.0"
+    "@phosphor/dragdrop" "^1.3.0"
+    "@phosphor/signaling" "^1.2.2"
+    "@phosphor/widgets" "^1.6.0"
+    json-stable-stringify "^1.0.1"
 
 nearley@^2.7.10:
   version "2.16.0"


### PR DESCRIPTION
This change introduces the feature to be able to diff ipynb from various points inside the Git experience. The currently supported points are the Changed, Staged areas, and the History panel.

The `<Diff />` component maintains a registry of DiffProvider components and delegates to each provider based on the file extension.

Note
* This change is off the pre 1.0 version of the Git extension because NBDime isn't upgraded to 1.0 

Addresses #252 #268 

TODOs

* [x] Port to 1.0 after https://github.com/jupyter/nbdime/pull/483 and use `ReactWidget` interface