### PR TITLE
ensured that the styling in diff.css gets imported into the bundle

### DIFF
--- a/style/diff.css
+++ b/style/diff.css
@@ -1,3 +1,8 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
 .jp-git-Notebook-diff .CodeMirror-gutter.CodeMirror-linenumbers[style] {
     width: 29px !important;
 }

--- a/style/index.css
+++ b/style/index.css
@@ -1,1 +1,7 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+@import 'diff.css';
 @import 'variables.css';

--- a/style/variables.css
+++ b/style/variables.css
@@ -2,6 +2,7 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
+
 @import url('https://fonts.googleapis.com/css?family=Oswald');
 
 :root {


### PR DESCRIPTION
The CSS imports in `index.ts` were (rightfully) dropped in #426. Unfortunately, `diff.css` is now not getting imported anywhere, so we're missing styling for the nbdime diff. This PR fixes that by importing `diff.css` in `index.css`