### PR TITLE
Fix for #396

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   pip: true
   directories:
     - /home/travis/.yarn-cache/
-install: pip install pytest "jupyterlab>=1.0.3"
+install: pip install pytest
 script:
   - pytest tests/unit
   - yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ cache:
     - /home/travis/.yarn-cache/
 install: pip install pytest
 script:
+  - pip install .
   - pytest tests/unit
   - yarn
   - yarn build
   - yarn test
-  - pip install .
   - jupyter serverextension enable --py jupyterlab_git
   - jupyter labextension install .
   - python -m jupyterlab.browser_check

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     install_requires=[
-        'jupyterlab >= 1.0.0',
+        'jupyterlab >= 1.0.3',
         'nbdime >= 1.1.0'
     ],
     package_data={'jupyterlab_git': ['*']},

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     install_requires=[
-        'notebook',
+        'jupyterlab >= 1.0.0',
         'nbdime >= 1.1.0'
     ],
     package_data={'jupyterlab_git': ['*']},


### PR DESCRIPTION
Using `pip`, the user could end up not having the latest frontend extension as JupyterLab version has not the right version (see #396).

Fix #396 