### PR TITLE
fixes display of version in `jupyter serverextension list` ouput

### DIFF
--- a/jupyterlab_git/__init__.py
+++ b/jupyterlab_git/__init__.py
@@ -1,20 +1,20 @@
+"""Initialize the backend server extension
 """
-Initialize the backend server extension
-"""
+# need this in order to show version in `jupyter serverextension list`
+from ._version import __version__
+
 from jupyterlab_git.handlers import setup_handlers
 from jupyterlab_git.git import Git
 
 
 def _jupyter_server_extension_paths():
-    """
-    Declare the Jupyter server extension paths.
+    """Declare the Jupyter server extension paths.
     """
     return [{"module": "jupyterlab_git"}]
 
 
 def load_jupyter_server_extension(nbapp):
-    """
-    Load the Jupyter server extension.
+    """Load the Jupyter server extension.
     """
     git = Git(nbapp.web_app.settings['contents_manager'])
     nbapp.web_app.settings["git"] = git


### PR DESCRIPTION
With this PR, the output of `jupyter serverextension list` will now correctly show the version of `jupyterlab-git`:

```
    jupyterlab_git  enabled
    - Validating...
      jupyterlab_git 0.10.0 OK
```