### PR TITLE
Don't build JLab extension for sdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
   - pip install jupyterlab_git[test] --pre --no-index --find-links=dist --no-deps --no-cache-dir -v
   # Install the extension dependencies
   - pip install jupyterlab_git[test]
+  - jupyter serverextension list
   - jupyter labextension list
   - jupyter lab build
   - pytest jupyterlab_git -r ap

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - jupyter labextension list
   - jupyter lab build
   - pytest jupyterlab_git -r ap
+  - jlpm install
   - jlpm run test
   - python -m jupyterlab.browser_check
   - jlpm run lint

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,6 @@ include setupbase.py
 
 include package.json
 include *.config.js
-include setupJest.js
 include ts*.json
 include jupyterlab_git/labextension/*.tgz
 recursive-include jupyter-config *.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ include *.config.js
 include setupJest.js
 include ts*.json
 include jupyterlab_git/labextension/*.tgz
+recursive-include jupyter-config *.json
 
 # Tests
 graft tests

--- a/setupbase.py
+++ b/setupbase.py
@@ -179,7 +179,7 @@ def create_cmdclass(prerelease_cmd=None, package_data_spec=None,
     cmdclass = dict(
         build_py=wrapper(build_py, strict=is_repo),
         bdist_egg=egg,
-        sdist=wrapper(sdist, strict=True),
+        sdist=sdist,
         handle_files=handle_files,
     )
 


### PR DESCRIPTION
Alternative solution for #430 compared to #458 

The purpose of the `sdist` package is to contain all source files needed for building a fully functional package. This implies that it needs building tools to work and this is the usage for python package shipping cython, C/C++ or Fortran code. So it makes sense to ship the Typescript files and associated configuration in `sdist`.

But as mentioned in #430 and #458, it does not make sense to build the JS files twice (once for `sdist` and one for `bdist`). So to respect the above comment, the production of the JLab extension should only be carried out when executing the installation or the `bdist` command.

The difference of the source and wheel archive can be seen below:

![image](https://user-images.githubusercontent.com/8435071/69708072-3f1e2f80-10fb-11ea-9e4b-75c6d0995907.png)

Fix #430