### PR TITLE
gitApi: add corner case handling for deleted remote branches

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -693,6 +693,8 @@ class Git:
             return output.decode("utf-8").strip()
         elif "fatal: no upstream configured for branch" in error.decode("utf-8").lower():
             return None
+        elif "unknown revision or path not in the working tree" in error.decode("utf-8"):
+            return None
         else:
             raise Exception(
                 "Error [{}] occurred while executing [{}] command to get upstream branch.".format(

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -693,7 +693,7 @@ class Git:
             return output.decode("utf-8").strip()
         elif "fatal: no upstream configured for branch" in error.decode("utf-8").lower():
             return None
-        elif "unknown revision or path not in the working tree" in error.decode("utf-8"):
+        elif "unknown revision or path not in the working tree" in error.decode("utf-8").lower():
             return None
         else:
             raise Exception(


### PR DESCRIPTION
Add handling for corner case when remote branch have been deleted while local branch still persists. To reproduce existing bug:
```
git branch exist-on-local-but-deleted-on-remote-branch
git push --set-upstream origin exist-on-local-but-deleted-on-remote-branch
git push --delete origin exist-on-local-but-deleted-on-remote-branch
# refresh jupyterlab-git to show generic `you aren't in a git repository` message
```
this is caused by calling
`git rev-parse --abbrev-ref exist-on-local-but-deleted-on-remote-branch@{upstream}`
which returns
```
fatal: ambiguous argument 'exist-on-local-but-deleted-on-remote-branch@{upstream}': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

this small MR address the issue by addling the handle for this error message, which should `return None` for the upstream message instead of throwing an Exception which breaks `branch` function at `jupyterlab_git/git.py:335`