### PR TITLE
Adjust commit textarea styling and element alignment

### DIFF
--- a/src/style/BranchHeaderStyle.ts
+++ b/src/style/BranchHeaderStyle.ts
@@ -113,18 +113,18 @@ export const textInputStyle = style({
 export const stagedCommitStyle = style({
   resize: 'none',
   display: 'flex',
-  alignItems: 'center',
+  alignItems: 'flex-start',
   margin: '8px'
 });
 
 export const stagedCommitMessageStyle = style({
   width: '75%',
   fontWeight: 300,
-  height: '32px',
+  height: '35px',
   overflowX: 'auto',
   border: 'var(--jp-border-width) solid var(--jp-border-color2)',
   flex: '20 1 auto',
-  resize: 'none',
+  resize: 'vertical',
   padding: '4px 8px',
   backgroundColor: 'var(--jp-layout-color1)',
   color: 'var(--jp-ui-font-color0)',


### PR DESCRIPTION
This PR

-   adds support for resizing the commit message `textarea`. This is important for multiline commit messages containing a subject and body. Currently, one is unable to resize the `textarea` to see the entire message, and, instead, one must scroll.
-   because the `textarea` is now resizable, aligns the commit box items to the starting alignment. Otherwise, when one resizes the `textarea`, the commit button moves, which does not seem either desirable or necessary.
-   tweaks the initial `textarea` height so that the button height and `textarea` height are approximately the same and appear aligned.