### PR TITLE
Fix usage of old node in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache:
   pip: true
   directories:
     - /home/travis/.yarn-cache/
+before_install:
+  - nvm install 10
 install: pip install pytest "jupyterlab~=1.0"
 script:
   - python setup.py sdist


### PR DESCRIPTION
This fixes the bug appearing in the scheduled master check: https://travis-ci.org/jupyterlab/jupyterlab-git/builds/604902811?utm_medium=notification&utm_source=github_status