### PR TITLE
Lowercase Git error messages before checking substring existence

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -691,7 +691,7 @@ class Git:
         output, error = p.communicate()
         if p.returncode == 0:
             return output.decode("utf-8").strip()
-        elif "fatal: no upstream configured for branch" in error.decode("utf-8").toLowerCase():
+        elif "fatal: no upstream configured for branch" in error.decode("utf-8").lower():
             return None
         else:
             raise Exception(
@@ -717,9 +717,9 @@ class Git:
             return output.decode("utf-8").strip()
         elif "fatal: no tags can describe '{}'.".format(commit_sha) in error.decode(
             "utf-8"
-        ).toLowerCase():
+        ).lower():
             return None
-        elif "fatal: no names found" in error.decode("utf-8").toLowerCase():
+        elif "fatal: no names found" in error.decode("utf-8").lower():
             return None
         else:
             raise Exception(

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -691,7 +691,7 @@ class Git:
         output, error = p.communicate()
         if p.returncode == 0:
             return output.decode("utf-8").strip()
-        elif "fatal: no upstream configured for branch" in error.decode("utf-8"):
+        elif "fatal: no upstream configured for branch" in error.decode("utf-8").toLowerCase():
             return None
         else:
             raise Exception(
@@ -715,11 +715,11 @@ class Git:
         output, error = p.communicate()
         if p.returncode == 0:
             return output.decode("utf-8").strip()
-        elif "fatal: No tags can describe '{}'.".format(commit_sha) in error.decode(
+        elif "fatal: no tags can describe '{}'.".format(commit_sha) in error.decode(
             "utf-8"
-        ):
+        ).toLowerCase():
             return None
-        elif "fatal: No names found" in error.decode("utf-8"):
+        elif "fatal: no names found" in error.decode("utf-8").toLowerCase():
             return None
         else:
             raise Exception(


### PR DESCRIPTION
This pull request is to be defensive and add a little flexibility when checking for exact error messages from the output of `git` commands.

<img width="713" alt="Screen Shot 2019-09-09 at 3 03 21 PM" src="https://user-images.githubusercontent.com/7623671/64570692-3137ea00-d316-11e9-8420-f2cd6dda69c3.png">

At Twitter, we have a custom fork of Git that apparently has the `n` letter capitalized for the `git rev-parse --abbrev-ref branch@{upstream}` scenario which was breaking the `GitPanel` component ultimately resulting in an inability to create new branches. 

This change would help us maintain a dependency with this upstream version rather than a custom fork and is backwards compatible.

Thanks!