### PR TITLE
Greatly improve performance of GitPanel refresh by streamlining Git.branch

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -477,64 +477,6 @@ class Git:
                 "message": error.decode("utf-8"),
             }
 
-    def branch_all(self, current_path):
-        """
-        Execute 'git for-each-ref' command on refs/heads & return the result.
-        """
-        formats = ['refname', 'refname:short', 'objectname', 'upstream:short', 'HEAD']
-        cmd = ["git", "for-each-ref", "--format=" + "%09".join("%({})".format(f) for f in formats), "refs/heads/", "refs/remotes/"]
-        p = subprocess.Popen(
-            cmd,
-            stdout=PIPE,
-            stderr=PIPE,
-            cwd=os.path.join(self.root_dir, current_path),
-        )
-        output, error = p.communicate()
-        if p.returncode == 0:
-            current_branch_seen = False
-            results = []
-            try:
-                for ref_name,name,commit_sha,upstream_name,is_current_branch in (line.split('\t') for line in output.decode("utf-8").splitlines()):
-                    # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
-                    is_current_branch = bool(is_current_branch.strip())
-                    current_branch_seen |= is_current_branch
-
-                    results.append({
-                        "is_current_branch": is_current_branch,
-                        "is_remote_branch": ref_name.startswith('refs/remotes/'),
-                        "name": name,
-                        "upstream": upstream_name if upstream_name else None,
-                        "top_commit": commit_sha,
-                        "tag": None,
-                    })
-
-                # Remote branch is seleted use 'git branch -a' as fallback machanism
-                # to get add detached head on remote branch to preserve older functionality
-                # TODO : Revisit this to checkout new local branch with same name as remote
-                # when the remote branch is seleted, VS Code git does the same thing.
-                if not current_branch_seen and self.get_current_branch(current_path) == "HEAD":
-                    results.append({
-                        "is_current_branch": True,
-                        "is_remote_branch": False,
-                        "name": self._get_detached_head_name(current_path),
-                        "upstream": None,
-                        "top_commit": None,
-                        "tag": None,
-                    })
-                return {"code": p.returncode, "branches": results}
-            except Exception as downstream_error:
-                return {
-                    "code": p.returncode,
-                    "command": ' '.join(cmd),
-                    "message": str(downstream_error),
-                }
-        else:
-            return {
-                "code": p.returncode,
-                "command": ' '.join(cmd),
-                "message": error.decode("utf-8"),
-            }
-
     def show_top_level(self, current_path):
         """
         Execute git --show-toplevel command & return the result.

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -383,7 +383,8 @@ class Git:
         """
         Execute 'git for-each-ref' command on refs/heads & return the result.
         """
-        cmd = ["git", "for-each-ref", "--format=%(refname)%09%(objectname)%09%(HEAD)%09%(upstream:short)", "refs/heads/"]
+        formats = ['refname:short', 'objectname', 'upstream:short', 'HEAD']
+        cmd = ["git", "for-each-ref", "--format=" + "%09".join("%({})".format(f) for f in formats), "refs/heads/"]
         p = subprocess.Popen(
             cmd,
             stdout=PIPE,
@@ -392,14 +393,18 @@ class Git:
         )
         output, error = p.communicate()
         if p.returncode == 0:
+            current_branch_seen = False
             results = []
             try:
-                for ref_name,commit_sha,is_current_branch,upstream_name in (line.split('\t') for line in output.decode("utf-8").splitlines()):
+                for name,commit_sha,upstream_name,is_current_branch in (line.split('\t') for line in output.decode("utf-8").splitlines()):
                     # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
+                    is_current_branch = bool(is_current_branch.strip())
+                    current_branch_seen |= is_current_branch
+
                     results.append({
-                        "is_current_branch": bool(is_current_branch.strip()),
+                        "is_current_branch": is_current_branch,
                         "is_remote_branch": False,
-                        "name": ref_name,
+                        "name": name,
                         "upstream": upstream_name if upstream_name else None,
                         "top_commit": commit_sha,
                         "tag": None,
@@ -409,7 +414,7 @@ class Git:
                 # to get add detached head on remote branch to preserve older functionality
                 # TODO : Revisit this to checkout new local branch with same name as remote
                 # when the remote branch is seleted, VS Code git does the same thing.
-                if self.get_current_branch(current_path) == "HEAD":
+                if not current_branch_seen and self.get_current_branch(current_path) == "HEAD":
                     results.append({
                         "is_current_branch": True,
                         "is_remote_branch": False,
@@ -421,7 +426,7 @@ class Git:
                 return {"code": p.returncode, "branches": results}
             except Exception as downstream_error:
                 return {
-                    "code": p.returncode,
+                    "code": -1,
                     "command": ' '.join(cmd),
                     "message": str(downstream_error),
                 }
@@ -436,7 +441,8 @@ class Git:
         """
         Execute 'git for-each-ref' command on refs/heads & return the result.
         """
-        cmd = ["git", "for-each-ref", '--format=%(refname)%09%(objectname)%09%(HEAD)', "refs/remotes/"]
+        formats = ['refname:short', 'objectname']
+        cmd = ["git", "for-each-ref", "--format=" + "%09".join("%({})".format(f) for f in formats), "refs/remotes/"]
         p = subprocess.Popen(
             cmd,
             stdout=PIPE,
@@ -447,14 +453,72 @@ class Git:
         if p.returncode == 0:
             results = []
             try:
-                for ref_name,commit_sha,is_current_branch in (line.split('\t') for line in output.decode("utf-8").splitlines()):
+                for name,commit_sha in (line.split('\t') for line in output.decode("utf-8").splitlines()):
                     # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
                     results.append({
-                        "is_current_branch": bool(is_current_branch.strip()),
+                        "is_current_branch": False,
                         "is_remote_branch": True,
-                        "name": ref_name,
+                        "name": name,
                         "upstream": None,
                         "top_commit": commit_sha,
+                        "tag": None,
+                    })
+                return {"code": p.returncode, "branches": results}
+            except Exception as downstream_error:
+                return {
+                    "code": -1,
+                    "command": ' '.join(cmd),
+                    "message": str(downstream_error),
+                }
+        else:
+            return {
+                "code": p.returncode,
+                "command": ' '.join(cmd),
+                "message": error.decode("utf-8"),
+            }
+
+    def branch_all(self, current_path):
+        """
+        Execute 'git for-each-ref' command on refs/heads & return the result.
+        """
+        formats = ['refname', 'refname:short', 'objectname', 'upstream:short', 'HEAD']
+        cmd = ["git", "for-each-ref", "--format=" + "%09".join("%({})".format(f) for f in formats), "refs/heads/", "refs/remotes/"]
+        p = subprocess.Popen(
+            cmd,
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd=os.path.join(self.root_dir, current_path),
+        )
+        output, error = p.communicate()
+        if p.returncode == 0:
+            current_branch_seen = False
+            results = []
+            try:
+                for ref_name,name,commit_sha,upstream_name,is_current_branch in (line.split('\t') for line in output.decode("utf-8").splitlines()):
+                    # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
+                    is_current_branch = bool(is_current_branch.strip())
+                    current_branch_seen |= is_current_branch
+
+                    results.append({
+                        "is_current_branch": is_current_branch,
+                        "is_remote_branch": ref_name.startswith('refs/remotes/'),
+                        "name": name,
+                        "upstream": upstream_name if upstream_name else None,
+                        "top_commit": commit_sha,
+                        "tag": None,
+                    })
+
+                # Remote branch is seleted use 'git branch -a' as fallback machanism
+                # to get add detached head on remote branch to preserve older functionality
+                # TODO : Revisit this to checkout new local branch with same name as remote
+                # when the remote branch is seleted, VS Code git does the same thing.
+                if not current_branch_seen and self.get_current_branch(current_path) == "HEAD":
+                    results.append({
+                        "is_current_branch": True,
+                        "is_remote_branch": False,
+                        "name": self._get_detached_head_name(current_path),
+                        "upstream": None,
+                        "top_commit": None,
                         "tag": None,
                     })
                 return {"code": p.returncode, "branches": results}

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -364,10 +364,28 @@ class Git:
 
     def branch(self, current_path):
         """
-        Execute 'git show-ref' command & return the result.
+        Execute 'git for-each-ref' command & return the result.
         """
+        heads = self.branch_heads(current_path)
+        if heads["code"] != 0:
+            # error; bail
+            return heads
+
+        remotes = self.branch_remotes(current_path)
+        if remotes["code"] != 0:
+            # error; bail
+            return remotes
+
+        # all's good; concatenate results and return
+        return {"code": 0, "branches": heads["branches"] + remotes["branches"]}
+
+    def branch_heads(self, current_path):
+        """
+        Execute 'git for-each-ref' command on refs/heads & return the result.
+        """
+        cmd = ["git", "for-each-ref", "--format=%(refname)%09%(objectname)%09%(HEAD)%09%(upstream:short)", "refs/heads/"]
         p = subprocess.Popen(
-            ["git", "show-ref"],
+            cmd,
             stdout=PIPE,
             stderr=PIPE,
             cwd=os.path.join(self.root_dir, current_path),
@@ -376,62 +394,80 @@ class Git:
         if p.returncode == 0:
             results = []
             try:
-                current_branch = self.get_current_branch(current_path)
-                for line in output.decode("utf-8").splitlines():
-                    # The format for git show-ref is '<SHA-1 ID> <space> <reference name>'
-                    # For this method we are only interested in reference name.
-                    # Reference : https://git-scm.com/docs/git-show-ref#_output
-                    commit_sha = line.strip().split()[0].strip()
-                    reference_name = line.strip().split()[1].strip()
-                    if self._is_branch(reference_name):
-                        branch_name = self._get_branch_name(reference_name)
-                        is_current_branch = self._is_current_branch(
-                            branch_name, current_branch
-                        )
-                        is_remote_branch = self._is_remote_branch(reference_name)
-                        upstream_branch_name = None
-                        if not is_remote_branch:
-                            upstream_branch_name = self.get_upstream_branch(
-                                current_path, branch_name
-                            )
-                        tag = self._get_tag(current_path, commit_sha)
-                        results.append(
-                            {
-                                "is_current_branch": is_current_branch,
-                                "is_remote_branch": is_remote_branch,
-                                "name": branch_name,
-                                "upstream": upstream_branch_name,
-                                "top_commit": commit_sha,
-                                "tag": tag,
-                            }
-                        )
+                for ref_name,commit_sha,is_current_branch,upstream_name in (line.split('\t') for line in output.decode("utf-8").splitlines()):
+                    # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
+                    results.append({
+                        "is_current_branch": bool(is_current_branch.strip()),
+                        "is_remote_branch": False,
+                        "name": ref_name,
+                        "upstream": upstream_name if upstream_name else None,
+                        "top_commit": commit_sha,
+                        "tag": None,
+                    })
 
                 # Remote branch is seleted use 'git branch -a' as fallback machanism
                 # to get add detached head on remote branch to preserve older functionality
                 # TODO : Revisit this to checkout new local branch with same name as remote
                 # when the remote branch is seleted, VS Code git does the same thing.
-                if current_branch == "HEAD":
-                    results.append(
-                        {
-                            "is_current_branch": True,
-                            "is_remote_branch": False,
-                            "name": self._get_detached_head_name(current_path),
-                            "upstream": None,
-                            "top_commit": None,
-                            "tag": None,
-                        }
-                    )
+                if self.get_current_branch(current_path) == "HEAD":
+                    results.append({
+                        "is_current_branch": True,
+                        "is_remote_branch": False,
+                        "name": self._get_detached_head_name(current_path),
+                        "upstream": None,
+                        "top_commit": None,
+                        "tag": None,
+                    })
                 return {"code": p.returncode, "branches": results}
             except Exception as downstream_error:
                 return {
                     "code": p.returncode,
-                    "command": "git show-ref",
+                    "command": ' '.join(cmd),
                     "message": str(downstream_error),
                 }
         else:
             return {
                 "code": p.returncode,
-                "command": "git show-ref",
+                "command": ' '.join(cmd),
+                "message": error.decode("utf-8"),
+            }
+
+    def branch_remotes(self, current_path):
+        """
+        Execute 'git for-each-ref' command on refs/heads & return the result.
+        """
+        cmd = ["git", "for-each-ref", '--format=%(refname)%09%(objectname)%09%(HEAD)', "refs/remotes/"]
+        p = subprocess.Popen(
+            cmd,
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd=os.path.join(self.root_dir, current_path),
+        )
+        output, error = p.communicate()
+        if p.returncode == 0:
+            results = []
+            try:
+                for ref_name,commit_sha,is_current_branch in (line.split('\t') for line in output.decode("utf-8").splitlines()):
+                    # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
+                    results.append({
+                        "is_current_branch": bool(is_current_branch.strip()),
+                        "is_remote_branch": True,
+                        "name": ref_name,
+                        "upstream": None,
+                        "top_commit": commit_sha,
+                        "tag": None,
+                    })
+                return {"code": p.returncode, "branches": results}
+            except Exception as downstream_error:
+                return {
+                    "code": p.returncode,
+                    "command": ' '.join(cmd),
+                    "message": str(downstream_error),
+                }
+        else:
+            return {
+                "code": p.returncode,
+                "command": ' '.join(cmd),
                 "message": error.decode("utf-8"),
             }
 

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -444,7 +444,8 @@ def test_branch_success(mock_subproc_popen):
                 'name': 'feature-bar',
                 'upstream': None,
                 'top_commit': '01234567899999abcdefghijklmnopqrstuvwxyz',
-                'tag': None},
+                'tag': None
+            },
             {
                 'is_current_branch': False,
                 'is_remote_branch': True,

--- a/jupyterlab_git/tests/test_handlers.py
+++ b/jupyterlab_git/tests/test_handlers.py
@@ -1,8 +1,13 @@
 import json
 from mock import Mock, ANY, patch
 
-from jupyterlab_git.handlers import GitAllHistoryHandler, GitUpstreamHandler, GitPushHandler, setup_handlers
-
+from jupyterlab_git.handlers import (
+    GitAllHistoryHandler,
+    GitBranchHandler,
+    GitPushHandler,
+    GitUpstreamHandler,
+    setup_handlers
+)
 
 def test_mapping_added():
     mock_web_app = Mock()
@@ -12,24 +17,6 @@ def test_mapping_added():
     setup_handlers(mock_web_app)
 
     mock_web_app.add_handlers.assert_called_once_with(".*", ANY)
-
-
-@patch('jupyterlab_git.handlers.GitUpstreamHandler.__init__', Mock(return_value=None))
-@patch('jupyterlab_git.handlers.GitUpstreamHandler.get_json_body', Mock(return_value={'current_path': 'test_path'}))
-@patch('jupyterlab_git.handlers.GitUpstreamHandler.git')
-@patch('jupyterlab_git.handlers.GitUpstreamHandler.finish')
-def test_upstream_handler_localbranch(mock_finish, mock_git):
-    # Given
-    mock_git.get_current_branch.return_value = 'foo'
-    mock_git.get_upstream_branch.return_value = 'bar'
-
-    # When
-    GitUpstreamHandler().post()
-
-    # Then
-    mock_git.get_current_branch.assert_called_with('test_path')
-    mock_git.get_upstream_branch.assert_called_with('test_path', 'foo')
-    mock_finish.assert_called_with('{"upstream": "bar"}')
 
 
 @patch('jupyterlab_git.handlers.GitAllHistoryHandler.__init__', Mock(return_value=None))
@@ -66,6 +53,73 @@ def test_all_history_handler_localbranch(mock_finish, mock_git):
             'status': status,
         }
     }))
+
+
+@patch('jupyterlab_git.handlers.GitBranchHandler.__init__', Mock(return_value=None))
+@patch('jupyterlab_git.handlers.GitBranchHandler.get_json_body', Mock(return_value={'current_path': 'test_path'}))
+@patch('jupyterlab_git.handlers.GitBranchHandler.git')
+@patch('jupyterlab_git.handlers.GitBranchHandler.finish')
+def test_branch_handler_localbranch(mock_finish, mock_git):
+    # Given
+    branch = {
+        'code': 0,
+        'branches': [
+            {
+                'is_current_branch': True,
+                'is_remote_branch': False,
+                'name': 'feature-foo',
+                'upstream': 'origin/feature-foo',
+                'top_commit': 'abcdefghijklmnopqrstuvwxyz01234567890123',
+                'tag': None,
+            },
+            {
+                'is_current_branch': False,
+                'is_remote_branch': False,
+                'name': 'master',
+                'upstream': 'origin/master',
+                'top_commit': 'abcdefghijklmnopqrstuvwxyz01234567890123',
+                'tag': None,
+            },
+            {
+                'is_current_branch': False,
+                'is_remote_branch': False,
+                'name': 'feature-bar',
+                'upstream': None,
+                'top_commit': '01234567899999abcdefghijklmnopqrstuvwxyz',
+                'tag': None
+            },
+            {
+                'is_current_branch': False,
+                'is_remote_branch': True,
+                'name': 'origin/feature-foo',
+                'upstream': None,
+                'top_commit': 'abcdefghijklmnopqrstuvwxyz01234567890123',
+                'tag': None,
+            },
+            {
+                'is_current_branch': False,
+                'is_remote_branch': True,
+                'name': 'origin/master',
+                'upstream': None,
+                'top_commit': 'abcdefghijklmnopqrstuvwxyz01234567890123',
+                'tag': None,
+            }
+        ]
+    }
+
+    mock_git.branch.return_value = branch
+
+    # When
+    GitBranchHandler().post()
+
+    # Then
+    mock_git.branch.assert_called_with('test_path')
+
+    mock_finish.assert_called_with(json.dumps({
+        'code': 0,
+        'branches': branch['branches']
+    }))
+
 
 
 @patch('jupyterlab_git.handlers.GitPushHandler.__init__', Mock(return_value=None))
@@ -126,3 +180,21 @@ def test_push_handler_noupstream(mock_finish, mock_git):
     mock_git.get_upstream_branch.assert_called_with('test_path', 'foo')
     mock_git.push.assert_not_called()
     mock_finish.assert_called_with('{"code": 128, "message": "fatal: The current branch foo has no upstream branch."}')
+
+
+@patch('jupyterlab_git.handlers.GitUpstreamHandler.__init__', Mock(return_value=None))
+@patch('jupyterlab_git.handlers.GitUpstreamHandler.get_json_body', Mock(return_value={'current_path': 'test_path'}))
+@patch('jupyterlab_git.handlers.GitUpstreamHandler.git')
+@patch('jupyterlab_git.handlers.GitUpstreamHandler.finish')
+def test_upstream_handler_localbranch(mock_finish, mock_git):
+    # Given
+    mock_git.get_current_branch.return_value = 'foo'
+    mock_git.get_upstream_branch.return_value = 'bar'
+
+    # When
+    GitUpstreamHandler().post()
+
+    # Then
+    mock_git.get_current_branch.assert_called_with('test_path')
+    mock_git.get_upstream_branch.assert_called_with('test_path', 'foo')
+    mock_finish.assert_called_with('{"upstream": "bar"}')


### PR DESCRIPTION
As I pointed out in #432, the `/git/all_history` API, and the GitPanel refresh that uses it, has some serious performance problems, especially in repos with many branches/tags. This is a serious usability issue for `jupyerlab-git`, since GitPanel refresh is fired whenever a user tries to open a different repo in the sidebar, including at startup.

This PR fixes the issue by refactoring `Git.branch` to require far fewer subprocess calls to fetch almost the same data. The one external change is that `Git.branch` no longer fetches a branch's "tag", which was very slow. The "tag" in this case is the most recent tag made before the leading commit of a particular branch, which is not really a standard git concept. More importantly, we aren't actually using the branch "tag" data anywhere, so it's totally pointless to fetch it.

For now, I've left the "tag" attribute in place (but it's value will always be `None`). I'll leave it for a future PR to decide if there's actually some use for "tag", or if it should be removed entirely.

I've also updated the unittests in the python package to match the updates to `Git.branch`.