### PR TITLE
Fixes #481: Adjusts bottom panel margin

### DIFF
--- a/src/style/HistorySideBarStyle.ts
+++ b/src/style/HistorySideBarStyle.ts
@@ -4,5 +4,6 @@ export const historySideBarStyle = style({
   display: 'flex',
   flexDirection: 'column',
   paddingLeft: 0,
-  overflowY: 'scroll'
+  overflowY: 'scroll',
+  marginBlockEnd: 0
 });


### PR DESCRIPTION
This PR resolves #481 by

-   adjusting the bottom panel margin thus ensuring that (a) the panel content extends to the bottom of the Git panel and (b) any side scrollbars are flush against the bottom of the Git panel.

New behavior:

<img width="366" alt="Screen Shot 2019-12-05 at 3 15 29 PM" src="https://user-images.githubusercontent.com/2643044/70274903-a9297b00-1772-11ea-858d-dbeed5cda80e.png">
