### PR TITLE
Remove the `cmd` argument in open terminal

### DIFF
--- a/src/gitMenuCommands.ts
+++ b/src/gitMenuCommands.ts
@@ -28,33 +28,25 @@ export function addCommands(
   const { commands, shell } = app;
 
   /**
-   * Add open terminal and run command
-   *
-   * Argument 'cmd' can be passed at the execute function to specify the command to execute
+   * Add open terminal in the Git repository
    */
   commands.addCommand(CommandIDs.gitTerminalCommand, {
-    label: 'Git Command in Terminal',
-    caption: 'Open a new terminal to perform git command',
+    label: 'Open Terminal in Git Repository',
+    caption: 'Open a New Terminal in the Git Repository',
     execute: async args => {
-      let changeDirectoryCommand =
-        model.pathRepository === null
-          ? ''
-          : 'cd "' + model.pathRepository.split('"').join('\\"') + '"';
-      let gitCommand = (args['cmd'] as string) || '';
-      let linkCommand =
-        changeDirectoryCommand !== '' && gitCommand !== '' ? '&&' : '';
-
       const main = (await commands.execute(
         'terminal:create-new',
         args
       )) as MainAreaWidget<ITerminal.ITerminal>;
 
-      const terminal = main.content;
       try {
-        terminal.session.send({
-          type: 'stdin',
-          content: [changeDirectoryCommand + linkCommand + gitCommand + '\n']
-        });
+        if (model.pathRepository !== null) {
+          const terminal = main.content;
+          terminal.session.send({
+            type: 'stdin',
+            content: [`cd "${model.pathRepository.split('"').join('\\"')}"\n`]
+          });
+        }
 
         return main;
       } catch (e) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -681,17 +681,6 @@ export class GitExtension implements IGitExtension {
     }
   }
 
-  performDiff(filename: string, revisionA: string, revisionB: string) {
-    let extension = PathExt.extname(filename).toLocaleLowerCase();
-    if (this._diffProviders[extension] !== undefined) {
-      this._diffProviders[extension](filename, revisionA, revisionB);
-    } else if (this.commands) {
-      this.commands.execute('git:terminal-cmd', {
-        cmd: 'git diff ' + revisionA + ' ' + revisionB
-      });
-    }
-  }
-
   /**
    * Register a new diff provider for specified file types
    *


### PR DESCRIPTION
Fix #494 

API change

This implies removing `GitExtension.performDiff` method - method unused.