### PR TITLE
Add demo notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A JupyterLab extension for version control using git
 
 ![](http://g.recordit.co/N9Ikzbyk8P.gif)
 
+To see the extension in action, open the example notebook included in the Binder [demo](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-git/master?urlpath=lab).
+
 ## Prerequisites
 
 - JupyterLab  


### PR DESCRIPTION
This PR

-   adds a demo notebook.

Having a demo notebook in the plugin repository is useful for two reasons:

1.  when opening the associated Binder, a user can immediately play around with a sample notebook having varied outputs, without needing to create one herself. This is particularly useful when testing the NBDime diffs.
2.  when performing local development, having a demo notebook is useful when testing out new and/or modified features.

The included demo notebook is based on a similar notebook from JupyterLab core.