### PR TITLE
Simplified staging UI for git novices

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -497,6 +497,14 @@ class Git:
         my_output = subprocess.check_output(["git", "add", "-A"], cwd=top_repo_path)
         return my_output
 
+    def add_all_changed(self, top_repo_path):
+        """
+        Execute git add_all_changed command & return the result.
+        """
+        e = 'git add -u'
+        my_output = subprocess.call(e, shell=True, cwd=top_repo_path)
+        return {"result": my_output}
+
     def add_all_untracked(self, top_repo_path):
         """
         Execute git add_all_untracked command & return the result.

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -200,12 +200,12 @@ class GitBranchHandler(GitHandler):
 class GitAddHandler(GitHandler):
     """
     Handler for git add <filename>'.
-    Adds one or all files into to the staging area.
+    Adds one or all files into the staging area.
     """
 
     def get(self):
         """
-        GET request handler, adds files in the staging area.
+        GET request handler, adds files into the staging area.
         """
         self.finish(
             json.dumps(
@@ -406,6 +406,18 @@ class GitInitHandler(GitHandler):
         my_output = self.git.init(current_path)
         self.finish(my_output)
 
+class GitAddAllChangedHandler(GitHandler):
+    """
+    Handler for 'git add -u'. Adds ONLY all changed files.
+    """
+
+    def post(self):
+        """
+        POST request handler, adds all the changed files.
+        """
+        my_output = self.git.add_all_changed(self.get_json_body()["top_repo_path"])
+        print(my_output)
+        self.finish(my_output)
 
 class GitAddAllUntrackedHandler(GitHandler):
     """
@@ -484,6 +496,7 @@ def setup_handlers(web_app):
         ("/git/detailed_log", GitDetailedLogHandler),
         ("/git/init", GitInitHandler),
         ("/git/all_history", GitAllHistoryHandler),
+        ("/git/add_all_changed", GitAddAllChangedHandler),
         ("/git/add_all_untracked", GitAddAllUntrackedHandler),
         ("/git/clone", GitCloneHandler),
         ("/git/upstream", GitUpstreamHandler),

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -10,6 +10,12 @@
       "title": "History count",
       "description": "Number of (most recent) commits shown in the history log",
       "default": 25
+    },
+    "simpleStaging": {
+      "type": "boolean",
+      "title": "Simple staging flag",
+      "description": "If true, use a simplified concept of staging. Only files with changes are shown (instead of showing staged/changed/untracked), and all files with changes will be automatically staged",
+      "default": false
     }
   }
 }

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -79,7 +79,7 @@ export class BranchHeader extends React.Component<
       if (message && message !== '' && (await this._hasIdentity(path))) {
         let gitApi = new Git();
 
-        const response = await gitApi.addAllChanged(message);
+        const response = await gitApi.addAllChanged(path);
 
         if (response.ok) {
           this.props.refresh();

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -19,7 +19,7 @@ import {
   fileIconStyle,
   fileLabelStyle,
   fileStyle,
-  fileStylePad,
+  filePadStyle,
   selectedFileChangedLabelStyle,
   selectedFileStyle,
   sideBarExpandedFileLabelStyle
@@ -142,7 +142,7 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
   }
 
   getFileClass() {
-    const baseStyle = classes(fileStyle, !this.props.moveFile && fileStylePad);
+    const baseStyle = classes(fileStyle, !this.props.moveFile && filePadStyle);
 
     if (!this.checkSelected() && this.props.disableFile) {
       return classes(baseStyle, disabledFileStyle);

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -19,6 +19,7 @@ import {
   fileIconStyle,
   fileLabelStyle,
   fileStyle,
+  fileStylePad,
   selectedFileChangedLabelStyle,
   selectedFileStyle,
   sideBarExpandedFileLabelStyle
@@ -141,14 +142,16 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
   }
 
   getFileClass() {
+    const baseStyle = classes(fileStyle, !this.props.moveFile && fileStylePad);
+
     if (!this.checkSelected() && this.props.disableFile) {
-      return classes(fileStyle, disabledFileStyle);
+      return classes(baseStyle, disabledFileStyle);
     } else if (this.showDiscardWarning()) {
-      classes(fileStyle, expandedFileStyle);
+      classes(baseStyle, expandedFileStyle);
     } else {
       return this.checkSelected()
-        ? classes(fileStyle, selectedFileStyle)
-        : classes(fileStyle);
+        ? classes(baseStyle, selectedFileStyle)
+        : classes(baseStyle);
     }
   }
 
@@ -248,6 +251,26 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
   }
 
   render() {
+    const MoveButton = () => {
+      if (this.props.moveFile) {
+        return (
+          <button
+            className={`jp-Git-button ${this.getMoveFileIconClass()}`}
+            title={this.props.moveFileTitle}
+            onClick={() => {
+              this.props.moveFile(
+                this.props.file.to,
+                this.props.topRepoPath,
+                this.props.refresh
+              );
+            }}
+          />
+        );
+      } else {
+        return <></>;
+      }
+    };
+
     return (
       <div
         className={this.getFileClass()}
@@ -255,17 +278,7 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
           this.props.updateSelectedFile(this.props.fileIndex, this.props.stage)
         }
       >
-        <button
-          className={`jp-Git-button ${this.getMoveFileIconClass()}`}
-          title={this.props.moveFileTitle}
-          onClick={() => {
-            this.props.moveFile(
-              this.props.file.to,
-              this.props.topRepoPath,
-              this.props.refresh
-            );
-          }}
-        />
+        <MoveButton />
         <span className={this.getFileLableIconClass()} />
         <span
           className={this.getFileLabelClass()}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -5,9 +5,13 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { Menu } from '@phosphor/widgets';
 
 import { ISettingRegistry, PathExt } from '@jupyterlab/coreutils';
+
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+
 import * as React from 'react';
+
 import { openDiffView } from './diff/DiffWidget';
+
 import {
   folderFileIconSelectedStyle,
   folderFileIconStyle,
@@ -32,8 +36,10 @@ import {
   yamlFileIconSelectedStyle,
   yamlFileIconStyle
 } from '../style/FileListStyle';
+
 import { Git, IGitShowPrefixResult } from '../git';
-import { GitStage } from './GitStage';
+
+import { GitStage, IGitStageProps } from './GitStage';
 
 export namespace CommandIDs {
   export const gitFileOpen = 'gf:Open';
@@ -519,14 +525,10 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       renderMime: this.props.renderMime
     };
 
-    const Staged = () => (
+    const Staged = (props: Partial<IGitStageProps> = {}) => (
       <GitStage
         heading={'Staged'}
-        files={
-          this.props.settings.composite['simpleStaging']
-            ? [...this.props.stagedFiles, ...this.props.unstagedFiles]
-            : this.props.stagedFiles
-        }
+        files={this.props.stagedFiles}
         showFiles={this.state.showStaged}
         displayFiles={this.displayStaged}
         moveAllFiles={this.resetAllStagedFiles}
@@ -539,10 +541,11 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         moveFileTitle={'Unstage this change'}
         disableOthers={null}
         {...sharedProps}
+        {...props}
       />
     );
 
-    const Changed = () => (
+    const Changed = (props: Partial<IGitStageProps> = {}) => (
       <GitStage
         heading={'Changed'}
         files={this.props.unstagedFiles}
@@ -558,10 +561,11 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         moveFileTitle={'Stage this change'}
         disableOthers={this.disableStagesForDiscardAll}
         {...sharedProps}
+        {...props}
       />
     );
 
-    const Untracked = () => (
+    const Untracked = (props: Partial<IGitStageProps> = {}) => (
       <GitStage
         heading={'Untracked'}
         files={this.props.untrackedFiles}
@@ -577,6 +581,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         moveFileTitle={'Track this file'}
         disableOthers={null}
         {...sharedProps}
+        {...props}
       />
     );
 
@@ -585,7 +590,14 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         {this.props.display &&
           (this.props.settings.composite['simpleStaging'] ? (
             <div>
-              <Staged />
+              <Changed
+                files={this.props.unstagedFiles}
+                moveFile={null}
+                moveFileIconClass={null}
+                moveFileIconSelectedClass={null}
+                moveAllFilesTitle={null}
+                moveFileTitle={null}
+              />
             </div>
           ) : (
             <div>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -519,12 +519,12 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       renderMime: this.props.renderMime
     };
 
-    const staged = () => (
+    const Staged = () => (
       <GitStage
         heading={'Staged'}
         files={
           this.props.settings.composite['simpleStaging']
-            ? { ...this.props.stagedFiles, ...this.props.unstagedFiles }
+            ? [...this.props.stagedFiles, ...this.props.unstagedFiles]
             : this.props.stagedFiles
         }
         showFiles={this.state.showStaged}
@@ -542,7 +542,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       />
     );
 
-    const changed = () => (
+    const Changed = () => (
       <GitStage
         heading={'Changed'}
         files={this.props.unstagedFiles}
@@ -561,7 +561,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       />
     );
 
-    const untracked = () => (
+    const Untracked = () => (
       <GitStage
         heading={'Untracked'}
         files={this.props.untrackedFiles}
@@ -584,9 +584,15 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       <div onContextMenu={event => event.preventDefault()}>
         {this.props.display &&
           (this.props.settings.composite['simpleStaging'] ? (
-            <div {...staged} />
+            <div>
+              <Staged />
+            </div>
           ) : (
-            <div {...staged} {...changed} {...untracked} />
+            <div>
+              <Staged />
+              <Changed />
+              <Untracked />
+            </div>
           ))}
       </div>
     );

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -4,7 +4,7 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 
 import { Menu } from '@phosphor/widgets';
 
-import { PathExt } from '@jupyterlab/coreutils';
+import { ISettingRegistry, PathExt } from '@jupyterlab/coreutils';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import * as React from 'react';
 import { openDiffView } from './diff/DiffWidget';
@@ -78,6 +78,7 @@ export interface IFileListProps {
   refresh: any;
   sideBarExpanded: boolean;
   display: boolean;
+  settings: ISettingRegistry.ISettings;
   renderMime: IRenderMimeRegistry;
 }
 
@@ -496,114 +497,97 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   };
 
   render() {
+    const sharedProps = {
+      selectedFile: this.state.selectedFile,
+      updateSelectedFile: this.updateSelectedFile,
+      selectedStage: this.state.selectedStage,
+      updateSelectedStage: this.updateSelectedStage,
+      selectedDiscardFile: this.state.selectedDiscardFile,
+      updateSelectedDiscardFile: this.updateSelectedDiscardFile,
+      disableFiles: this.state.disableFiles,
+      toggleDisableFiles: this.toggleDisableFiles,
+      openFile: this.openListedFile,
+      extractFilename: this.extractFilename,
+      contextMenu: this.contextMenuStaged,
+      parseFileExtension: parseFileExtension,
+      parseSelectedFileExtension: parseSelectedFileExtension,
+      topRepoPath: this.props.topRepoPath,
+      app: this.props.app,
+      refresh: this.props.refresh,
+      isDisabled: this.state.disableStaged,
+      sideBarExpanded: this.props.sideBarExpanded,
+      renderMime: this.props.renderMime
+    };
+
+    const staged = () => (
+      <GitStage
+        heading={'Staged'}
+        files={
+          this.props.settings.composite['simpleStaging']
+            ? { ...this.props.stagedFiles, ...this.props.unstagedFiles }
+            : this.props.stagedFiles
+        }
+        showFiles={this.state.showStaged}
+        displayFiles={this.displayStaged}
+        moveAllFiles={this.resetAllStagedFiles}
+        discardAllFiles={null}
+        discardFile={null}
+        moveFile={this.resetStagedFile}
+        moveFileIconClass={moveFileDownButtonStyle}
+        moveFileIconSelectedClass={moveFileDownButtonSelectedStyle}
+        moveAllFilesTitle={'Unstage all changes'}
+        moveFileTitle={'Unstage this change'}
+        disableOthers={null}
+        {...sharedProps}
+      />
+    );
+
+    const changed = () => (
+      <GitStage
+        heading={'Changed'}
+        files={this.props.unstagedFiles}
+        showFiles={this.state.showUnstaged}
+        displayFiles={this.displayUnstaged}
+        moveAllFiles={this.addAllUnstagedFiles}
+        discardAllFiles={this.discardAllUnstagedFiles}
+        discardFile={this.discardUnstagedFile}
+        moveFile={this.addUnstagedFile}
+        moveFileIconClass={moveFileUpButtonStyle}
+        moveFileIconSelectedClass={moveFileUpButtonSelectedStyle}
+        moveAllFilesTitle={'Stage all changes'}
+        moveFileTitle={'Stage this change'}
+        disableOthers={this.disableStagesForDiscardAll}
+        {...sharedProps}
+      />
+    );
+
+    const untracked = () => (
+      <GitStage
+        heading={'Untracked'}
+        files={this.props.untrackedFiles}
+        showFiles={this.state.showUntracked}
+        displayFiles={this.displayUntracked}
+        moveAllFiles={this.addAllUntrackedFiles}
+        discardAllFiles={null}
+        discardFile={null}
+        moveFile={this.addUntrackedFile}
+        moveFileIconClass={moveFileUpButtonStyle}
+        moveFileIconSelectedClass={moveFileUpButtonSelectedStyle}
+        moveAllFilesTitle={'Track all untracked files'}
+        moveFileTitle={'Track this file'}
+        disableOthers={null}
+        {...sharedProps}
+      />
+    );
+
     return (
       <div onContextMenu={event => event.preventDefault()}>
-        {this.props.display && (
-          <div>
-            <GitStage
-              heading={'Staged'}
-              topRepoPath={this.props.topRepoPath}
-              files={this.props.stagedFiles}
-              app={this.props.app}
-              refresh={this.props.refresh}
-              showFiles={this.state.showStaged}
-              displayFiles={this.displayStaged}
-              moveAllFiles={this.resetAllStagedFiles}
-              discardAllFiles={null}
-              discardFile={null}
-              moveFile={this.resetStagedFile}
-              moveFileIconClass={moveFileDownButtonStyle}
-              moveFileIconSelectedClass={moveFileDownButtonSelectedStyle}
-              moveAllFilesTitle={'Unstage all changes'}
-              moveFileTitle={'Unstage this change'}
-              openFile={this.openListedFile}
-              extractFilename={this.extractFilename}
-              contextMenu={this.contextMenuStaged}
-              parseFileExtension={parseFileExtension}
-              parseSelectedFileExtension={parseSelectedFileExtension}
-              selectedFile={this.state.selectedFile}
-              updateSelectedFile={this.updateSelectedFile}
-              selectedStage={this.state.selectedStage}
-              updateSelectedStage={this.updateSelectedStage}
-              selectedDiscardFile={this.state.selectedDiscardFile}
-              updateSelectedDiscardFile={this.updateSelectedDiscardFile}
-              disableFiles={this.state.disableFiles}
-              toggleDisableFiles={this.toggleDisableFiles}
-              disableOthers={null}
-              isDisabled={this.state.disableStaged}
-              sideBarExpanded={this.props.sideBarExpanded}
-              renderMime={this.props.renderMime}
-            />
-            <GitStage
-              heading={'Changed'}
-              topRepoPath={this.props.topRepoPath}
-              files={this.props.unstagedFiles}
-              app={this.props.app}
-              refresh={this.props.refresh}
-              showFiles={this.state.showUnstaged}
-              displayFiles={this.displayUnstaged}
-              moveAllFiles={this.addAllUnstagedFiles}
-              discardAllFiles={this.discardAllUnstagedFiles}
-              discardFile={this.discardUnstagedFile}
-              moveFile={this.addUnstagedFile}
-              moveFileIconClass={moveFileUpButtonStyle}
-              moveFileIconSelectedClass={moveFileUpButtonSelectedStyle}
-              moveAllFilesTitle={'Stage all changes'}
-              moveFileTitle={'Stage this change'}
-              openFile={this.openListedFile}
-              extractFilename={this.extractFilename}
-              contextMenu={this.contextMenuUnstaged}
-              parseFileExtension={parseFileExtension}
-              parseSelectedFileExtension={parseSelectedFileExtension}
-              selectedFile={this.state.selectedFile}
-              updateSelectedFile={this.updateSelectedFile}
-              selectedStage={this.state.selectedStage}
-              updateSelectedStage={this.updateSelectedStage}
-              selectedDiscardFile={this.state.selectedDiscardFile}
-              updateSelectedDiscardFile={this.updateSelectedDiscardFile}
-              disableFiles={this.state.disableFiles}
-              toggleDisableFiles={this.toggleDisableFiles}
-              disableOthers={this.disableStagesForDiscardAll}
-              isDisabled={this.state.disableUnstaged}
-              sideBarExpanded={this.props.sideBarExpanded}
-              renderMime={this.props.renderMime}
-            />
-            <GitStage
-              heading={'Untracked'}
-              topRepoPath={this.props.topRepoPath}
-              files={this.props.untrackedFiles}
-              app={this.props.app}
-              refresh={this.props.refresh}
-              showFiles={this.state.showUntracked}
-              displayFiles={this.displayUntracked}
-              moveAllFiles={this.addAllUntrackedFiles}
-              discardAllFiles={null}
-              discardFile={null}
-              moveFile={this.addUntrackedFile}
-              moveFileIconClass={moveFileUpButtonStyle}
-              moveFileIconSelectedClass={moveFileUpButtonSelectedStyle}
-              moveAllFilesTitle={'Track all untracked files'}
-              moveFileTitle={'Track this file'}
-              openFile={this.openListedFile}
-              extractFilename={this.extractFilename}
-              contextMenu={this.contextMenuUntracked}
-              parseFileExtension={parseFileExtension}
-              parseSelectedFileExtension={parseSelectedFileExtension}
-              selectedFile={this.state.selectedFile}
-              updateSelectedFile={this.updateSelectedFile}
-              selectedStage={this.state.selectedStage}
-              updateSelectedStage={this.updateSelectedStage}
-              selectedDiscardFile={this.state.selectedDiscardFile}
-              updateSelectedDiscardFile={this.updateSelectedDiscardFile}
-              disableFiles={this.state.disableFiles}
-              toggleDisableFiles={this.toggleDisableFiles}
-              disableOthers={null}
-              isDisabled={this.state.disableUntracked}
-              sideBarExpanded={this.props.sideBarExpanded}
-              renderMime={this.props.renderMime}
-            />
-          </div>
-        )}
+        {this.props.display &&
+          (this.props.settings.composite['simpleStaging'] ? (
+            <div {...staged} />
+          ) : (
+            <div {...staged} {...changed} {...untracked} />
+          ))}
       </div>
     );
   }

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -257,6 +257,7 @@ export class GitPanel extends React.Component<
             refresh={this.refresh}
             diff={this.props.diff}
             sideBarExpanded={this.state.sideBarExpanded}
+            settings={this.props.settings}
             renderMime={this.props.renderMime}
           />
         </div>

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -1,6 +1,10 @@
-import * as React from 'react';
-
 import { JupyterFrontEnd } from '@jupyterlab/application';
+
+import { ISettingRegistry } from '@jupyterlab/coreutils';
+
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+
+import * as React from 'react';
 
 import {
   Git,
@@ -27,8 +31,6 @@ import {
   panelWarningStyle,
   findRepoButtonStyle
 } from '../style/GitPanelStyle';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { ISettingRegistry } from '@jupyterlab/coreutils';
 
 /** Interface for GitPanel component state */
 export interface IGitSessionNodeState {
@@ -231,11 +233,13 @@ export class GitPanel extends React.Component<
             currentBranch={this.state.currentBranch}
             upstreamBranch={this.state.upstreamBranch}
             stagedFiles={this.state.stagedFiles}
+            unstagedFiles={this.state.unstagedFiles}
             data={this.state.branches}
             disabled={this.state.disableSwitchBranch}
             toggleSidebar={this.toggleSidebar}
             showList={this.state.showList}
             sideBarExpanded={this.state.sideBarExpanded}
+            settings={this.props.settings}
           />
           <HistorySideBar
             isExpanded={this.state.sideBarExpanded}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -83,6 +83,8 @@ export class GitPanel extends React.Component<
       untrackedFiles: [],
       sideBarExpanded: false
     };
+
+    this.props.settings.changed.connect(this.refresh, this);
   }
 
   setShowList = (state: boolean) => {

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -89,6 +89,10 @@ export class GitPanel extends React.Component<
     this.props.settings.changed.connect(this.refresh, this);
   }
 
+  componentDidMount(): void {
+    this.refresh();
+  }
+
   setShowList = (state: boolean) => {
     this.setState({ showList: state });
   };

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -85,12 +85,6 @@ export class GitPanel extends React.Component<
       untrackedFiles: [],
       sideBarExpanded: false
     };
-
-    this.props.settings.changed.connect(this.refresh, this);
-  }
-
-  componentDidMount(): void {
-    this.refresh();
   }
 
   setShowList = (state: boolean) => {

--- a/src/components/GitStage.tsx
+++ b/src/components/GitStage.tsx
@@ -109,6 +109,25 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
     });
   }
 
+  MoveAllButton = () => {
+    if (this.props.moveAllFiles) {
+      return (
+        <button
+          disabled={this.checkContents()}
+          className={`${
+            this.props.moveFileIconClass
+          } ${changeStageButtonStyle} ${changeStageButtonLeftStyle}`}
+          title={this.props.moveAllFilesTitle}
+          onClick={() =>
+            this.props.moveAllFiles(this.props.topRepoPath, this.props.refresh)
+          }
+        />
+      );
+    } else {
+      return <></>;
+    }
+  };
+
   Header = () => {
     return (
       <div className={sectionAreaStyle}>
@@ -125,15 +144,7 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
             onClick={() => this.props.displayFiles()}
           />
         )}
-        <button
-          disabled={this.checkContents()}
-          className={`${this.props.moveFileIconClass} ${changeStageButtonStyle}
-               ${changeStageButtonLeftStyle}`}
-          title={this.props.moveAllFilesTitle}
-          onClick={() =>
-            this.props.moveAllFiles(this.props.topRepoPath, this.props.refresh)
-          }
-        />
+        <this.MoveAllButton />
         {this.props.heading === 'Changed' && (
           <button
             disabled={this.checkContents()}

--- a/src/components/GitStage.tsx
+++ b/src/components/GitStage.tsx
@@ -109,93 +109,91 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
     });
   }
 
+  header() {
+    return (
+      <div className={sectionAreaStyle}>
+        <span className={sectionHeaderLabelStyle}>
+          {this.props.heading}({this.props.files.length})
+        </span>
+        {this.props.files.length > 0 && (
+          <button
+            className={
+              this.props.showFiles
+                ? `${changeStageButtonStyle} ${caretdownImageStyle}`
+                : `${changeStageButtonStyle} ${caretrightImageStyle}`
+            }
+            onClick={() => this.props.displayFiles()}
+          />
+        )}
+        <button
+          disabled={this.checkContents()}
+          className={`${this.props.moveFileIconClass} ${changeStageButtonStyle}
+               ${changeStageButtonLeftStyle}`}
+          title={this.props.moveAllFilesTitle}
+          onClick={() =>
+            this.props.moveAllFiles(this.props.topRepoPath, this.props.refresh)
+          }
+        />
+        {this.props.heading === 'Changed' && (
+          <button
+            disabled={this.checkContents()}
+            className={classes(changeStageButtonStyle, discardFileButtonStyle)}
+            title={'Discard All Changes'}
+            onClick={() => this.discardAllChanges()}
+          />
+        )}
+      </div>
+    );
+  }
+
+  filelist() {
+    return (
+      <div className={sectionFileContainerStyle}>
+        {this.props.files.map(
+          (file: IGitStatusFileResult, fileIndex: number) => {
+            return (
+              <FileItem
+                key={fileIndex}
+                topRepoPath={this.props.topRepoPath}
+                stage={this.props.heading}
+                file={file}
+                app={this.props.app}
+                refresh={this.props.refresh}
+                moveFile={this.props.moveFile}
+                discardFile={this.props.discardFile}
+                moveFileIconClass={this.props.moveFileIconClass}
+                moveFileIconSelectedClass={this.props.moveFileIconSelectedClass}
+                moveFileTitle={this.props.moveFileTitle}
+                openFile={this.props.openFile}
+                extractFilename={this.props.extractFilename}
+                contextMenu={this.props.contextMenu}
+                parseFileExtension={this.props.parseFileExtension}
+                parseSelectedFileExtension={
+                  this.props.parseSelectedFileExtension
+                }
+                selectedFile={this.props.selectedFile}
+                updateSelectedFile={this.props.updateSelectedFile}
+                fileIndex={fileIndex}
+                selectedStage={this.props.selectedStage}
+                selectedDiscardFile={this.props.selectedDiscardFile}
+                updateSelectedDiscardFile={this.props.updateSelectedDiscardFile}
+                disableFile={this.props.disableFiles}
+                toggleDisableFiles={this.props.toggleDisableFiles}
+                sideBarExpanded={this.props.sideBarExpanded}
+                renderMime={this.props.renderMime}
+              />
+            );
+          }
+        )}
+      </div>
+    );
+  }
+
   render() {
     return (
       <div className={this.checkDisabled()}>
-        <div className={sectionAreaStyle}>
-          <span className={sectionHeaderLabelStyle}>
-            {this.props.heading}({this.props.files.length})
-          </span>
-          {this.props.files.length > 0 && (
-            <button
-              className={
-                this.props.showFiles
-                  ? `${changeStageButtonStyle} ${caretdownImageStyle}`
-                  : `${changeStageButtonStyle} ${caretrightImageStyle}`
-              }
-              onClick={() => this.props.displayFiles()}
-            />
-          )}
-          <button
-            disabled={this.checkContents()}
-            className={`${
-              this.props.moveFileIconClass
-            } ${changeStageButtonStyle}
-               ${changeStageButtonLeftStyle}`}
-            title={this.props.moveAllFilesTitle}
-            onClick={() =>
-              this.props.moveAllFiles(
-                this.props.topRepoPath,
-                this.props.refresh
-              )
-            }
-          />
-          {this.props.heading === 'Changed' && (
-            <button
-              disabled={this.checkContents()}
-              className={classes(
-                changeStageButtonStyle,
-                discardFileButtonStyle
-              )}
-              title={'Discard All Changes'}
-              onClick={() => this.discardAllChanges()}
-            />
-          )}
-        </div>
-        {this.props.showFiles && (
-          <div className={sectionFileContainerStyle}>
-            {this.props.files.map(
-              (file: IGitStatusFileResult, fileIndex: number) => {
-                return (
-                  <FileItem
-                    key={fileIndex}
-                    topRepoPath={this.props.topRepoPath}
-                    stage={this.props.heading}
-                    file={file}
-                    app={this.props.app}
-                    refresh={this.props.refresh}
-                    moveFile={this.props.moveFile}
-                    discardFile={this.props.discardFile}
-                    moveFileIconClass={this.props.moveFileIconClass}
-                    moveFileIconSelectedClass={
-                      this.props.moveFileIconSelectedClass
-                    }
-                    moveFileTitle={this.props.moveFileTitle}
-                    openFile={this.props.openFile}
-                    extractFilename={this.props.extractFilename}
-                    contextMenu={this.props.contextMenu}
-                    parseFileExtension={this.props.parseFileExtension}
-                    parseSelectedFileExtension={
-                      this.props.parseSelectedFileExtension
-                    }
-                    selectedFile={this.props.selectedFile}
-                    updateSelectedFile={this.props.updateSelectedFile}
-                    fileIndex={fileIndex}
-                    selectedStage={this.props.selectedStage}
-                    selectedDiscardFile={this.props.selectedDiscardFile}
-                    updateSelectedDiscardFile={
-                      this.props.updateSelectedDiscardFile
-                    }
-                    disableFile={this.props.disableFiles}
-                    toggleDisableFiles={this.props.toggleDisableFiles}
-                    sideBarExpanded={this.props.sideBarExpanded}
-                    renderMime={this.props.renderMime}
-                  />
-                );
-              }
-            )}
-          </div>
-        )}
+        {this.header}
+        {this.props.showFiles && this.filelist}
       </div>
     );
   }

--- a/src/components/GitStage.tsx
+++ b/src/components/GitStage.tsx
@@ -109,7 +109,7 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
     });
   }
 
-  header() {
+  Header = () => {
     return (
       <div className={sectionAreaStyle}>
         <span className={sectionHeaderLabelStyle}>
@@ -144,9 +144,9 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
         )}
       </div>
     );
-  }
+  };
 
-  filelist() {
+  FileItems = () => {
     return (
       <div className={sectionFileContainerStyle}>
         {this.props.files.map(
@@ -187,13 +187,13 @@ export class GitStage extends React.Component<IGitStageProps, IGitStageState> {
         )}
       </div>
     );
-  }
+  };
 
   render() {
     return (
       <div className={this.checkDisabled()}>
-        {this.header}
-        {this.props.showFiles && this.filelist}
+        <this.Header />
+        {this.props.showFiles && <this.FileItems />}
       </div>
     );
   }

--- a/src/components/PastCommits.tsx
+++ b/src/components/PastCommits.tsx
@@ -1,5 +1,9 @@
 import { JupyterFrontEnd } from '@jupyterlab/application';
 
+import { ISettingRegistry } from '@jupyterlab/coreutils';
+
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+
 import { FileList } from './FileList';
 
 import { pastCommitsContainerStyle } from '../style/PastCommitsStyle';
@@ -7,7 +11,6 @@ import { pastCommitsContainerStyle } from '../style/PastCommitsStyle';
 import { IDiffCallback } from '../git';
 
 import * as React from 'react';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 /** Interface for PastCommits component props */
 export interface IPastCommitsProps {
@@ -22,6 +25,7 @@ export interface IPastCommitsProps {
   refresh: any;
   diff: IDiffCallback;
   sideBarExpanded: boolean;
+  settings: ISettingRegistry.ISettings;
   renderMime: IRenderMimeRegistry;
 }
 
@@ -42,6 +46,7 @@ export class PastCommits extends React.Component<IPastCommitsProps, {}> {
           refresh={this.props.refresh}
           sideBarExpanded={this.props.sideBarExpanded}
           display={this.props.showList}
+          settings={this.props.settings}
           renderMime={this.props.renderMime}
         />
       </div>

--- a/src/git.ts
+++ b/src/git.ts
@@ -404,6 +404,24 @@ export class Git {
     });
   }
 
+  /** Make request to add all changed files into
+   * the staging area in repository 'path'
+   */
+  async addAllChanged(path: string): Promise<Response> {
+    try {
+      let response = await httpGitRequest('/git/add_all_changed', 'POST', {
+        top_repo_path: path
+      });
+      if (response.status !== 200) {
+        const data = await response.json();
+        throw new ServerConnection.ResponseError(response, data.message);
+      }
+      return response.json();
+    } catch (err) {
+      throw ServerConnection.NetworkError;
+    }
+  }
+
   /** Make request to add all untracked files into
    * the staging area in repository 'path'
    */

--- a/src/style/FileItemStyle.tsx
+++ b/src/style/FileItemStyle.tsx
@@ -20,7 +20,7 @@ export const fileStyle = style({
   }
 });
 
-export const fileStylePad = style({
+export const filePadStyle = style({
   padding: '4px 12px'
 });
 

--- a/src/style/FileItemStyle.tsx
+++ b/src/style/FileItemStyle.tsx
@@ -7,7 +7,7 @@ export const fileStyle = style({
   color: 'var(--jp-ui-font-color1)',
   height: '25px',
   lineHeight: 'var(--jp-private-running-item-height)',
-  paddingLeft: '4px',
+  padding: '0px 0px 0px 4px',
   listStyleType: 'none',
 
   $nest: {
@@ -18,6 +18,10 @@ export const fileStyle = style({
       visibility: 'visible'
     }
   }
+});
+
+export const fileStylePad = style({
+  padding: '4px 12px'
 });
 
 export const selectedFileStyle = style({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,13 +5,15 @@
     "noImplicitAny": false,
     "noEmitOnError": true,
     "noUnusedLocals": true,
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
-    "target": "es2015",
+    "target": "es2019",
     "outDir": "lib",
     "types": ["jest"],
     "jsx": "react",
     "plugins": [{ "name": "typescript-tslint-plugin" }],
+    "rootDir": "src",
+    "sourceMap": true,
     "resolveJsonModule": true
   },
   "include": ["src/*"]


### PR DESCRIPTION
For people who haven't used any VCS before, `git` can prove to be somewhat overwhelming. In particular, the untracked/unstaged/staged concept can seem very foreign to someone who up until now has never done any kind of "commit" more complicated than saving a file to disk. For that reason I think it would be idea to have an option to switch the staging UI to a "simplified" mode. As a model, I'm thinking along the lines of the UI in the Github desktop app:

![image](https://user-images.githubusercontent.com/2263641/67166307-24b6a080-f35c-11e9-9b79-e88e141b8bf1.png)

It would simply show which files have changed, rather than splitting them into categories. When the commit button is pushed, all changed files will be automatically staged and commited (although there should also be something like the Github app's checkboxes to opt files out of a commit).

Additionally, some color coding of file names would be nice, a la VSCode:

![image](https://user-images.githubusercontent.com/2263641/67166362-74956780-f35c-11e9-9c27-dc667b327229.png)

Currently this PR is at proof of concept stage. It adds a `simpleStaging` flag to the user settings. When enabled, the staging UI is simplified, and only shows a single "changed" category. When disabled, the staging UI reverts back to the standard version.