### PR TITLE
Adds user setings: historyCount controls number of logs shown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - python setup.py bdist_wheel
   - pip install --find-links=dist jupyterlab_git[test]
   - jupyter lab build
-  - pytest jupyterlab_git
+  - pytest jupyterlab_git -r ap
   - jlpm run test
   - python -m jupyterlab.browser_check
   - jlpm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ cache:
   pip: true
   directories:
     - /home/travis/.yarn-cache/
+install: pip install pytest "jupyterlab~=1.0"
 script:
-  - pip install 'jupyterlab~=1.0'
-  - python setup.py sdist
+  - python setup.py bdist_wheel
   - pip install --find-links=dist jupyterlab_git[test]
+  - jupyter lab build
   - pytest jupyterlab_git
   - jlpm run test
-  - jupyter lab build
   - python -m jupyterlab.browser_check
   - jlpm run lint
   - python tests/test-browser/run_browser_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ cache:
     - /home/travis/.yarn-cache/
 install: pip install pytest "jupyterlab~=1.0"
 script:
-  - python setup.py bdist_wheel
-  - pip install --find-links=dist jupyterlab_git[test]
+  - python setup.py sdist
+  - pip install jupyterlab_git[test] --find-links=dist --no-deps --no-cache-dir -v
+  - pip install jupyterlab_git[test] --find-links=dist -v
+  - jupyter labextension list
   - jupyter lab build
   - pytest jupyterlab_git -r ap
   - jlpm run test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ graft tests
 prune tests/build
 
 # Javascript files
+graft schema
 graft src
 graft style
 prune **/node_modules

--- a/jupyterlab_git/_version.py
+++ b/jupyterlab_git/_version.py
@@ -1,5 +1,5 @@
 # Copyright (c) Project Jupyter.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 8, 2)
+version_info = (0, 9, 0)
 __version__ = ".".join(map(str, version_info))

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -233,12 +233,12 @@ class Git:
                 "message": my_error.decode("utf-8"),
             }
 
-    def log(self, current_path):
+    def log(self, current_path, history_count=10):
         """
         Execute git log command & return the result.
         """
         p = Popen(
-            ["git", "log", "--pretty=format:%H%n%an%n%ar%n%s", "-10"],
+            ["git", "log", "--pretty=format:%H%n%an%n%ar%n%s", ("-%d" % history_count)],
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, current_path),

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -51,13 +51,16 @@ class GitAllHistoryHandler(GitHandler):
         POST request handler, calls individual handlers for
         'git show_top_level', 'git branch', 'git log', and 'git status'
         """
-        current_path = self.get_json_body()["current_path"]
+        body = self.get_json_body()
+        current_path = body["current_path"]
+        history_count = body["history_count"]
+
         show_top_level = self.git.show_top_level(current_path)
         if show_top_level["code"] != 0:
             self.finish(json.dumps(show_top_level))
         else:
             branch = self.git.branch(current_path)
-            log = self.git.log(current_path)
+            log = self.git.log(current_path, history_count)
             status = self.git.status(current_path)
 
             result = {

--- a/jupyterlab_git/tests/test_handlers.py
+++ b/jupyterlab_git/tests/test_handlers.py
@@ -1,6 +1,7 @@
+import json
 from mock import Mock, ANY, patch
 
-from jupyterlab_git.handlers import GitUpstreamHandler, GitPushHandler, setup_handlers
+from jupyterlab_git.handlers import GitAllHistoryHandler, GitUpstreamHandler, GitPushHandler, setup_handlers
 
 
 def test_mapping_added():
@@ -17,7 +18,7 @@ def test_mapping_added():
 @patch('jupyterlab_git.handlers.GitUpstreamHandler.get_json_body', Mock(return_value={'current_path': 'test_path'}))
 @patch('jupyterlab_git.handlers.GitUpstreamHandler.git')
 @patch('jupyterlab_git.handlers.GitUpstreamHandler.finish')
-def test_push_handler_localbranch(mock_finish, mock_git):
+def test_upstream_handler_localbranch(mock_finish, mock_git):
     # Given
     mock_git.get_current_branch.return_value = 'foo'
     mock_git.get_upstream_branch.return_value = 'bar'
@@ -29,6 +30,42 @@ def test_push_handler_localbranch(mock_finish, mock_git):
     mock_git.get_current_branch.assert_called_with('test_path')
     mock_git.get_upstream_branch.assert_called_with('test_path', 'foo')
     mock_finish.assert_called_with('{"upstream": "bar"}')
+
+
+@patch('jupyterlab_git.handlers.GitAllHistoryHandler.__init__', Mock(return_value=None))
+@patch('jupyterlab_git.handlers.GitAllHistoryHandler.get_json_body', Mock(return_value={'current_path': 'test_path', 'history_count': 25}))
+@patch('jupyterlab_git.handlers.GitAllHistoryHandler.git')
+@patch('jupyterlab_git.handlers.GitAllHistoryHandler.finish')
+def test_all_history_handler_localbranch(mock_finish, mock_git):
+    # Given
+    show_top_level = {'code': 0, 'foo': 'top_level'}
+    branch = 'branch_foo'
+    log = 'log_foo'
+    status = 'status_foo'
+
+    mock_git.show_top_level.return_value = show_top_level
+    mock_git.branch.return_value = branch
+    mock_git.log.return_value = log
+    mock_git.status.return_value = status
+
+    # When
+    GitAllHistoryHandler().post()
+
+    # Then
+    mock_git.show_top_level.assert_called_with('test_path')
+    mock_git.branch.assert_called_with('test_path')
+    mock_git.log.assert_called_with('test_path', 25)
+    mock_git.status.assert_called_with('test_path')
+
+    mock_finish.assert_called_with(json.dumps({
+        'code': show_top_level['code'],
+        'data': {
+            'show_top_level': show_top_level,
+            'branch': branch,
+            'log': log,
+            'status': status,
+        }
+    }))
 
 
 @patch('jupyterlab_git.handlers.GitPushHandler.__init__', Mock(return_value=None))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/git",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "A JupyterLab extension for version control using git",
   "main": "lib/index.js",
   "style": "style/index.css",

--- a/package.json
+++ b/package.json
@@ -28,14 +28,13 @@
   },
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/*.css",
-    "style/images/*.svg"
+    "schema/**/*.{json,}",
+    "style/**/*.{css,svg}"
   ],
   "sideEffects": [
     "style/*.css"
   ],
   "jupyterlab": {
-    "extension": true,
     "discovery": {
       "server": {
         "managers": [
@@ -46,7 +45,9 @@
           "name": "jupyterlab-git"
         }
       }
-    }
+    },
+    "extension": true,
+    "schemaDir": "schema"
   },
   "dependencies": {
     "@jupyterlab/application": "^1.1.0",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,0 +1,15 @@
+{
+  "jupyter.lab.setting-icon-class": "jp-GitIcon",
+  "jupyter.lab.setting-icon-label": "Git",
+  "title": "Git",
+  "description": "jupyterlab-git settings.",
+  "type": "object",
+  "properties": {
+    "historyCount": {
+      "type": "integer",
+      "title": "History count",
+      "description": "Number of (most recent) commits shown in the history log",
+      "default": 100
+    }
+  }
+}

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -9,7 +9,7 @@
       "type": "integer",
       "title": "History count",
       "description": "Number of (most recent) commits shown in the history log",
-      "default": 100
+      "default": 25
     }
   }
 }

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -28,6 +28,7 @@ import {
   findRepoButtonStyle
 } from '../style/GitPanelStyle';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ISettingRegistry } from '@jupyterlab/coreutils';
 
 /** Interface for GitPanel component state */
 export interface IGitSessionNodeState {
@@ -56,6 +57,7 @@ export interface IGitSessionNodeProps {
   app: JupyterFrontEnd;
   diff: IDiffCallback;
   renderMime: IRenderMimeRegistry;
+  settings: ISettingRegistry.ISettings;
 }
 
 /** A React component for the git extension's main display */
@@ -103,7 +105,8 @@ export class GitPanel extends React.Component<
       if (fileBrowser) {
         // Make API call to get all git info for repo
         let apiResult = await gitApi.allHistory(
-          (fileBrowser as any).model.path
+          (fileBrowser as any).model.path,
+          this.props.settings.composite['historyCount'] as number
         );
 
         if (apiResult.code === 0) {

--- a/src/components/GitWidget.tsx
+++ b/src/components/GitWidget.tsx
@@ -94,7 +94,6 @@ export class GitWidget extends Widget {
 
     void registry.load(key).then(settings => {
       this._settings = settings;
-      // this._settings.changed.connect(this._loadSettings, this);
 
       const element = (
         <GitPanel
@@ -105,6 +104,8 @@ export class GitWidget extends Widget {
         />
       );
       this.component = ReactDOM.render(element, this.node);
+
+      this._settings.changed.connect(this.component.refresh, this);
       this.component.refresh();
     });
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -270,10 +270,14 @@ export class Git {
   /** Make request for all git info of repository 'path'
    * (This API is also implicitly used to check if the current repo is a Git repo)
    */
-  async allHistory(path: string): Promise<IGitAllHistory> {
+  async allHistory(
+    path: string,
+    historyCount: number
+  ): Promise<IGitAllHistory> {
     try {
       let response = await httpGitRequest('/git/all_history', 'POST', {
-        current_path: path
+        current_path: path,
+        history_count: historyCount
       });
       if (response.status !== 200) {
         const data = await response.text();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { PathExt } from '@jupyterlab/coreutils';
+import { ISettingRegistry, PathExt } from '@jupyterlab/coreutils';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
@@ -32,12 +32,13 @@ export interface IGitExtension {
  * The default running sessions extension.
  */
 const plugin: JupyterFrontEndPlugin<IGitExtension> = {
-  id: 'jupyter.extensions.running-sessions-git',
+  id: '@jupyterlab/git:plugin',
   requires: [
     IMainMenu,
     ILayoutRestorer,
     IFileBrowserFactory,
-    IRenderMimeRegistry
+    IRenderMimeRegistry,
+    ISettingRegistry
   ],
   provides: IGitExtension,
   activate,
@@ -55,6 +56,8 @@ export class GitExtension implements IGitExtension {
   gitCloneWidget: GitClone;
   constructor(
     app: JupyterFrontEnd,
+    key: string,
+    settings: ISettingRegistry,
     restorer: ILayoutRestorer,
     factory: IFileBrowserFactory,
     renderMime: IRenderMimeRegistry
@@ -62,7 +65,7 @@ export class GitExtension implements IGitExtension {
     this.app = app;
     this.gitPlugin = new GitWidget(
       app,
-      { manager: app.serviceManager },
+      { key, manager: app.serviceManager, settings },
       this.performDiff.bind(this),
       renderMime
     );
@@ -109,13 +112,22 @@ function activate(
   mainMenu: IMainMenu,
   restorer: ILayoutRestorer,
   factory: IFileBrowserFactory,
-  renderMime: IRenderMimeRegistry
+  renderMime: IRenderMimeRegistry,
+  settings: ISettingRegistry
 ): IGitExtension {
   const { commands } = app;
+  const key = plugin.id;
 
   registerGitIcons(defaultIconRegistry);
 
-  let gitExtension = new GitExtension(app, restorer, factory, renderMime);
+  let gitExtension = new GitExtension(
+    app,
+    key,
+    settings,
+    restorer,
+    factory,
+    renderMime
+  );
 
   const category = 'Git';
   // Rank has been chosen somewhat arbitrarily to give priority to the running


### PR DESCRIPTION
This PR adds a schema file for user settings for this extension. `jupyterlab-git` now has a section in the Advanced Settings Editor that you can access via the Settings menu. I've also added a simple `historyCount` setting to get the git settings started. It controls how many logs are visible in the history tab.