### PR TITLE
Set title attributes to support tooltip info

### DIFF
--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -167,6 +167,7 @@ export class SinglePastCommitInfo extends React.Component<
                 discardFileButtonStyle
               )}
               onClick={this.showDeleteCommit}
+              title="Discard changes introduced by this commit"
             />
             <button
               className={classes(
@@ -175,6 +176,7 @@ export class SinglePastCommitInfo extends React.Component<
                 revertButtonStyle
               )}
               onClick={this.showResetToCommit}
+              title="Discard changes introduced *after* this commit"
             />
           </div>
           <div>


### PR DESCRIPTION
This PR

-   sets `title` attributes for past commit info buttons, thus enabling native support for tooltips. Currently, if you hover over the buttons, no contextual information regarding button behavior is displayed.