### PR TITLE
Fix remote checkout

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -652,12 +652,7 @@ class Git:
         if p.returncode == 0:
             return { "code": 0, "message": my_output.decode("utf-8") }
         else:
-            response = {
-                "code": p.returncode,
-                "message": my_error.decode("utf-8"),
-            }
-            response["command"] = " ".join(cmd)
-            return response
+            return { "code": p.returncode, "message": my_error.decode("utf-8"), "command":  " ".join(cmd) }
 
     def checkout(self, filename, top_repo_path):
         """

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -646,7 +646,6 @@ class Git:
         )
 
         my_output, my_error = p.communicate()
-        p.returncode = 99
         if p.returncode == 0:
             return { "code": 0, "message": my_output.decode("utf-8") }
         else:
@@ -654,11 +653,8 @@ class Git:
                 "code": p.returncode,
                 "message": my_error.decode("utf-8"),
             }
-            response["command"] = "git checkout "
-            if is_remote_branch: response['command'] += "--track "
-            response['command'] += branchname
+            response["command"] = " ".join(cmd)
             return response
-
 
     def checkout(self, filename, top_repo_path):
         """

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -610,7 +610,10 @@ class Git:
             }
 
     def _get_branch_reference(self, branchname, current_path):
-        p = Popen(
+        """
+        Execute git rev-parse --symbolic-full-name <branch-name> and return the result (or None).
+        """
+        p = subprocess.Popen(
             ["git", "rev-parse", "--symbolic-full-name", branchname],
             stdout=PIPE,
             stderr=PIPE,
@@ -638,7 +641,7 @@ class Git:
         else:
             cmd = ["git", "checkout", branchname]
 
-        p = Popen(
+        p = subprocess.Popen(
             cmd,
             stdout=PIPE,
             stderr=PIPE,

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -609,25 +609,56 @@ class Git:
                 "message": my_error.decode("utf-8"),
             }
 
-    def checkout_branch(self, branchname, current_path):
-        """
-        Execute git checkout <branch-name> command & return the result.
-        """
+    def _get_branch_reference(self, branchname, current_path):
         p = Popen(
-            ["git", "checkout", branchname],
+            ["git", "rev-parse", "--symbolic-full-name", branchname],
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, current_path),
         )
         my_output, my_error = p.communicate()
         if p.returncode == 0:
-            return {"code": p.returncode, "message": my_output.decode("utf-8")}
+            return my_output.decode("utf-8").strip("\n")
         else:
-            return {
+            return None
+
+    def checkout_branch(self, branchname, current_path):
+        """
+        Execute git checkout <branch-name> command & return the result.
+        Use the --track parameter for a remote branch.
+        """
+        reference_name = self._get_branch_reference(branchname, current_path)
+        if reference_name is None:
+            is_remote_branch = False
+        else:
+            is_remote_branch = self._is_remote_branch(reference_name)
+
+        if is_remote_branch:
+            cmd = ["git", "checkout", "--track", branchname]
+        else:
+            cmd = ["git", "checkout", branchname]
+
+        p = Popen(
+            cmd,
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd=os.path.join(self.root_dir, current_path),
+        )
+
+        my_output, my_error = p.communicate()
+        p.returncode = 99
+        if p.returncode == 0:
+            return { "code": 0, "message": my_output.decode("utf-8") }
+        else:
+            response = {
                 "code": p.returncode,
-                "command": "git checkout " + branchname,
                 "message": my_error.decode("utf-8"),
             }
+            response["command"] = "git checkout "
+            if is_remote_branch: response['command'] += "--track "
+            response['command'] += branchname
+            return response
+
 
     def checkout(self, filename, top_repo_path):
         """

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -98,6 +98,242 @@ def test_get_current_branch_success(mock_subproc_popen):
     ])
     assert 'feature-foo' == actual_response
 
+@patch('subprocess.Popen')
+@patch.object(Git, '_get_branch_reference', return_value=None)
+def test_checkout_branch_noref_success(mock__get_branch_reference, mock_subproc_popen):
+    branch='test-branch'
+    stdout_message='checkout output from git'
+    stderr_message=''
+    rc=0
+
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': (stdout_message.encode('utf-8'), stderr_message.encode('utf-8')),
+        'returncode': rc
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').checkout_branch(
+        branchname=branch,
+        current_path='test_curr_path')
+
+    # Then
+    cmd=['git', 'checkout', branch]
+    mock_subproc_popen.assert_has_calls([
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call().communicate()
+    ])
+    assert { "code": rc, "message": stdout_message } == actual_response
+
+
+@patch('subprocess.Popen')
+@patch.object(Git, '_get_branch_reference', return_value=None)
+def test_checkout_branch_noref_failure(mock__get_branch_reference, mock_subproc_popen):
+    branch='test-branch'
+    stdout_message=''
+    stderr_message="error: pathspec '"+branch+"' did not match any file(s) known to git"
+    rc=1
+
+    # Given
+    process_mock = Mock()
+    attrs = { 'communicate.return_value': (stdout_message.encode('utf-8'), stderr_message.encode('utf-8')), 'returncode': rc }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').checkout_branch(branchname=branch, current_path='test_curr_path')
+
+    # Then
+    cmd=['git', 'checkout', branch]
+    mock_subproc_popen.assert_has_calls([
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call().communicate()
+    ])
+    assert { "code": rc, "message": stderr_message,  "command": ' '.join(cmd) } == actual_response
+
+
+@patch('subprocess.Popen')
+@patch.object(Git, '_get_branch_reference', return_value="refs/remotes/remote_branch")
+def test_checkout_branch_remoteref_success(mock__get_branch_reference, mock_subproc_popen):
+    branch='test-branch'
+    stdout_message='checkout output from git'
+    stderr_message=''
+    rc=0
+
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': (stdout_message.encode('utf-8'), stderr_message.encode('utf-8')),
+        'returncode': rc
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').checkout_branch(
+        branchname=branch,
+        current_path='test_curr_path')
+
+    # Then
+    cmd=['git', 'checkout', '--track', branch]
+    mock_subproc_popen.assert_has_calls([
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call().communicate()
+    ])
+    assert { "code": rc, "message": stdout_message } == actual_response
+
+
+@patch('subprocess.Popen')
+@patch.object(Git, '_get_branch_reference', return_value="refs/heads/local_branch")
+def test_checkout_branch_headsref_failure(mock__get_branch_reference, mock_subproc_popen):
+    branch='test-branch'
+    stdout_message=''
+    stderr_message="error: pathspec '"+branch+"' did not match any file(s) known to git"
+    rc=1
+
+    # Given
+    process_mock = Mock()
+    attrs = { 'communicate.return_value': (stdout_message.encode('utf-8'), stderr_message.encode('utf-8')), 'returncode': rc }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').checkout_branch(branchname=branch, current_path='test_curr_path')
+
+    # Then
+    cmd=['git', 'checkout', branch]
+    mock_subproc_popen.assert_has_calls([
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call().communicate()
+    ])
+    assert { "code": rc, "message": stderr_message,  "command": ' '.join(cmd) } == actual_response
+
+
+@patch('subprocess.Popen')
+@patch.object(Git, '_get_branch_reference', return_value="refs/heads/local_branch")
+def test_checkout_branch_headsref_success(mock__get_branch_reference, mock_subproc_popen):
+    branch='test-branch'
+    stdout_message='checkout output from git'
+    stderr_message=''
+    rc=0
+
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': (stdout_message.encode('utf-8'), stderr_message.encode('utf-8')),
+        'returncode': rc
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').checkout_branch(
+        branchname=branch,
+        current_path='test_curr_path')
+
+    # Then
+    cmd=['git', 'checkout', branch]
+    mock_subproc_popen.assert_has_calls([
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call().communicate()
+    ])
+    assert { "code": rc, "message": stdout_message } == actual_response
+
+
+@patch('subprocess.Popen')
+@patch.object(Git, '_get_branch_reference', return_value="refs/remotes/remote_branch")
+def test_checkout_branch_remoteref_failure(mock__get_branch_reference, mock_subproc_popen):
+    branch='test-branch'
+    stdout_message=''
+    stderr_message="error: pathspec '"+branch+"' did not match any file(s) known to git"
+    rc=1
+
+    # Given
+    process_mock = Mock()
+    attrs = { 'communicate.return_value': (stdout_message.encode('utf-8'), stderr_message.encode('utf-8')), 'returncode': rc }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    # When
+    actual_response = Git(root_dir='/bin').checkout_branch(branchname=branch, current_path='test_curr_path')
+
+    # Then
+    cmd=['git', 'checkout', '--track', branch]
+    mock_subproc_popen.assert_has_calls([
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call().communicate()
+    ])
+    assert { "code": rc, "message": stderr_message,  "command": ' '.join(cmd) } == actual_response
+
+
+
+@patch('subprocess.Popen')
+def test_get_branch_reference_success(mock_subproc_popen):
+    actual_response = 0
+    branch='test-branch'
+    reference = 'refs/remotes/origin/test_branch'
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': (reference.encode('utf-8'), ''.encode('utf-8')),
+        'returncode': 0
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+ 
+    # When
+    actual_response = Git(root_dir='/bin')._get_branch_reference(
+        branchname=branch,
+        current_path='test_curr_path')
+ 
+    # Then
+    mock_subproc_popen.assert_has_calls([
+        call(
+            ['git', 'rev-parse', '--symbolic-full-name', branch],
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd='/bin/test_curr_path'
+        ),
+        call().communicate()
+    ])
+    assert actual_response == reference
+
+
+@patch('subprocess.Popen')
+def test_get_branch_reference_faillure(mock_subproc_popen):
+    actual_response = 0
+    branch='test-branch'
+    reference = 'test-branch'
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': (reference.encode('utf-8'),
+        ("fatal: ambiguous argument '"+branch+"': unknown revision or path not in the working tree.").encode('utf-8')),
+        'returncode': 128
+    }
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+ 
+    # When
+    actual_response = Git(root_dir='/bin')._get_branch_reference(
+        branchname=branch,
+        current_path='test_curr_path')
+ 
+    # Then
+    mock_subproc_popen.assert_has_calls([
+        call(
+            ['git', 'rev-parse', '--symbolic-full-name', branch],
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd='/bin/test_curr_path'
+        ),
+        call().communicate()
+    ])
+    assert actual_response is None
+
 
 @patch('subprocess.Popen')
 def test_get_current_branch_failure(mock_subproc_popen):

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -102,6 +102,7 @@ def test_get_current_branch_success(mock_subproc_popen):
 @patch.object(Git, '_get_branch_reference', return_value=None)
 def test_checkout_branch_noref_success(mock__get_branch_reference, mock_subproc_popen):
     branch='test-branch'
+    curr_path='test_curr_path'
     stdout_message='checkout output from git'
     stderr_message=''
     rc=0
@@ -116,16 +117,17 @@ def test_checkout_branch_noref_success(mock__get_branch_reference, mock_subproc_
     mock_subproc_popen.return_value = process_mock
 
     # When
-    actual_response = Git(root_dir='/bin').checkout_branch(
-        branchname=branch,
-        current_path='test_curr_path')
+    actual_response = Git(root_dir='/bin').checkout_branch(branchname=branch, current_path=curr_path)
 
     # Then
+    mock__get_branch_reference.assert_has_calls([ call(branch, curr_path) ])
+
     cmd=['git', 'checkout', branch]
     mock_subproc_popen.assert_has_calls([
-        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/{}'.format(curr_path)),
         call().communicate()
     ])
+
     assert { "code": rc, "message": stdout_message } == actual_response
 
 
@@ -133,8 +135,9 @@ def test_checkout_branch_noref_success(mock__get_branch_reference, mock_subproc_
 @patch.object(Git, '_get_branch_reference', return_value=None)
 def test_checkout_branch_noref_failure(mock__get_branch_reference, mock_subproc_popen):
     branch='test-branch'
+    curr_path='test_curr_path'
     stdout_message=''
-    stderr_message="error: pathspec '"+branch+"' did not match any file(s) known to git"
+    stderr_message="error: pathspec '{}' did not match any file(s) known to git".format(branch)
     rc=1
 
     # Given
@@ -144,14 +147,17 @@ def test_checkout_branch_noref_failure(mock__get_branch_reference, mock_subproc_
     mock_subproc_popen.return_value = process_mock
 
     # When
-    actual_response = Git(root_dir='/bin').checkout_branch(branchname=branch, current_path='test_curr_path')
+    actual_response = Git(root_dir='/bin').checkout_branch(branchname=branch, current_path=curr_path)
 
     # Then
+    mock__get_branch_reference.assert_has_calls([ call(branch, curr_path) ])
+
     cmd=['git', 'checkout', branch]
     mock_subproc_popen.assert_has_calls([
-        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/{}'.format(curr_path)),
         call().communicate()
     ])
+
     assert { "code": rc, "message": stderr_message,  "command": ' '.join(cmd) } == actual_response
 
 
@@ -159,6 +165,7 @@ def test_checkout_branch_noref_failure(mock__get_branch_reference, mock_subproc_
 @patch.object(Git, '_get_branch_reference', return_value="refs/remotes/remote_branch")
 def test_checkout_branch_remoteref_success(mock__get_branch_reference, mock_subproc_popen):
     branch='test-branch'
+    curr_path='test_curr_path'
     stdout_message='checkout output from git'
     stderr_message=''
     rc=0
@@ -173,14 +180,14 @@ def test_checkout_branch_remoteref_success(mock__get_branch_reference, mock_subp
     mock_subproc_popen.return_value = process_mock
 
     # When
-    actual_response = Git(root_dir='/bin').checkout_branch(
-        branchname=branch,
-        current_path='test_curr_path')
+    actual_response = Git(root_dir='/bin').checkout_branch(branchname=branch, current_path=curr_path)
 
     # Then
+    mock__get_branch_reference.assert_has_calls([ call(branch, curr_path) ])
+
     cmd=['git', 'checkout', '--track', branch]
     mock_subproc_popen.assert_has_calls([
-        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/{}'.format(curr_path)),
         call().communicate()
     ])
     assert { "code": rc, "message": stdout_message } == actual_response
@@ -190,8 +197,9 @@ def test_checkout_branch_remoteref_success(mock__get_branch_reference, mock_subp
 @patch.object(Git, '_get_branch_reference', return_value="refs/heads/local_branch")
 def test_checkout_branch_headsref_failure(mock__get_branch_reference, mock_subproc_popen):
     branch='test-branch'
+    curr_path='test_curr_path'
     stdout_message=''
-    stderr_message="error: pathspec '"+branch+"' did not match any file(s) known to git"
+    stderr_message="error: pathspec '{}' did not match any file(s) known to git".format(branch)
     rc=1
 
     # Given
@@ -201,12 +209,14 @@ def test_checkout_branch_headsref_failure(mock__get_branch_reference, mock_subpr
     mock_subproc_popen.return_value = process_mock
 
     # When
-    actual_response = Git(root_dir='/bin').checkout_branch(branchname=branch, current_path='test_curr_path')
+    actual_response = Git(root_dir='/bin').checkout_branch(branchname=branch, current_path=curr_path)
 
     # Then
+    mock__get_branch_reference.assert_has_calls([ call(branch, curr_path) ])
+
     cmd=['git', 'checkout', branch]
     mock_subproc_popen.assert_has_calls([
-        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/test_curr_path'),
+        call(cmd, stdout=PIPE, stderr=PIPE, cwd='/bin/{}'.format(curr_path)),
         call().communicate()
     ])
     assert { "code": rc, "message": stderr_message,  "command": ' '.join(cmd) } == actual_response
@@ -248,7 +258,7 @@ def test_checkout_branch_headsref_success(mock__get_branch_reference, mock_subpr
 def test_checkout_branch_remoteref_failure(mock__get_branch_reference, mock_subproc_popen):
     branch='test-branch'
     stdout_message=''
-    stderr_message="error: pathspec '"+branch+"' did not match any file(s) known to git"
+    stderr_message="error: pathspec '{}' did not match any file(s) known to git".format(branch)
     rc=1
 
     # Given
@@ -303,15 +313,17 @@ def test_get_branch_reference_success(mock_subproc_popen):
 
 
 @patch('subprocess.Popen')
-def test_get_branch_reference_faillure(mock_subproc_popen):
+def test_get_branch_reference_failure(mock_subproc_popen):
     actual_response = 0
     branch='test-branch'
     reference = 'test-branch'
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': (reference.encode('utf-8'),
-        ("fatal: ambiguous argument '"+branch+"': unknown revision or path not in the working tree.").encode('utf-8')),
+        'communicate.return_value': (
+            reference.encode('utf-8'),
+            "fatal: ambiguous argument '{}': unknown revision or path not in the working tree.".format(branch).encode('utf-8')
+        ),
         'returncode': 128
     }
     process_mock.configure_mock(**attrs)


### PR DESCRIPTION
Currently, checking out a remote branch results in a detached branch.

The fix included in this branch does the following:

* it provides a new method to get the branch reference:
_get_branch_reference(self, branchname, current_path)

* it changes the behavior of the checkout_branch(...) method so that the '--track' parameter is passed during remote branches checkout.

Current checkout behavior is unchanged for local branch checkouts and also in case of error.