### PR TITLE
followup #450: fixes behavior when `"disableBranchWithChanges": true`

### DIFF
--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -19,6 +19,9 @@ import {
 import { Git, IGitExtension } from '../tokens';
 import { NewBranchBox } from './NewBranchBox';
 
+const CHANGES_ERR_MSG =
+  'You have files with changes in current branch. Please commit or discard changed files before';
+
 export interface IBranchHeaderState {
   dropdownOpen: boolean;
   showNewBranchBox: boolean;
@@ -79,7 +82,7 @@ export class BranchHeader extends React.Component<
     } else {
       showErrorMessage(
         'Switching branch disabled',
-        'You have staged changes in current branch. Please commit / discard them before switching to another branch.'
+        CHANGES_ERR_MSG + 'switching to another branch.'
       );
     }
   }
@@ -102,7 +105,7 @@ export class BranchHeader extends React.Component<
     } else {
       showErrorMessage(
         'Creating new branch disabled',
-        'You have staged changes in current branch. Please commit / discard them before creating a new branch.'
+        CHANGES_ERR_MSG + 'creating a new branch.'
       );
     }
   };

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -201,7 +201,10 @@ export class GitPanel extends React.Component<
               (this.props.settings.composite[
                 'disableBranchWithChanges'
               ] as boolean) &&
-              (!!this.state.unstagedFiles || !!this.state.stagedFiles)
+(
+   (this.state.unstagedFiles && this.state.unstagedFiles.length) ||
+   (this.state.stagedFiles && this.state.stagedFiles.length)
+)
             }
             toggleSidebar={this.toggleSidebar}
             sideBarExpanded={this.state.isHistoryVisible}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -198,10 +198,10 @@ export class GitPanel extends React.Component<
             stagedFiles={this.state.stagedFiles}
             data={this.state.branches}
             disabled={
-              this.state.pastCommits.length === 0 ||
               (this.props.settings.composite[
                 'disableBranchWithChanges'
-              ] as boolean)
+              ] as boolean) &&
+              (!!this.state.unstagedFiles || !!this.state.stagedFiles)
             }
             toggleSidebar={this.toggleSidebar}
             sideBarExpanded={this.state.isHistoryVisible}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -188,6 +188,12 @@ export class GitPanel extends React.Component<
     }
 
     if (this.state.inGitRepository) {
+      const disableBranchOps = Boolean(
+        this.props.settings.composite['disableBranchWithChanges'] &&
+          ((this.state.unstagedFiles && this.state.unstagedFiles.length) ||
+            (this.state.stagedFiles && this.state.stagedFiles.length))
+      );
+
       main = (
         <React.Fragment>
           <BranchHeader
@@ -197,15 +203,7 @@ export class GitPanel extends React.Component<
             upstreamBranch={this.state.upstreamBranch}
             stagedFiles={this.state.stagedFiles}
             data={this.state.branches}
-            disabled={
-              (this.props.settings.composite[
-                'disableBranchWithChanges'
-              ] as boolean) &&
-(
-   (this.state.unstagedFiles && this.state.unstagedFiles.length) ||
-   (this.state.stagedFiles && this.state.stagedFiles.length)
-)
-            }
+            disabled={disableBranchOps}
             toggleSidebar={this.toggleSidebar}
             sideBarExpanded={this.state.isHistoryVisible}
           />


### PR DESCRIPTION
followup #450

Currently, if `"disableBranchWithChanges": true` is in settings, branch ops are disabled completely in all cases. This PR restores the old "disable when there are changes" behavior when the setting is `true`