### PR TITLE
Fix filename split in detailed log (#427)

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -280,7 +280,7 @@ class Git:
         Execute git log -1 --stat --numstat --oneline command (used to get
         insertions & deletions per file) & return the result.
         """
-        p = Popen(
+        p = subprocess.Popen(
             ["git", "log", "-1", "--stat", "--numstat", "--oneline", selected_hash],
             stdout=PIPE,
             stderr=PIPE,
@@ -305,7 +305,7 @@ class Git:
                         note[count] = words[i]
                         count += 1
                 for num in range(1, int(length / 2)):
-                    line_info = line_array[num].split()
+                    line_info = line_array[num].split(maxsplit=2)
                     words = line_info[2].split("/")
                     length = len(words)
                     result.append(

--- a/jupyterlab_git/tests/test_detailed_log.py
+++ b/jupyterlab_git/tests/test_detailed_log.py
@@ -1,0 +1,80 @@
+# python lib
+from subprocess import PIPE
+from mock import patch, call, Mock
+
+# local lib
+from jupyterlab_git.git import Git
+
+
+@patch('subprocess.Popen')
+def test_detailed_log(mock_subproc_popen):
+    # Given
+    process_output = [
+        'f29660a (HEAD, origin/feature) Commit message',
+        '10      3       notebook_without_spaces.ipynb',
+        '11      4       Notebook with spaces.ipynb',
+        '12      5       path/notebook_without_spaces.ipynb',
+        '13      6       path/Notebook with spaces.ipynb',
+        ' notebook_without_spaces.ipynb      | 13 ++++++++---',
+        ' Notebook with spaces.ipynb         | 15 +++++++++----',
+        ' path/notebook_without_spaces.ipynb | 17 ++++++++++-----',
+        ' path/Notebook with spaces.ipynb    | 19 +++++++++++------',
+        ' 4 files changed, 46 insertions(+), 18 deletions(-)'
+    ]
+    process_mock = Mock(returncode=0)
+    process_mock.communicate.side_effect = [
+        ('\n'.join(process_output).encode('utf-8'), ''.encode('utf-8')),
+    ]
+    mock_subproc_popen.return_value = process_mock
+
+    expected_response = {
+        'code': 0,
+        'modified_file_note': ' 4 files changed, 46 insertions(+), 18 deletions(-)',
+        'modified_files_count': '4',
+        'number_of_insertions': '46',
+        'number_of_deletions': '18',
+        'modified_files': [
+            {
+                'modified_file_path': 'notebook_without_spaces.ipynb',
+                'modified_file_name': 'notebook_without_spaces.ipynb',
+                'insertion': '10',
+                'deletion': '3'
+            },
+            {
+                'modified_file_path': 'Notebook with spaces.ipynb',
+                'modified_file_name': 'Notebook with spaces.ipynb',
+                'insertion': '11',
+                'deletion': '4'
+            },
+            {
+                'modified_file_path': 'path/notebook_without_spaces.ipynb',
+                'modified_file_name': 'notebook_without_spaces.ipynb',
+                'insertion': '12',
+                'deletion': '5'
+            },
+            {
+                'modified_file_path': 'path/Notebook with spaces.ipynb',
+                'modified_file_name': 'Notebook with spaces.ipynb',
+                'insertion': '13',
+                'deletion': '6'
+            }
+        ]
+    }
+
+    # When
+    actual_response = Git(root_dir='/bin').detailed_log(
+        selected_hash='f29660a2472e24164906af8653babeb48e4bf2ab',
+        current_path='test_curr_path')
+
+    # Then
+    mock_subproc_popen.assert_has_calls([
+        call(
+            ['git', 'log', '-1', '--stat', '--numstat', '--oneline', 'f29660a2472e24164906af8653babeb48e4bf2ab'],
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd='/bin/test_curr_path'
+        ),
+        call().communicate(),
+    ], any_order=False)
+
+    assert expected_response == actual_response


### PR DESCRIPTION
Files with spaces weren't being recognized because of a split in `Git.detailed_logs` that was splitting too much, see #427

The `Git.detailed_logs` function was also missing tests so I added some to validate my fix. I used the same test structure as what I found in `test_branch.py`.

I validated this locally too and it works as expected :+1:

![JupyterLab](https://user-images.githubusercontent.com/5640848/67134401-d754fa80-f1c6-11e9-8aad-25b51a44027c.png)
