### PR TITLE
Adjust icon spacing in path header component

### DIFF
--- a/src/style/PathHeaderStyle.ts
+++ b/src/style/PathHeaderStyle.ts
@@ -30,7 +30,7 @@ export const repoRefreshStyle = style({
   boxSizing: 'border-box',
   outline: 'none',
   padding: '0px 6px',
-  margin: 'auto 5px auto auto',
+  margin: 'auto 5px auto 5px',
   height: '24px',
 
   $nest: {
@@ -54,7 +54,7 @@ export const gitPushStyle = style({
   boxSizing: 'border-box',
   outline: 'none',
   padding: '0px 6px',
-  margin: 'auto 5px auto auto',
+  margin: 'auto 5px auto 5px',
   height: '24px',
 
   $nest: {


### PR DESCRIPTION
Currently, icon margins simply expand and contract as the Git side panel expands and contracts, leading to (arguably) unnatural icon alignment. This PR changes to fixed icon margins and ensures that the icons remain right-aligned as the side panel is resized.

Before:

![image](https://user-images.githubusercontent.com/2643044/69907898-7ad32680-1393-11ea-9587-8cb38227d2ad.png)

After:

<img width="483" alt="Screen Shot 2019-11-30 at 5 05 44 PM" src="https://user-images.githubusercontent.com/2643044/69907906-d2719200-1393-11ea-8137-eb6e207fc438.png">
