### PR TITLE
Simplify the staging UI to make it easier for git beginners

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "sourceMap": "inline",
   presets: [
     [
       '@babel/preset-env',

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ var tsConfig = require ('./tsconfig.json');
 var tsOptions = tsConfig["compilerOptions"];
 // Need as the test folder is not visible from the src folder
 tsOptions["rootDir"] = null;
+tsOptions["inlineSourceMap"] = true;
 
 module.exports = {
   automock: false,

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -377,7 +377,7 @@ class Git:
             return remotes
 
         # all's good; concatenate results and return
-        return {"code": 0, "branches": heads["branches"] + remotes["branches"]}
+        return {"code": 0, "branches": heads["branches"] + remotes["branches"], "current_branch": heads["current_branch"]}
 
     def branch_heads(self, current_path):
         """
@@ -393,37 +393,39 @@ class Git:
         )
         output, error = p.communicate()
         if p.returncode == 0:
-            current_branch_seen = False
+            current_branch = None
             results = []
             try:
                 for name,commit_sha,upstream_name,is_current_branch in (line.split('\t') for line in output.decode("utf-8").splitlines()):
                     # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
-                    is_current_branch = bool(is_current_branch.strip())
-                    current_branch_seen |= is_current_branch
-
-                    results.append({
-                        "is_current_branch": is_current_branch,
+                    branch = {
                         "is_remote_branch": False,
                         "name": name,
                         "upstream": upstream_name if upstream_name else None,
                         "top_commit": commit_sha,
                         "tag": None,
-                    })
+                    }
+                    results.append(branch)
+                    if is_current_branch.strip():
+                        current_branch = branch
 
                 # Remote branch is seleted use 'git branch -a' as fallback machanism
                 # to get add detached head on remote branch to preserve older functionality
                 # TODO : Revisit this to checkout new local branch with same name as remote
                 # when the remote branch is seleted, VS Code git does the same thing.
-                if not current_branch_seen and self.get_current_branch(current_path) == "HEAD":
-                    results.append({
-                        "is_current_branch": True,
+                if not current_branch and self.get_current_branch(current_path) == "HEAD":
+                    branch = {
                         "is_remote_branch": False,
                         "name": self._get_detached_head_name(current_path),
                         "upstream": None,
                         "top_commit": None,
                         "tag": None,
-                    })
-                return {"code": p.returncode, "branches": results}
+                    }
+                    results.append(branch)
+                    current_branch = branch
+
+                return {"code": p.returncode, "branches": results, "current_branch": current_branch}
+
             except Exception as downstream_error:
                 return {
                     "code": -1,
@@ -456,7 +458,6 @@ class Git:
                 for name,commit_sha in (line.split('\t') for line in output.decode("utf-8").splitlines()):
                     # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
                     results.append({
-                        "is_current_branch": False,
                         "is_remote_branch": True,
                         "name": name,
                         "upstream": None,

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -594,8 +594,12 @@ class Git:
         """
         Reset the current branch to a specific past commit.
         """
+        cmd = ["git", "reset", "--hard"]
+        if commit_id:
+            cmd.append(commit_id)
+
         my_output = subprocess.check_output(
-            ["git", "reset", "--hard", commit_id], cwd=top_repo_path
+            cmd, cwd=top_repo_path
         )
         return my_output
 

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -529,6 +529,10 @@ class Git:
         """
         Execute git add<filename> command & return the result.
         """
+        if not isinstance(filename, str):
+            # assume filename is a sequence
+            filename = ' '.join(filename)
+
         my_output = subprocess.check_output(["git", "add", filename], cwd=top_repo_path)
         return my_output
 

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -398,7 +398,10 @@ class Git:
             try:
                 for name,commit_sha,upstream_name,is_current_branch in (line.split('\t') for line in output.decode("utf-8").splitlines()):
                     # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
+                    is_current_branch = bool(is_current_branch.strip())
+
                     branch = {
+                        "is_current_branch": is_current_branch,
                         "is_remote_branch": False,
                         "name": name,
                         "upstream": upstream_name if upstream_name else None,
@@ -406,7 +409,7 @@ class Git:
                         "tag": None,
                     }
                     results.append(branch)
-                    if is_current_branch.strip():
+                    if is_current_branch:
                         current_branch = branch
 
                 # Remote branch is seleted use 'git branch -a' as fallback machanism
@@ -415,6 +418,7 @@ class Git:
                 # when the remote branch is seleted, VS Code git does the same thing.
                 if not current_branch and self.get_current_branch(current_path) == "HEAD":
                     branch = {
+                        "is_current_branch": True,
                         "is_remote_branch": False,
                         "name": self._get_detached_head_name(current_path),
                         "upstream": None,
@@ -458,6 +462,7 @@ class Git:
                 for name,commit_sha in (line.split('\t') for line in output.decode("utf-8").splitlines()):
                     # Format reference : https://git-scm.com/docs/git-for-each-ref#_field_names
                     results.append({
+                        "is_current_branch": False,
                         "is_remote_branch": True,
                         "name": name,
                         "upstream": None,

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -423,7 +423,6 @@ def test_branch_success(mock_subproc_popen):
         'code': 0,
         'branches': [
             {
-                'is_current_branch': True,
                 'is_remote_branch': False,
                 'name': 'feature-foo',
                 'upstream': 'origin/feature-foo',
@@ -431,7 +430,6 @@ def test_branch_success(mock_subproc_popen):
                 'tag': None,
             },
             {
-                'is_current_branch': False,
                 'is_remote_branch': False,
                 'name': 'master',
                 'upstream': 'origin/master',
@@ -439,7 +437,6 @@ def test_branch_success(mock_subproc_popen):
                 'tag': None,
             },
             {
-                'is_current_branch': False,
                 'is_remote_branch': False,
                 'name': 'feature-bar',
                 'upstream': None,
@@ -447,7 +444,6 @@ def test_branch_success(mock_subproc_popen):
                 'tag': None
             },
             {
-                'is_current_branch': False,
                 'is_remote_branch': True,
                 'name': 'origin/feature-foo',
                 'upstream': None,
@@ -455,14 +451,20 @@ def test_branch_success(mock_subproc_popen):
                 'tag': None,
             },
             {
-                'is_current_branch': False,
                 'is_remote_branch': True,
                 'name': 'origin/master',
                 'upstream': None,
                 'top_commit': 'abcdefghijklmnopqrstuvwxyz01234567890123',
                 'tag': None,
             }
-        ]
+        ],
+        'current_branch': {
+            'is_remote_branch': False,
+            'name': 'feature-foo',
+            'upstream': 'origin/feature-foo',
+            'top_commit': 'abcdefghijklmnopqrstuvwxyz01234567890123',
+            'tag': None,
+        }
     }
 
     # When
@@ -561,7 +563,6 @@ def test_branch_success_detached_head(mock_subproc_popen):
         'code': 0,
         'branches': [
             {
-                'is_current_branch': False,
                 'is_remote_branch': False,
                 'name': 'master',
                 'upstream': 'origin/master',
@@ -569,7 +570,6 @@ def test_branch_success_detached_head(mock_subproc_popen):
                 'tag': None,
             },
             {
-                'is_current_branch': True,
                 'is_remote_branch': False,
                 'name': '(HEAD detached at origin/feature-foo)',
                 'upstream': None,
@@ -577,14 +577,20 @@ def test_branch_success_detached_head(mock_subproc_popen):
                 'tag': None,
             },
             {
-                'is_current_branch': False,
                 'is_remote_branch': True,
                 'name': 'origin/feature-foo',
                 'upstream': None,
                 'top_commit': 'abcdefghijklmnopqrstuvwxyz01234567890123',
                 'tag': None,
             }
-        ]
+        ],
+        'current_branch': {
+            'is_remote_branch': False,
+            'name': '(HEAD detached at origin/feature-foo)',
+            'upstream': None,
+            'top_commit': None,
+            'tag': None,
+        }
     }
 
     # When

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -423,6 +423,7 @@ def test_branch_success(mock_subproc_popen):
         'code': 0,
         'branches': [
             {
+                'is_current_branch': True,
                 'is_remote_branch': False,
                 'name': 'feature-foo',
                 'upstream': 'origin/feature-foo',
@@ -430,6 +431,7 @@ def test_branch_success(mock_subproc_popen):
                 'tag': None,
             },
             {
+                'is_current_branch': False,
                 'is_remote_branch': False,
                 'name': 'master',
                 'upstream': 'origin/master',
@@ -437,6 +439,7 @@ def test_branch_success(mock_subproc_popen):
                 'tag': None,
             },
             {
+                'is_current_branch': False,
                 'is_remote_branch': False,
                 'name': 'feature-bar',
                 'upstream': None,
@@ -444,6 +447,7 @@ def test_branch_success(mock_subproc_popen):
                 'tag': None
             },
             {
+                'is_current_branch': False,
                 'is_remote_branch': True,
                 'name': 'origin/feature-foo',
                 'upstream': None,
@@ -451,6 +455,7 @@ def test_branch_success(mock_subproc_popen):
                 'tag': None,
             },
             {
+                'is_current_branch': False,
                 'is_remote_branch': True,
                 'name': 'origin/master',
                 'upstream': None,
@@ -459,6 +464,7 @@ def test_branch_success(mock_subproc_popen):
             }
         ],
         'current_branch': {
+            'is_current_branch': True,
             'is_remote_branch': False,
             'name': 'feature-foo',
             'upstream': 'origin/feature-foo',
@@ -563,6 +569,7 @@ def test_branch_success_detached_head(mock_subproc_popen):
         'code': 0,
         'branches': [
             {
+                'is_current_branch': False,
                 'is_remote_branch': False,
                 'name': 'master',
                 'upstream': 'origin/master',
@@ -570,6 +577,7 @@ def test_branch_success_detached_head(mock_subproc_popen):
                 'tag': None,
             },
             {
+                'is_current_branch': True,
                 'is_remote_branch': False,
                 'name': '(HEAD detached at origin/feature-foo)',
                 'upstream': None,
@@ -577,6 +585,7 @@ def test_branch_success_detached_head(mock_subproc_popen):
                 'tag': None,
             },
             {
+                'is_current_branch': False,
                 'is_remote_branch': True,
                 'name': 'origin/feature-foo',
                 'upstream': None,
@@ -585,6 +594,7 @@ def test_branch_success_detached_head(mock_subproc_popen):
             }
         ],
         'current_branch': {
+            'is_current_branch': True,
             'is_remote_branch': False,
             'name': '(HEAD detached at origin/feature-foo)',
             'upstream': None,

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -10,6 +10,12 @@
       "title": "History count",
       "description": "Number of (most recent) commits shown in the history log",
       "default": 25
+    },
+    "simpleStaging": {
+      "type": "boolean",
+      "title": "Simple staging flag",
+      "description": "If true, use a simplified concept of staging. Only files with changes are shown (instead of showing staged/changed/untracked), and all files with changes will be automatically staged",
+      "default": false
     }
   }
 }

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -55,7 +55,7 @@ export class CommitBox extends React.Component<
   };
 
   /** Update state of commit message input box */
-  checkReadyForSubmit = (hasStagedFiles: boolean) => {
+  commitButtonStyle = (hasStagedFiles: boolean) => {
     if (hasStagedFiles) {
       if (this.state.value.length === 0) {
         return classes(stagedCommitButtonStyle, stagedCommitButtonReadyStyle);
@@ -85,7 +85,7 @@ export class CommitBox extends React.Component<
           onChange={this.handleChange}
         />
         <input
-          className={this.checkReadyForSubmit(this.props.hasFiles)}
+          className={this.commitButtonStyle(this.props.hasFiles)}
           type="button"
           title="Commit"
           disabled={!(this.props.hasFiles && this.state.value)}

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -10,8 +10,8 @@ import {
 } from '../style/BranchHeaderStyle';
 
 export interface ICommitBoxProps {
-  hasStagedFiles: boolean;
-  commitAllStagedFiles: (message: string) => Promise<void>;
+  hasFiles: boolean;
+  commitFunc: (message: string) => Promise<void>;
 }
 
 export interface ICommitBoxState {
@@ -19,7 +19,6 @@ export interface ICommitBoxState {
    * Commit message
    */
   value: string;
-  disableSubmit: boolean;
 }
 
 export class CommitBox extends React.Component<
@@ -29,8 +28,7 @@ export class CommitBox extends React.Component<
   constructor(props: ICommitBoxProps) {
     super(props);
     this.state = {
-      value: '',
-      disableSubmit: true
+      value: ''
     };
   }
 
@@ -45,24 +43,15 @@ export class CommitBox extends React.Component<
   /** Initalize commit message input box */
   initializeInput = (): void => {
     this.setState({
-      value: '',
-      disableSubmit: true
+      value: ''
     });
   };
 
   /** Handle input inside commit message box */
   handleChange = (event: any): void => {
-    if (event.target.value && event.target.value !== '') {
-      this.setState({
-        value: event.target.value,
-        disableSubmit: false
-      });
-    } else {
-      this.setState({
-        value: event.target.value,
-        disableSubmit: true
-      });
-    }
+    this.setState({
+      value: event.target.value
+    });
   };
 
   /** Update state of commit message input box */
@@ -86,9 +75,9 @@ export class CommitBox extends React.Component<
       >
         <textarea
           className={classes(textInputStyle, stagedCommitMessageStyle)}
-          disabled={!this.props.hasStagedFiles}
+          disabled={!this.props.hasFiles}
           placeholder={
-            this.props.hasStagedFiles
+            this.props.hasFiles
               ? 'Input message to commit staged changes'
               : 'Stage your changes before commit'
           }
@@ -96,12 +85,12 @@ export class CommitBox extends React.Component<
           onChange={this.handleChange}
         />
         <input
-          className={this.checkReadyForSubmit(this.props.hasStagedFiles)}
+          className={this.checkReadyForSubmit(this.props.hasFiles)}
           type="button"
           title="Commit"
-          disabled={this.state.disableSubmit}
+          disabled={!(this.props.hasFiles && this.state.value)}
           onClick={() => {
-            this.props.commitAllStagedFiles(this.state.value);
+            this.props.commitFunc(this.state.value);
             this.initializeInput();
           }}
         />

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -123,7 +123,7 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
     }
   }
 
-  getFileLableIconClass() {
+  getFileLabelIconClass() {
     if (this.showDiscardWarning()) {
       return classes(fileIconStyle, parseFileExtension(this.props.file.to));
     } else {
@@ -248,7 +248,7 @@ export class FileItem extends React.Component<IFileItemProps, {}> {
             this.props.moveFile(this.props.file.to);
           }}
         />
-        <span className={this.getFileLableIconClass()} />
+        <span className={this.getFileLabelIconClass()} />
         <span
           className={this.getFileLabelClass()}
           onContextMenu={e => {

--- a/src/components/FileItemSimple.tsx
+++ b/src/components/FileItemSimple.tsx
@@ -36,8 +36,10 @@ export class GitMarkBox extends React.Component<IGitMarkBoxProps> {
   }
 
   protected _onClick(event: React.ChangeEvent<HTMLInputElement>) {
+    // toggle will force an update of GitPanel
     this.props.marker.toggle(this.props.fname);
-    console.log(this.props.marker);
+
+    // needed if not a descendent of a GitPanel
     this.forceUpdate();
   }
 
@@ -107,9 +109,9 @@ export class FileItemSimple extends React.Component<IFileItemSimpleProps> {
     return (
       <li className={fileStyle}>
         <GitMarkBox
-          marker={this.props.marker}
-          stage={this.props.stage}
           fname={this.props.file.to}
+          stage={this.props.stage}
+          marker={this.props.marker}
         />
         <span
           className={classes(

--- a/src/components/FileItemSimple.tsx
+++ b/src/components/FileItemSimple.tsx
@@ -1,0 +1,141 @@
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import * as React from 'react';
+import { classes } from 'typestyle';
+import { GitExtension } from '../model';
+import {
+  fileButtonStyle,
+  fileGitButtonStyle,
+  fileIconStyle,
+  fileLabelStyle,
+  fileStyle
+} from '../style/FileItemStyle';
+import {
+  changeStageButtonStyle,
+  diffFileButtonStyle,
+  discardFileButtonStyle
+} from '../style/GitStageStyle';
+import { Git } from '../tokens';
+import { openListedFile, parseFileExtension } from '../utils';
+import { isDiffSupported } from './diff/Diff';
+import { openDiffView } from './diff/DiffWidget';
+import { ISpecialRef } from './diff/model';
+
+export interface IFileItemSimpleProps {
+  file: Git.IStatusFileResult;
+  stage: string;
+  model: GitExtension;
+  discardFile: (file: string) => Promise<void>;
+  renderMime: IRenderMimeRegistry;
+}
+
+export class FileItemSimple extends React.Component<IFileItemSimpleProps, {}> {
+  constructor(props: IFileItemSimpleProps) {
+    super(props);
+  }
+
+  getDiffFileIconClass() {
+    return classes(
+      fileButtonStyle,
+      changeStageButtonStyle,
+      fileGitButtonStyle,
+      diffFileButtonStyle
+    );
+  }
+
+  getDiscardFileIconClass() {
+    return classes(
+      fileButtonStyle,
+      changeStageButtonStyle,
+      fileGitButtonStyle,
+      discardFileButtonStyle
+    );
+  }
+
+  /**
+   * Callback method discarding unstanged changes for selected file.
+   * It shows modal asking for confirmation and when confirmed make
+   * server side call to git checkout to discard changes in selected file.
+   */
+  async discardSelectedFileChanges() {
+    const result = await showDialog({
+      title: 'Discard changes',
+      body: `Are you sure you want to permanently discard changes to ${
+        this.props.file.from
+      }? This action cannot be undone.`,
+      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Discard' })]
+    });
+    if (result.button.accept) {
+      this.props.discardFile(this.props.file.to);
+    }
+  }
+
+  render() {
+    return (
+      <li className={fileStyle}>
+        <span
+          className={classes(
+            fileIconStyle,
+            parseFileExtension(this.props.file.to)
+          )}
+        />
+        <span
+          className={fileLabelStyle}
+          onDoubleClick={() =>
+            openListedFile(
+              this.props.file.x,
+              this.props.file.y,
+              this.props.file.to,
+              this.props.model
+            )
+          }
+          title={this.props.file.to}
+        >
+          {this.props.file.to}
+        </span>
+        {this.props.stage === 'Changed' && (
+          <React.Fragment>
+            <button
+              className={`jp-Git-button ${this.getDiscardFileIconClass()}`}
+              title={'Discard this change'}
+              onClick={() => {
+                this.discardSelectedFileChanges();
+              }}
+            />
+            {isDiffSupported(this.props.file.to) &&
+              this.diffButton({ specialRef: 'WORKING' })}
+          </React.Fragment>
+        )}
+        {this.props.stage === 'Staged' &&
+          isDiffSupported(this.props.file.to) &&
+          this.diffButton({ specialRef: 'INDEX' })}
+      </li>
+    );
+  }
+
+  /**
+   * Creates a button element which is used to request diff from within the
+   * Git panel.
+   *
+   * @param currentRef the ref to diff against the git 'HEAD' ref
+   */
+  private diffButton(currentRef: ISpecialRef): JSX.Element {
+    return (
+      <button
+        className={`jp-Git-button ${this.getDiffFileIconClass()}`}
+        title={'Diff this file'}
+        onClick={async () => {
+          await openDiffView(
+            this.props.file.to,
+            this.props.model,
+            {
+              previousRef: { gitRef: 'HEAD' },
+              currentRef: { specialRef: currentRef.specialRef }
+            },
+            this.props.renderMime
+          );
+        }}
+      />
+    );
+  }
+}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -4,7 +4,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { JSONObject } from '@phosphor/coreutils';
 import { Menu } from '@phosphor/widgets';
 import * as React from 'react';
-import { BranchMarker, GitExtension } from '../model';
+import { GitExtension } from '../model';
 import {
   moveFileDownButtonSelectedStyle,
   moveFileDownButtonStyle,
@@ -56,7 +56,6 @@ export interface IFileListProps {
   stagedFiles: Git.IStatusFileResult[];
   unstagedFiles: Git.IStatusFileResult[];
   untrackedFiles: Git.IStatusFileResult[];
-  marker: BranchMarker;
   model: GitExtension;
   renderMime: IRenderMimeRegistry;
   settings: ISettingRegistry.ISettings;
@@ -413,7 +412,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
 
   get markedFiles() {
     return this.allFilesExcludingUnmodified.filter(file =>
-      this.props.marker.get(file.to)
+      this.props.model.getMark(file.to)
     );
   }
 
@@ -518,7 +517,6 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
             <GitStageSimple
               heading={'Changed'}
               files={this.allFilesExcludingUnmodified}
-              marker={this.props.marker}
               model={this.props.model}
               discardAllFiles={this.discardAllChanges}
               discardFile={this.discardChanges}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -484,11 +484,15 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       />
     );
 
-    const allFilesExcludingUnmodified = () =>
-      this.props.untrackedFiles.concat(
+    const allFilesExcludingUnmodified = () => {
+      let files = this.props.untrackedFiles.concat(
         this.props.unstagedFiles,
         this.props.stagedFiles
       );
+
+      files.sort((a, b) => a.to.localeCompare(b.to));
+      return files;
+    };
 
     return (
       <div onContextMenu={event => event.preventDefault()}>
@@ -501,6 +505,10 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
             <GitStageSimple
               heading={'Changed'}
               files={allFilesExcludingUnmodified()}
+              marker={this.props.model.getMarker(
+                this.props.model.pathRepository,
+                ''
+              )}
               model={this.props.model}
               discardAllFiles={this.discardAllChanges}
               discardFile={this.discardChanges}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -82,33 +82,13 @@ export class GitPanel extends React.Component<
   }
 
   refreshBranch = async () => {
-    // Get current and upstream git branch
-    if (this.props.model.pathRepository !== null) {
-      const branchData = await this.props.model.branch();
-      let currentBranch = 'master';
-      let upstreamBranch = '';
-      if (branchData.code === 0) {
-        let allBranches = branchData.branches;
-        for (let i = 0; i < allBranches.length; i++) {
-          if (allBranches[i].is_current_branch) {
-            currentBranch = allBranches[i].name;
-            upstreamBranch = allBranches[i].upstream;
-            break;
-          }
-        }
-      }
+    const { currentBranch } = this.props.model;
 
-      this.props.model.getMarker(
-        this.props.model.pathRepository,
-        currentBranch
-      );
-
-      this.setState({
-        branches: branchData.branches,
-        currentBranch: currentBranch,
-        upstreamBranch: upstreamBranch
-      });
-    }
+    this.setState({
+      branches: this.props.model.branches,
+      currentBranch: currentBranch ? currentBranch.name : 'master',
+      upstreamBranch: currentBranch ? currentBranch.upstream : ''
+    });
   };
 
   refreshHistory = async () => {
@@ -209,10 +189,6 @@ export class GitPanel extends React.Component<
           stagedFiles={this.state.stagedFiles}
           unstagedFiles={this.state.unstagedFiles}
           untrackedFiles={this.state.untrackedFiles}
-          marker={this.props.model.getMarker(
-            this.props.model.pathRepository,
-            this.state.currentBranch
-          )}
           model={this.props.model}
           renderMime={this.props.renderMime}
           settings={this.props.settings}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -208,6 +208,10 @@ export class GitPanel extends React.Component<
           stagedFiles={this.state.stagedFiles}
           unstagedFiles={this.state.unstagedFiles}
           untrackedFiles={this.state.untrackedFiles}
+          marker={this.props.model.getMarker(
+            this.props.model.pathRepository,
+            this.state.currentBranch
+          )}
           model={this.props.model}
           renderMime={this.props.renderMime}
           settings={this.props.settings}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -1,7 +1,7 @@
 import { ISettingRegistry } from '@jupyterlab/coreutils';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import * as React from 'react';
-import { GitExtension } from '../model';
+import { GitExtension, BranchMarker } from '../model';
 import {
   findRepoButtonStyle,
   panelContainerStyle,
@@ -27,6 +27,8 @@ export interface IGitSessionNodeState {
   unstagedFiles: Git.IStatusFileResult[];
   untrackedFiles: Git.IStatusFileResult[];
   hasChangedFiles: boolean;
+
+  marker: BranchMarker;
 
   isHistoryVisible: boolean;
 }
@@ -55,6 +57,7 @@ export class GitPanel extends React.Component<
       stagedFiles: [],
       unstagedFiles: [],
       untrackedFiles: [],
+      marker: null,
       isHistoryVisible: false
     };
 
@@ -99,7 +102,11 @@ export class GitPanel extends React.Component<
       this.setState({
         branches: branchData.branches,
         currentBranch: currentBranch,
-        upstreamBranch: upstreamBranch
+        upstreamBranch: upstreamBranch,
+        marker: this.props.model.getMarker(
+          this.props.model.pathRepository,
+          currentBranch
+        )
       });
     }
   };
@@ -150,6 +157,12 @@ export class GitPanel extends React.Component<
           }
         }
       }
+
+      this.state.marker.addMarked(
+        ...stagedFiles.map(x => x.to),
+        ...unstagedFiles.map(x => x.to)
+      );
+      this.state.marker.addUnmarked(...untrackedFiles.map(x => x.to));
 
       this.setState({
         stagedFiles: stagedFiles,

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -204,6 +204,7 @@ export class GitPanel extends React.Component<
           untrackedFiles={this.state.untrackedFiles}
           model={this.props.model}
           renderMime={this.props.renderMime}
+          settings={this.props.settings}
         />
       );
     }

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -76,6 +76,7 @@ export class GitPanel extends React.Component<
         this.refreshStatus();
       }
     }, this);
+    props.model.markChanged.connect(() => this.forceUpdate());
 
     props.settings.changed.connect(this.refresh, this);
   }

--- a/src/components/GitStageSimple.tsx
+++ b/src/components/GitStageSimple.tsx
@@ -2,7 +2,7 @@ import { Dialog, showDialog } from '@jupyterlab/apputils';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import * as React from 'react';
 import { classes } from 'typestyle';
-import { BranchMarker, GitExtension } from '../model';
+import { GitExtension } from '../model';
 import {
   changeStageButtonStyle,
   discardFileButtonStyle,
@@ -17,7 +17,6 @@ import { decodeStage } from '../utils';
 export interface IGitStageSimpleProps {
   heading: string;
   files: Git.IStatusFileResult[];
-  marker: BranchMarker;
   model: GitExtension;
   discardAllFiles: () => Promise<void>;
   discardFile: (file: string) => Promise<void>;
@@ -83,7 +82,6 @@ export class GitStageSimple extends React.Component<IGitStageSimpleProps> {
                   key={fileIndex}
                   file={file}
                   stage={decodeStage(file.x, file.y)}
-                  marker={this.props.marker}
                   model={this.props.model}
                   discardFile={this.props.discardFile}
                   renderMime={this.props.renderMime}

--- a/src/components/GitStageSimple.tsx
+++ b/src/components/GitStageSimple.tsx
@@ -2,7 +2,7 @@ import { Dialog, showDialog } from '@jupyterlab/apputils';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import * as React from 'react';
 import { classes } from 'typestyle';
-import { GitExtension } from '../model';
+import { BranchMarker, GitExtension } from '../model';
 import {
   changeStageButtonStyle,
   discardFileButtonStyle,
@@ -12,10 +12,12 @@ import {
 } from '../style/GitStageStyle';
 import { Git } from '../tokens';
 import { FileItemSimple } from './FileItemSimple';
+import { decodeStage } from '../utils';
 
 export interface IGitStageSimpleProps {
   heading: string;
   files: Git.IStatusFileResult[];
+  marker: BranchMarker;
   model: GitExtension;
   discardAllFiles: () => Promise<void>;
   discardFile: (file: string) => Promise<void>;
@@ -80,7 +82,8 @@ export class GitStageSimple extends React.Component<IGitStageSimpleProps> {
                 <FileItemSimple
                   key={fileIndex}
                   file={file}
-                  stage={this.props.heading}
+                  stage={decodeStage(file.x, file.y)}
+                  marker={this.props.marker}
                   model={this.props.model}
                   discardFile={this.props.discardFile}
                   renderMime={this.props.renderMime}

--- a/src/components/GitStageSimple.tsx
+++ b/src/components/GitStageSimple.tsx
@@ -1,0 +1,95 @@
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import * as React from 'react';
+import { classes } from 'typestyle';
+import { GitExtension } from '../model';
+import {
+  changeStageButtonStyle,
+  discardFileButtonStyle,
+  sectionAreaStyle,
+  sectionFileContainerStyle,
+  sectionHeaderLabelStyle
+} from '../style/GitStageStyle';
+import { Git } from '../tokens';
+import { FileItemSimple } from './FileItemSimple';
+
+export interface IGitStageSimpleProps {
+  heading: string;
+  files: Git.IStatusFileResult[];
+  model: GitExtension;
+  discardAllFiles: () => Promise<void>;
+  discardFile: (file: string) => Promise<void>;
+  renderMime: IRenderMimeRegistry;
+}
+
+export class GitStageSimple extends React.Component<IGitStageSimpleProps> {
+  constructor(props: IGitStageSimpleProps) {
+    super(props);
+    this.state = {
+      showDiscardWarning: false
+    };
+  }
+
+  checkContents() {
+    if (this.props.files.length > 0) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  /**
+   * Callback method discarding all unstanged changes.
+   * It shows modal asking for confirmation and when confirmed make
+   * server side call to git checkout to discard all unstanged changes.
+   */
+  async discardAllChanges() {
+    const result = await showDialog({
+      title: 'Discard all changes',
+      body: `Are you sure you want to permanently discard changes to all files? This action cannot be undone.`,
+      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Discard' })]
+    });
+    if (result.button.accept) {
+      this.props.discardAllFiles();
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <div className={sectionAreaStyle}>
+          <span className={sectionHeaderLabelStyle}>
+            {this.props.heading}({this.props.files.length})
+          </span>
+          {this.props.heading === 'Changed' && (
+            <button
+              disabled={this.checkContents()}
+              className={classes(
+                changeStageButtonStyle,
+                discardFileButtonStyle
+              )}
+              title={'Discard All Changes'}
+              onClick={() => this.discardAllChanges()}
+            />
+          )}
+        </div>
+        <ul className={sectionFileContainerStyle}>
+          {this.props.files.map(
+            (file: Git.IStatusFileResult, fileIndex: number) => {
+              return (
+                <FileItemSimple
+                  key={fileIndex}
+                  file={file}
+                  stage={this.props.heading}
+                  model={this.props.model}
+                  discardFile={this.props.discardFile}
+                  renderMime={this.props.renderMime}
+                />
+              );
+            }
+          )}
+        </ul>
+      </div>
+    );
+  }
+}

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -88,7 +88,7 @@ export class PastCommitNode extends React.Component<
         <div className={branchesStyle}>
           {this.getBranchesForCommit().map((branch, id) => (
             <React.Fragment key={id}>
-              {branch.name === this.props.model.currentBranch.name && (
+              {branch.is_current_branch && (
                 <span className={classes(branchStyle, workingBranchStyle)}>
                   working
                 </span>

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -88,7 +88,7 @@ export class PastCommitNode extends React.Component<
         <div className={branchesStyle}>
           {this.getBranchesForCommit().map((branch, id) => (
             <React.Fragment key={id}>
-              {branch.is_current_branch && (
+              {branch.name === this.props.model.currentBranch.name && (
                 <span className={classes(branchStyle, workingBranchStyle)}>
                   working
                 </span>

--- a/src/gitMenuCommands.ts
+++ b/src/gitMenuCommands.ts
@@ -3,6 +3,7 @@ import { Dialog, MainAreaWidget, showDialog } from '@jupyterlab/apputils';
 import { FileBrowser } from '@jupyterlab/filebrowser';
 import { ITerminal } from '@jupyterlab/terminal';
 import { IGitExtension } from './tokens';
+import { ISettingRegistry } from '@jupyterlab/coreutils';
 
 /**
  * The command IDs used by the git plugin.
@@ -12,6 +13,7 @@ export namespace CommandIDs {
   export const gitTerminalCommand = 'git:terminal-command';
   export const gitInit = 'git:init';
   export const gitOpenUrl = 'git:open-url';
+  export const gitToggleSimpleStaging = 'git:toggle-simple-staging';
 }
 
 /**
@@ -20,7 +22,8 @@ export namespace CommandIDs {
 export function addCommands(
   app: JupyterFrontEnd,
   model: IGitExtension,
-  fileBrowser: FileBrowser
+  fileBrowser: FileBrowser,
+  settings: ISettingRegistry.ISettings
 ) {
   const { commands, shell } = app;
 
@@ -97,6 +100,15 @@ export function addCommands(
     execute: args => {
       const url = args['url'] as string;
       window.open(url);
+    }
+  });
+
+  /** add toggle for simple staging */
+  commands.addCommand(CommandIDs.gitToggleSimpleStaging, {
+    label: 'Simple staging',
+    isToggled: () => !!settings.composite['simpleStaging'],
+    execute: args => {
+      settings.set('simpleStaging', !settings.composite['simpleStaging']);
     }
   });
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -454,8 +454,10 @@ export class GitExtension implements IGitExtension, IDisposable {
       this._branches = response.branches;
       this._currentBranch = response.current_branch;
 
-      // set up the marker obj for this particular repo/branch
-      this._setMarker(this.pathRepository, this._currentBranch.name);
+      if (this._currentBranch) {
+        // set up the marker obj for the current (valid) repo/branch combination
+        this._setMarker(this.pathRepository, this._currentBranch.name);
+      }
     } else {
       this._branches = [];
       this._currentBranch = null;

--- a/src/model.ts
+++ b/src/model.ts
@@ -89,7 +89,6 @@ export class GitExtension implements IGitExtension, IDisposable {
 
           if (change.newValue !== change.oldValue) {
             this.refresh().then(() => this._repositoryChanged.emit(change));
-            this._repositoryChanged.emit(change);
           }
         })
         .catch(reason => {
@@ -337,7 +336,7 @@ export class GitExtension implements IGitExtension, IDisposable {
   }
 
   /** Refresh the git repository status */
-  async _refreshStatus(): Promise<void> {
+  protected async _refreshStatus(): Promise<void> {
     await this.ready;
     const path = this.pathRepository;
 
@@ -422,7 +421,7 @@ export class GitExtension implements IGitExtension, IDisposable {
   }
 
   /** Make request for a list of all git branches in the repository */
-  async _branch(): Promise<Git.IBranchResult> {
+  protected async _branch(): Promise<Git.IBranchResult> {
     await this.ready;
     const path = this.pathRepository;
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -439,7 +439,7 @@ export class GitExtension implements IGitExtension, IDisposable {
   /** Make request to add one or all files into
    * the staging area in repository
    */
-  async add(filename?: string): Promise<Response> {
+  async add(...filename: string[]): Promise<Response> {
     await this.ready;
     const path = this.pathRepository;
 
@@ -455,8 +455,8 @@ export class GitExtension implements IGitExtension, IDisposable {
     }
 
     const response = await httpGitRequest('/git/add', 'POST', {
-      add_all: filename === undefined,
-      filename: filename === undefined ? null : filename,
+      add_all: !filename,
+      filename: filename || '',
       top_repo_path: path
     });
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -879,15 +879,19 @@ export class BranchMarker {
   }
 
   addMarked(...fnames: string[]) {
-    for (let fname in fnames) {
+    for (let fname of fnames) {
       this.add(fname, true);
     }
   }
 
   addUnmarked(...fnames: string[]) {
-    for (let fname in fnames) {
+    for (let fname of fnames) {
       this.add(fname, false);
     }
+  }
+
+  get(fname: string) {
+    return this._marks[fname];
   }
 
   mark(fname: string) {

--- a/src/style/FileItemSimpleStyle.ts
+++ b/src/style/FileItemSimpleStyle.ts
@@ -1,0 +1,9 @@
+import { style } from 'typestyle';
+import { NestedCSSProperties } from 'typestyle/lib/types';
+
+export const gitMarkBoxCss: NestedCSSProperties = {
+  flex: '0 0 auto',
+  margin: 'auto 8px auto 4px'
+};
+
+export const gitMarkBoxStyle = style(gitMarkBoxCss);

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -313,6 +313,7 @@ export namespace Git {
    * Branch description interface
    */
   export interface IBranch {
+    is_current_branch: boolean;
     is_remote_branch: boolean;
     name: string;
     upstream: string;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -81,6 +81,11 @@ export interface IGitExtension {
   showPrefix(path: string): Promise<Git.IShowPrefixResult>;
 
   /**
+   * General git refresh
+   */
+  refresh(): Promise<void>;
+
+  /**
    * Request git status refresh
    */
   refreshStatus(): Promise<void>;
@@ -103,7 +108,17 @@ export interface IGitExtension {
   /**
    * Make request for a list of all git branches
    */
-  branch(): Promise<Git.IBranchResult>;
+  refreshBranch(): Promise<void>;
+
+  /**
+   * The list of branch in the current repo
+   */
+  branches: Git.IBranch[];
+
+  /**
+   * The current branch
+   */
+  currentBranch: Git.IBranch;
 
   /**
    * Make request to add one or all files into
@@ -208,6 +223,21 @@ export interface IGitExtension {
    * i.e. if the top folder repository has been found.
    */
   isReady: boolean;
+
+  /**
+   * Add the file named fname to the current marker with given mark
+   */
+  addMark(fname: string, mark: boolean): void;
+
+  /**
+   * Get current mark of file named fname
+   */
+  getMark(fname: string): boolean;
+
+  /**
+   * Toggle the mark for the file named fname
+   */
+  toggleMark(fname: string): void;
 }
 
 export namespace Git {
@@ -283,7 +313,6 @@ export namespace Git {
    * Branch description interface
    */
   export interface IBranch {
-    is_current_branch: boolean;
     is_remote_branch: boolean;
     name: string;
     upstream: string;
@@ -297,6 +326,7 @@ export namespace Git {
   export interface IBranchResult {
     code: number;
     branches?: IBranch[];
+    current_branch?: IBranch;
   }
 
   /** Interface for GitStatus request result,
@@ -402,5 +432,18 @@ export namespace Git {
   export interface IPushPullResult {
     code: number;
     message?: string;
+  }
+
+  /**
+   * Interface for a marker obj
+   */
+  export interface IBranchMarker {
+    add(fname: string, mark: boolean): void;
+
+    get(fname: string): boolean;
+
+    set(fname: string, mark: boolean): void;
+
+    toggle(fname: string): void;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,24 @@ export function extractFilename(path: string): string {
   }
 }
 
+export function decodeStage(x: string, y: string) {
+  // If file is untracked
+  if (x === '?' && y === '?') {
+    return 'untracked';
+  } else {
+    // If file is staged
+    if (x !== ' ' && y !== 'D') {
+      return 'staged';
+    }
+    // If file is unstaged but tracked
+    if (y !== ' ') {
+      return 'unstaged';
+    }
+  }
+
+  return undefined;
+}
+
 /** Open a file in the git listing */
 export async function openListedFile(
   typeX: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,7 @@ export function extractFilename(path: string): string {
   }
 }
 
-export function decodeStage(x: string, y: string) {
+export function decodeStage(x: string, y: string): string | null {
   // If file is untracked
   if (x === '?' && y === '?') {
     return 'untracked';
@@ -46,7 +46,7 @@ export function decodeStage(x: string, y: string) {
     }
   }
 
-  return undefined;
+  return null;
 }
 
 /** Open a file in the git listing */

--- a/tests/GitExtension.spec.tsx
+++ b/tests/GitExtension.spec.tsx
@@ -21,6 +21,14 @@ describe('IGitExtension', () => {
     jest.restoreAllMocks();
 
     mockResponses = {
+      '/git/branch': {
+        body: request =>
+          JSON.stringify({
+            code: 0,
+            branches: [],
+            current_branch: null
+          })
+      },
       '/git/show_top_level': {
         body: request =>
           JSON.stringify({
@@ -32,6 +40,13 @@ describe('IGitExtension', () => {
         body: () =>
           JSON.stringify({
             server_root: fakeRoot
+          })
+      },
+      '/git/status': {
+        body: () =>
+          JSON.stringify({
+            code: 0,
+            files: []
           })
       }
     };

--- a/tests/test-components/CommitBox.spec.tsx
+++ b/tests/test-components/CommitBox.spec.tsx
@@ -11,8 +11,8 @@ describe('CommitBox', () => {
   describe('#checkReadyForSubmit()', () => {
     it('should update commit box state to be ready when changes are staged', () => {
       const box = new CommitBox({
-        commitAllStagedFiles: async () => {},
-        hasStagedFiles: true
+        commitFunc: async () => {},
+        hasFiles: true
       });
 
       let actual = box.checkReadyForSubmit(true);
@@ -26,8 +26,8 @@ describe('CommitBox', () => {
 
     it('should update commit box state to be disabled when no changes are staged', () => {
       const box = new CommitBox({
-        commitAllStagedFiles: async () => {},
-        hasStagedFiles: true
+        commitFunc: async () => {},
+        hasFiles: true
       });
 
       let actual = box.checkReadyForSubmit(false);
@@ -40,8 +40,8 @@ describe('CommitBox', () => {
 
     it('should be ready to commit with a message set.', () => {
       const box = new CommitBox({
-        commitAllStagedFiles: async () => {},
-        hasStagedFiles: true
+        commitFunc: async () => {},
+        hasFiles: true
       });
       box.setState(
         {

--- a/tests/test-components/CommitBox.spec.tsx
+++ b/tests/test-components/CommitBox.spec.tsx
@@ -15,7 +15,7 @@ describe('CommitBox', () => {
         hasFiles: true
       });
 
-      let actual = box.checkReadyForSubmit(true);
+      let actual = box.commitButtonStyle(true);
 
       let expected = classes(
         stagedCommitButtonStyle,
@@ -30,7 +30,7 @@ describe('CommitBox', () => {
         hasFiles: true
       });
 
-      let actual = box.checkReadyForSubmit(false);
+      let actual = box.commitButtonStyle(false);
       let expected = classes(
         stagedCommitButtonStyle,
         stagedCommitButtonDisabledStyle
@@ -48,7 +48,7 @@ describe('CommitBox', () => {
           value: 'message'
         },
         () => {
-          let actual = box.checkReadyForSubmit(true);
+          let actual = box.commitButtonStyle(true);
 
           let expected = stagedCommitButtonStyle;
           expect(actual).toEqual(expected);

--- a/tests/test-components/FileList.spec.tsx
+++ b/tests/test-components/FileList.spec.tsx
@@ -15,7 +15,8 @@ describe('FileList', () => {
     renderMime: null,
     stagedFiles: [],
     unstagedFiles: [],
-    untrackedFiles: []
+    untrackedFiles: [],
+    settings: null
   };
 
   describe('#commitAllStagedFiles()', () => {


### PR DESCRIPTION
This is a resumption of the work from #437 following the major refactor that was done in #438. I've cherry picked various lines from #437 to get this started. Here's the info from the old PR:

>For people who haven't used any VCS before, `git` can prove to be somewhat overwhelming. In particular, the untracked/unstaged/staged concept can seem very foreign to someone who up until now has never done any kind of "commit" more complicated than saving a file to disk. For that reason I think it would be idea to have an option to switch the staging UI to a "simplified" mode. As a model, I'm thinking along the lines of the UI in the Github desktop app:

![image](https://user-images.githubusercontent.com/2263641/67166307-24b6a080-f35c-11e9-9b79-e88e141b8bf1.png)

>It would simply show which files have changed, rather than splitting them into categories. When the commit button is pushed, all changed files will be automatically staged and commited (although there should also be something like the Github app's checkboxes to opt files out of a commit).

>Additionally, some color coding of file names would be nice, a la VSCode:

![image](https://user-images.githubusercontent.com/2263641/67166362-74956780-f35c-11e9-9c27-dc667b327229.png)

>Currently this PR is at proof of concept stage. It adds a `simpleStaging` flag to the user settings. When enabled, the staging UI is simplified, and only shows a single "changed" category. When disabled, the staging UI reverts back to the standard version.