### PR TITLE
bump to `0.10.0` for dev branch; final `0.9.0` release system fixes

### DIFF
--- a/jupyterlab_git/_version.py
+++ b/jupyterlab_git/_version.py
@@ -1,5 +1,7 @@
 # Copyright (c) Project Jupyter.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 9, 0)
-__version__ = ".".join(map(str, version_info))
+version_info = (0, 10, 0)
+flag = ''
+
+__version__ = ".".join(map(str, version_info)) + flag

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/git",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A JupyterLab extension for version control using git",
   "main": "lib/index.js",
   "style": "style/index.css",


### PR DESCRIPTION
This PR bumps the Python and npm packages to `0.10.0` for the dev build, now that `0.9.0` has been released. If we do need to do any patch releases before `0.10.0` is released, we can use a backport branch strategy similar to what jlab core does.

The PR also contains the final tweaks to the release system that I had to make while doing the `0.9.0` release