### PR TITLE
Adjust branch dropdown alignment

### DIFF
--- a/src/style/BranchHeaderStyle.ts
+++ b/src/style/BranchHeaderStyle.ts
@@ -82,6 +82,8 @@ export const headerButtonDisabledStyle = style({
 
 export const branchListItemStyle = style({
   listStyle: 'none',
+  textAlign: 'left',
+  marginLeft: '1em',
   color: 'var(--jp-ui-font-color1)'
 });
 


### PR DESCRIPTION
This PR

-   adjusts branch dropdown item alignment.

Currently, branch dropdown items are center aligned which is poor for readability, as one must constantly reset to a new visual alignment position before reading the next list item.

Before:

<img width="314" alt="Screen Shot 2019-11-30 at 5 25 05 PM" src="https://user-images.githubusercontent.com/2643044/69908050-63496d00-1396-11ea-8ea9-4540c993b483.png">

After:

<img width="314" alt="Screen Shot 2019-11-30 at 5 23 38 PM" src="https://user-images.githubusercontent.com/2643044/69908040-3432fb80-1396-11ea-8eef-747560ba3c8d.png">
