### PR TITLE
fixes #442: addAllUnstagedFiles now has the correct behavior

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -539,9 +539,17 @@ class Git:
         my_output = subprocess.check_output(["git", "add", "-A"], cwd=top_repo_path)
         return my_output
 
+    def add_all_unstaged(self, top_repo_path):
+        """
+        Execute git add all unstaged command & return the result.
+        """
+        e = 'git add -u'
+        my_output = subprocess.call(e, shell=True, cwd=top_repo_path)
+        return {"result": my_output}
+
     def add_all_untracked(self, top_repo_path):
         """
-        Execute git add_all_untracked command & return the result.
+        Execute git add all untracked command & return the result.
         """
         e = 'echo "a\n*\nq\n" | git add -i'
         my_output = subprocess.call(e, shell=True, cwd=top_repo_path)

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -182,6 +182,7 @@ class GitDiffHandler(GitHandler):
         my_output = self.git.diff(top_repo_path)
         self.finish(my_output)
 
+
 class GitBranchHandler(GitHandler):
     """
     Handler for 'git branch -a'. Fetches list of all branches in current repository
@@ -199,12 +200,12 @@ class GitBranchHandler(GitHandler):
 class GitAddHandler(GitHandler):
     """
     Handler for git add <filename>'.
-    Adds one or all files into to the staging area.
+    Adds one or all files to the staging area.
     """
 
     def get(self):
         """
-        GET request handler, adds files in the staging area.
+        GET request handler, adds files to the staging area.
         """
         self.finish(
             json.dumps(
@@ -224,6 +225,40 @@ class GitAddHandler(GitHandler):
             filename = data["filename"]
             my_output = self.git.add(filename, top_repo_path)
         self.finish(my_output)
+
+
+class GitAddAllUnstagedHandler(GitHandler):
+    """
+    Handler for 'git add -u'. Adds ONLY all unstaged files, does not touch
+    untracked or staged files.
+    """
+
+    def post(self):
+        """
+        POST request handler, adds all the changed files.
+        """
+        self.finish(
+            self.git.add_all_unstaged(
+                self.get_json_body()["top_repo_path"]
+            )
+        )
+
+
+class GitAddAllUntrackedHandler(GitHandler):
+    """
+    Handler for 'echo "a\n*\nq\n" | git add -i'. Adds ONLY all
+    untracked files, does not touch unstaged or staged files.
+    """
+
+    def post(self):
+        """
+        POST request handler, adds all the untracked files.
+        """
+        self.finish(
+            self.git.add_all_untracked(
+                self.get_json_body()["top_repo_path"]
+            )
+        )
 
 
 class GitResetHandler(GitHandler):
@@ -344,7 +379,7 @@ class GitPullHandler(GitHandler):
         """
         data = self.get_json_body()
         response = self.git.pull(data['current_path'], data.get('auth', None))
-        
+
         self.finish(json.dumps(response))
 
 
@@ -404,18 +439,6 @@ class GitInitHandler(GitHandler):
         self.finish(my_output)
 
 
-class GitAddAllUntrackedHandler(GitHandler):
-    """
-    Handler for 'echo "a\n*\nq\n" | git add -i'. Adds ONLY all untracked files.
-    """
-
-    def post(self):
-        """
-        POST request handler, adds all the untracked files.
-        """
-        top_repo_path = self.get_json_body()["top_repo_path"]
-        my_output = self.git.add_all_untracked(top_repo_path)
-        self.finish(my_output)
 
 class GitChangedFilesHandler(GitHandler):
 
@@ -466,6 +489,8 @@ def setup_handlers(web_app):
         ("/git/show_top_level", GitShowTopLevelHandler),
         ("/git/show_prefix", GitShowPrefixHandler),
         ("/git/add", GitAddHandler),
+        ("/git/add_all_unstaged", GitAddAllUnstagedHandler),
+        ("/git/add_all_untracked", GitAddAllUntrackedHandler),
         ("/git/status", GitStatusHandler),
         ("/git/branch", GitBranchHandler),
         ("/git/reset", GitResetHandler),
@@ -480,7 +505,6 @@ def setup_handlers(web_app):
         ("/git/detailed_log", GitDetailedLogHandler),
         ("/git/init", GitInitHandler),
         ("/git/all_history", GitAllHistoryHandler),
-        ("/git/add_all_untracked", GitAddAllUntrackedHandler),
         ("/git/clone", GitCloneHandler),
         ("/git/upstream", GitUpstreamHandler),
         ("/git/config", GitConfigHandler),

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -312,7 +312,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
 
   /** Add all unstaged files */
   addAllUnstagedFiles = async () => {
-    await this.props.model.add();
+    await this.props.model.addAllUnstaged();
   };
 
   /** Discard changes in all unstaged files */

--- a/src/model.ts
+++ b/src/model.ts
@@ -464,6 +464,38 @@ export class GitExtension implements IGitExtension, IDisposable {
     return Promise.resolve(response);
   }
 
+  /** Make request to add all unstaged files into
+   * the staging area in repository 'path'
+   */
+  async addAllUnstaged(): Promise<Response> {
+    await this.ready;
+    const path = this.pathRepository;
+
+    if (path === null) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            code: -1,
+            message: 'Not in a git repository.'
+          })
+        )
+      );
+    }
+
+    try {
+      let response = await httpGitRequest('/git/add_all_unstaged', 'POST', {
+        top_repo_path: path
+      });
+      if (response.status !== 200) {
+        const data = await response.json();
+        throw new ServerConnection.ResponseError(response, data.message);
+      }
+      return response.json();
+    } catch (err) {
+      throw ServerConnection.NetworkError;
+    }
+  }
+
   /** Make request to add all untracked files into
    * the staging area in the repository
    */

--- a/src/model.ts
+++ b/src/model.ts
@@ -492,7 +492,7 @@ export class GitExtension implements IGitExtension, IDisposable {
       }
       return response.json();
     } catch (err) {
-      throw ServerConnection.NetworkError;
+      throw new ServerConnection.NetworkError(err);
     }
   }
 


### PR DESCRIPTION
Basically, we doing an inappropriate `git add -A` where we should have been doing `git add -u`. This has been fixed.

In various places in the code we refer to the 3 categories of files that git pays attention to as untracked, unstaged, and staged. We should try to be as consistent about these names throughout the program as we can be (eg, we should probably(?) change the text header over the middle file list from `Changed` -> `Unstaged`). Being consistent will help us to avoid this kind of unexpected behavior in the future.