### PR TITLE
Update refresh interval

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -21,7 +21,7 @@
       "type": "integer",
       "title": "Refresh interval",
       "description": "Number of milliseconds between polling the file system for changes.",
-      "default": 4000
+      "default": 3000
     }
   }
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -16,6 +16,12 @@
       "title": "Simple staging flag",
       "description": "If true, use a simplified concept of staging. Only files with changes are shown (instead of showing staged/changed/untracked), and all files with changes will be automatically staged",
       "default": false
+    },
+    "refreshInterval": {
+      "type": "integer",
+      "title": "Refresh interval",
+      "description": "Number of milliseconds between polling the file system for changes.",
+      "default": 4000
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,15 +115,8 @@ function activate(
         { rank: 60 }
       );
 
-      // Sync the refresh interval to the current settings:
-      gitExtension.refreshInterval = settings.composite
-        .refreshInterval as number;
-
-      // Listen for changes to extension settings:
-      settings.changed.connect((settings: ISettingRegistry.ISettings) => {
-        gitExtension.refreshInterval = settings.composite
-          .refreshInterval as number;
-      });
+      // Pass along the plugin settings to the Git model:
+      gitExtension.settings = settings;
     })
     .catch(reason => {
       console.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ async function activate(
   try {
     settings = await settingRegistry.load(plugin.id);
   } catch (error) {
-    console.error(`Failed to load settings for the Git Exetnsion.\n${error}`);
+    console.error(`Failed to load settings for the Git Extension.\n${error}`);
   }
   // Create the Git model
   const gitExtension = new GitExtension(app, settings);

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,9 +74,6 @@ async function activate(
   // Get a reference to the default file browser extension
   const filebrowser = factory.defaultBrowser;
 
-  // Wait for the application and file browser extension to be restored:
-  await Promise.all([app.restored, filebrowser.model.restored]);
-
   // Attempt to load application settings
   try {
     settings = await settingRegistry.load(plugin.id);
@@ -86,8 +83,10 @@ async function activate(
   // Create the Git model
   const gitExtension = new GitExtension(app, settings);
 
-  // Sync the Git extension path with the file browser extension's current path
-  gitExtension.pathRepository = filebrowser.model.path;
+  // Whenever we restore the application, sync the Git extension path
+  Promise.all([app.restored, filebrowser.model.restored]).then(() => {
+    gitExtension.pathRepository = filebrowser.model.path;
+  });
 
   // Whenever the file browser path changes, sync the Git extension path
   filebrowser.model.pathChanged.connect(

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,10 @@ function activate(
         { rank: 60 }
       );
 
+      // Sync the refresh interval to the current settings:
+      gitExtension.refreshInterval = settings.composite
+        .refreshInterval as number;
+
       // Listen for changes to extension settings:
       settings.changed.connect((settings: ISettingRegistry.ISettings) => {
         gitExtension.refreshInterval = settings.composite

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ async function activate(
   filebrowser.model.fileChanged.connect(() => gitExtension.refreshStatus());
 
   // Provided we were able to load application settings, create the extension widgets
-  if (typeof settings !== void 0) {
+  if (settings) {
     // Create the Git widget sidebar
     const gitPlugin = new GitWidget(gitExtension, settings, renderMime);
     gitPlugin.id = 'jp-git-sessions';

--- a/src/model.ts
+++ b/src/model.ts
@@ -11,7 +11,7 @@ import { IGitExtension, Git } from './tokens';
 /**
  * The default duration of the auto-refresh in ms
  */
-const DEFAULT_REFRESH_INTERVAL = 10000;
+const DEFAULT_REFRESH_INTERVAL = 2000;
 
 /** Main extension class */
 export class GitExtension implements IGitExtension, IDisposable {

--- a/src/model.ts
+++ b/src/model.ts
@@ -353,7 +353,7 @@ export class GitExtension implements IGitExtension, IDisposable {
       await this._poll.refresh();
       await this._poll.tick;
     } else {
-      await Promise.resolve();
+      return Promise.resolve();
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -354,6 +354,7 @@ export class GitExtension implements IGitExtension, IDisposable {
       await this._poll.tick;
     } else {
       await this._refreshStatus();
+      await Promise.resolve();
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -13,7 +13,7 @@ import { ISignal, Signal } from '@phosphor/signaling';
 import { httpGitRequest } from './git';
 import { IGitExtension, Git } from './tokens';
 
-// Default refresh interval (in milliseconds) for polling the current Git status:
+// Default refresh interval (in milliseconds) for polling the current Git status (NOTE: this value should be the same value as in the plugin settings schema):
 const DEFAULT_REFRESH_INTERVAL = 3000; // ms
 
 /** Main extension class */

--- a/src/model.ts
+++ b/src/model.ts
@@ -169,7 +169,9 @@ export class GitExtension implements IGitExtension, IDisposable {
       return;
     }
     this._isDisposed = true;
-    this._poll.dispose();
+    if (this._poll) {
+      this._poll.dispose();
+    }
     Signal.clearData(this);
   }
 
@@ -347,8 +349,12 @@ export class GitExtension implements IGitExtension, IDisposable {
   }
 
   async refreshStatus(): Promise<void> {
-    await this._poll.refresh();
-    await this._poll.tick;
+    if (this._poll) {
+      await this._poll.refresh();
+      await this._poll.tick;
+    } else {
+      await Promise.resolve();
+    }
   }
 
   /** Refresh the git repository status */

--- a/src/model.ts
+++ b/src/model.ts
@@ -353,7 +353,7 @@ export class GitExtension implements IGitExtension, IDisposable {
       await this._poll.refresh();
       await this._poll.tick;
     } else {
-      return Promise.resolve();
+      await this._refreshStatus();
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -924,7 +924,7 @@ export class GitExtension implements IGitExtension, IDisposable {
   private _readyPromise: Promise<void> = Promise.resolve();
   private _pendingReadyPromise = 0;
   private _poll: Poll;
-  private _refreshInterval = 4000; // ms
+  private _refreshInterval = 3000; // ms
   private _headChanged = new Signal<IGitExtension, void>(this);
   private _markChanged = new Signal<IGitExtension, void>(this);
   private _repositoryChanged = new Signal<


### PR DESCRIPTION
This PR resolves https://github.com/jupyterlab/jupyterlab-git/issues/454 by

-   reducing the refresh interval to create a more responsive user experience. Previously, if a file change was made outside of the lab environment, it could take up to 10 seconds for the Git extension to register that a change had been made. After experimenting with different durations, I settled on a (maximum) duration of 3 seconds. In my experience, once I had to wait longer, I immediately began wondering if something was wrong. Maybe others are more patient.
-   exposing a `refreshInterval` configurable setting. This should allow users (and organizations) to adjust the polling behavior according to taste and desired performance profiles.
-   adding logic for listening to `fileChanged` events emitted by the default file browser extension and syncing the Git extension accordingly.

A future PR may want to consider refactoring the Git extension backend to be async, in order to ensure that the backend remains responsive when shelling out to execute Git commands. The current polling rate of 3 seconds should not be problematic, in and of itself, from a perf perspective within the frontend/UI. However, I cannot readily vouch for the performance implications of repeatedly performing synchronous commands in very large Git repositories on the backend.

By allowing the refresh interval to be configurable and documented accordingly, we should allow users (and organizations) to tailor as need be, regardless of the backend implementation.