### PR TITLE
Color insertion and deletion icons

### DIFF
--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -19,6 +19,8 @@ import {
   fileList,
   floatRightStyle,
   iconStyle,
+  insertionsIconStyle,
+  deletionsIconStyle,
   revertButtonStyle
 } from '../style/SinglePastCommitInfoStyle';
 import { Git } from '../tokens';
@@ -140,7 +142,7 @@ export class SinglePastCommitInfo extends React.Component<
             <span>
               <DefaultIconReact
                 name="git-insertionsMade"
-                className={iconStyle}
+                className={classes(iconStyle, insertionsIconStyle)}
                 tag="span"
                 title="# Insertions"
               />
@@ -149,7 +151,7 @@ export class SinglePastCommitInfo extends React.Component<
             <span>
               <DefaultIconReact
                 name="git-deletionsMade"
-                className={iconStyle}
+                className={classes(iconStyle, deletionsIconStyle)}
                 tag="span"
                 title="# Deletions"
               />

--- a/src/style/SinglePastCommitInfoStyle.ts
+++ b/src/style/SinglePastCommitInfoStyle.ts
@@ -72,6 +72,22 @@ export const iconStyle = style({
   right: '10px'
 });
 
+export const insertionsIconStyle = style({
+  $nest: {
+    '.jp-icon3': {
+      fill: '#00dc00'
+    }
+  }
+});
+
+export const deletionsIconStyle = style({
+  $nest: {
+    '.jp-icon3': {
+      fill: '#ff0000'
+    }
+  }
+});
+
 export const diffIconStyle = style({
   backgroundColor: 'transparent',
   backgroundPosition: 'center',


### PR DESCRIPTION
This PR

-   sets the fill color of the insertion and deletion icons in the Git history panel, thus providing a color indication, similar to Git terminal output, as to insertion and deletion statistics.

Before:

<img width="314" alt="Screen Shot 2019-11-30 at 5 56 58 PM" src="https://user-images.githubusercontent.com/2643044/69908273-d81ea600-139a-11ea-849c-15e19712a4e7.png">

After:

<img width="314" alt="Screen Shot 2019-11-30 at 5 56 10 PM" src="https://user-images.githubusercontent.com/2643044/69908266-c1784f00-139a-11ea-9e97-e6228b63870b.png">
