### PR TITLE
followup #448: fix git add multiple files

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -535,11 +535,12 @@ class Git:
         Execute git add<filename> command & return the result.
         """
         if not isinstance(filename, str):
-            # assume filename is a sequence
-            filename = ' '.join(filename)
+            # assume filename is a sequence of str
+            cmd = ["git", "add"] + list(filename)
+        else:
+            cmd = ["git", "add", filename]
 
-        my_output = subprocess.check_output(["git", "add", filename], cwd=top_repo_path)
-        return my_output
+        return subprocess.check_output(cmd, cwd=top_repo_path)
 
     def add_all(self, top_repo_path):
         """


### PR DESCRIPTION
followup #448

Changes made in #448 allow the frontend/backend to git add more than one file at a time with a single `add` cmd. This PR fixes a related backend issue with parsing multiple files when generating the cmd.

Also fixes committing more than one file at a time in simple staging mode