### PR TITLE
CD with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,17 @@ script:
   - python -m jupyterlab.browser_check
   - jlpm run lint
   - python tests/test-browser/run_browser_test.py
+
+deploy:
+  - provider: pypi
+    user: "Your username"
+    password:
+      secure: "Your encrypted password"
+    distributions: "sdist bdist_wheel"
+    on:
+      tags: true
+  - provider: npm
+    email: "YOUR_EMAIL_ADDRESS"
+    api_key: "YOUR_AUTH_TOKEN"
+    on:
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 script:
   - pip install 'jupyterlab~=1.0'
   - python setup.py sdist
-  - pip install --find-links=dist jupyterlab_git[test]
+  - pip install --find-links=dist --pre jupyterlab_git[test]
   - pytest jupyterlab_git
   - jlpm install
   - jlpm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,13 @@ script:
 
 deploy:
   - provider: pypi
-    user: "Your username"
-    password:
-      secure: "Your encrypted password"
+    user: "$PYPI_USER"
+    password: "$PYPI_TOKEN"
     distributions: "sdist bdist_wheel"
     on:
       tags: true
   - provider: npm
-    email: "YOUR_EMAIL_ADDRESS"
-    api_key: "YOUR_AUTH_TOKEN"
+    email: "$NPM_EMAIL"
+    api_key: "$NPM_TOKEN"
     on:
       tags: true

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
  ## CI/CD: 
- - ~~CD: Trigger releases on tags.~~ (#416)
+ - CD: Trigger releases on tags. (#416)
    - **What?** Add CD capabilities to trigger a release when a tag is pushed.
    - **Why?** Save maintainer manual effort on releases. Increase cadence of releases.
- - ~~Combining the Python and JS files into one installable package~~ (#415)
+ - Combining the Python and JS files into one installable package (#415)
    - **What?** Provide a single installation  for both the frontend and the server package
    - **Why?** Reduce number of issues from users have different versions of the NPM and Python packages. Easier installation for users
  - Integration Testing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
  ## CI/CD: 
- - CD: Trigger releases on tags.
+ - ~~CD: Trigger releases on tags.~~ (#416)
    - **What?** Add CD capabilities to trigger a release when a tag is pushed.
    - **Why?** Save maintainer manual effort on releases. Increase cadence of releases.
- - Combining the Python and JS files into one installable package
+ - ~~Combining the Python and JS files into one installable package~~ (#415)
    - **What?** Provide a single installation  for both the frontend and the server package
    - **Why?** Reduce number of issues from users have different versions of the NPM and Python packages. Easier installation for users
  - Integration Testing

--- a/jupyterlab_git/_version.py
+++ b/jupyterlab_git/_version.py
@@ -1,5 +1,5 @@
 # Copyright (c) Project Jupyter.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 8, 2)
+version_info = (0, 8, "3a0")
 __version__ = ".".join(map(str, version_info))

--- a/package.json
+++ b/package.json
@@ -111,5 +111,8 @@
   "homepage": "https://github.com/jupyterlab/jupyterlab-git",
   "resolutions": {
     "@types/react": "~16.8.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/git",
-  "version": "0.8.2",
+  "version": "0.8.3-alpha.0",
   "description": "A JupyterLab extension for version control using git",
   "main": "lib/index.js",
   "style": "style/index.css",


### PR DESCRIPTION
@jaipreet-s following our discussion, I looked into Travis documentation for automatic deployment. It is definitely possible. I modify the travis file with a squeleton of configuration to deploy on tag action. What is missing: valid credentials for publishing the packages on PyPI and npm and testing.

Documentation:
- General documentation on deployment: https://docs.travis-ci.com/user/deployment/
- Documentation for PyPI: https://docs.travis-ci.com/user/deployment/pypi/
- Documentation for npm: https://docs.travis-ci.com/user/deployment/npm/

