### PR TITLE
Add remote command

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -25,7 +25,7 @@ async def execute(
     password: "Optional[str]" = None,
 ) -> "Tuple[int, str, str]":
     """Asynchronously execute a command.
-    
+
     Args:
         cmdline (List[str]): Command line to be executed
         cwd (Optional[str]): Current working directory
@@ -102,6 +102,35 @@ async def execute(
     return code, output, error
 
 
+class GitRemote:
+    """Container class for remote git commands"""
+
+    def add(self, top_repo_path, url, name="origin"):
+        """Handle call to `git remote add` command.
+
+        top_repo_path: str
+            Top Git repository path
+        url: str
+            Git remote url
+        name: str
+            Remote name; default "origin"
+        """
+        cmd = ["git", "remote", "add", name, url]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=top_repo_path)
+        my_output, my_error = p.communicate()
+        if p.returncode == 0:
+            return {
+                "code": p.returncode,
+                "command": " ".join(cmd)
+            }
+        else:
+            return {
+                "code": p.returncode,
+                "command": " ".join(cmd),
+                "message": my_error.decode("utf-8").strip()
+            }
+
+
 class Git:
     """
     A single parent class containing all of the individual git methods in it.
@@ -110,6 +139,8 @@ class Git:
     def __init__(self, contents_manager):
         self.contents_manager = contents_manager
         self.root_dir = os.path.expanduser(contents_manager.root_dir)
+
+        self.remote = GitRemote()
 
     async def config(self, top_repo_path, **kwargs):
         """Get or set Git options.

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -15,6 +15,7 @@ ALLOWED_OPTIONS = ['user.name', 'user.email']
 # Regex pattern to capture (key, value) of Git configuration options.
 # See https://git-scm.com/docs/git-config#_syntax for git var syntax
 CONFIG_PATTERN = re.compile(r"(?:^|\n)([\w\-\.]+)\=")
+DEFAULT_REMOTE_NAME = "origin"
 
 
 async def execute(
@@ -102,35 +103,6 @@ async def execute(
     return code, output, error
 
 
-class GitRemote:
-    """Container class for remote git commands"""
-
-    def add(self, top_repo_path, url, name="origin"):
-        """Handle call to `git remote add` command.
-
-        top_repo_path: str
-            Top Git repository path
-        url: str
-            Git remote url
-        name: str
-            Remote name; default "origin"
-        """
-        cmd = ["git", "remote", "add", name, url]
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=top_repo_path)
-        my_output, my_error = p.communicate()
-        if p.returncode == 0:
-            return {
-                "code": p.returncode,
-                "command": " ".join(cmd)
-            }
-        else:
-            return {
-                "code": p.returncode,
-                "command": " ".join(cmd),
-                "message": my_error.decode("utf-8").strip()
-            }
-
-
 class Git:
     """
     A single parent class containing all of the individual git methods in it.
@@ -139,8 +111,6 @@ class Git:
     def __init__(self, contents_manager):
         self.contents_manager = contents_manager
         self.root_dir = os.path.expanduser(contents_manager.root_dir)
-
-        self.remote = GitRemote()
 
     async def config(self, top_repo_path, **kwargs):
         """Get or set Git options.
@@ -996,3 +966,28 @@ class Git:
         else:
             curr_content = await self.show(filename, curr_ref["git"], top_repo_path)
         return {"prev_content": prev_content, "curr_content": curr_content}
+
+    def remote_add(self, top_repo_path, url, name=DEFAULT_REMOTE_NAME):
+        """Handle call to `git remote add` command.
+
+        top_repo_path: str
+            Top Git repository path
+        url: str
+            Git remote url
+        name: str
+            Remote name; default "origin"
+        """
+        cmd = ["git", "remote", "add", name, url]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=top_repo_path)
+        _, my_error = p.communicate()
+        if p.returncode == 0:
+            return {
+                "code": p.returncode,
+                "command": " ".join(cmd)
+            }
+        else:
+            return {
+                "code": p.returncode,
+                "command": " ".join(cmd),
+                "message": my_error.decode("utf-8").strip()
+            }

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -6,11 +6,9 @@ import os
 from pathlib import Path
 
 from notebook.base.handlers import APIHandler
-from notebook.utils import url2path
-from notebook.utils import url_path_join as ujoin
+from notebook.utils import url_path_join as ujoin, url2path
 
-import tornado
-
+from .git import DEFAULT_REMOTE_NAME
 
 class GitHandler(APIHandler):
     """
@@ -256,9 +254,9 @@ class GitRemoteAddHandler(GitHandler):
         """POST request handler to add a remote."""
         data = self.get_json_body()
         top_repo_path = data["top_repo_path"]
-        name = data.get("name", "origin")
+        name = data.get("name", DEFAULT_REMOTE_NAME)
         url = data["url"]
-        output = self.git.remote.add(top_repo_path, url, name)
+        output = self.git.remote_add(top_repo_path, url, name)
         if(output["code"] == 0):
             self.set_status(201)
         else:

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -249,6 +249,23 @@ class GitAddAllUntrackedHandler(GitHandler):
         self.finish(json.dumps(body))
 
 
+class GitRemoteAddHandler(GitHandler):
+    """Handler for 'git remote add <name> <url>'."""
+
+    def post(self):
+        """POST request handler to add a remote."""
+        data = self.get_json_body()
+        top_repo_path = data["top_repo_path"]
+        name = data.get("name", "origin")
+        url = data["url"]
+        output = self.git.remote.add(top_repo_path, url, name)
+        if(output["code"] == 0):
+            self.set_status(201)
+        else:
+            self.set_status(500)
+        self.finish(json.dumps(output))
+
+
 class GitResetHandler(GitHandler):
     """
     Handler for 'git reset <filename>'.
@@ -527,6 +544,7 @@ def setup_handlers(web_app):
         ("/git/log", GitLogHandler),
         ("/git/pull", GitPullHandler),
         ("/git/push", GitPushHandler),
+        ("/git/remote/add", GitRemoteAddHandler),
         ("/git/reset", GitResetHandler),
         ("/git/reset_to_commit", GitResetToCommitHandler),
         ("/git/server_root", GitServerRootHandler),

--- a/jupyterlab_git/tests/test_remote.py
+++ b/jupyterlab_git/tests/test_remote.py
@@ -1,0 +1,121 @@
+import subprocess
+from unittest.mock import Mock, patch
+
+from jupyterlab_git.handlers import GitRemoteAddHandler
+
+from .testutils import assert_http_error, ServerTest
+
+
+class TestAddRemote(ServerTest):
+    @patch("subprocess.Popen")
+    def test_git_add_remote_success_no_name(self, popen):
+        # Given
+        path = "test_path"
+        url = "http://github.com/myid/myrepository.git"
+        process_mock = Mock()
+        attrs = {
+            "communicate": Mock(return_value=(b"", b"",)),
+            "returncode": 0,
+        }
+        process_mock.configure_mock(**attrs)
+        popen.return_value = process_mock
+
+        # When
+        body = {
+            "top_repo_path": path,
+            "url": url,
+        }
+        response = self.tester.post(["remote", "add"], body=body)
+
+        # Then
+        popen.assert_called_once_with(
+            ["git", "remote", "add", "origin", url],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=path,
+        )
+        process_mock.communicate.assert_called_once_with()
+
+        assert response.status_code == 201
+        payload = response.json()
+        assert payload == {
+            "code": 0,
+            "cmd": " ".join(["git", "remote", "add", "origin", url]),
+        }
+
+    @patch("subprocess.Popen")
+    def test_git_add_remote_success(self, popen):
+        # Given
+        path = "test_path"
+        url = "http://github.com/myid/myrepository.git"
+        name = "distant"
+        process_mock = Mock()
+        attrs = {
+            "communicate": Mock(return_value=(b"", b"",)),
+            "returncode": 0,
+        }
+        process_mock.configure_mock(**attrs)
+        popen.return_value = process_mock
+
+        # When
+        body = {
+            "top_repo_path": path,
+            "url": url,
+        }
+        response = self.tester.post(["remote", "add"], body=body)
+
+        # Then
+        popen.assert_called_once_with(
+            ["git", "remote", "add", name, url],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=path,
+        )
+        process_mock.communicate.assert_called_once_with()
+
+        assert response.status_code == 201
+        payload = response.json()
+        assert payload == {
+            "code": 0,
+            "cmd": " ".join(["git", "remote", "add", name, url]),
+        }
+
+    @patch("subprocess.Popen")
+    def test_git_add_remote_failure(self, popen):
+        # Given
+        path = "test_path"
+        url = "http://github.com/myid/myrepository.git"
+        process_mock = Mock()
+        error_msg = "Fake failure"
+        error_code = 128
+        attrs = {
+            "communicate": Mock(return_value=(b"", bytes(error_msg))),
+            "returncode": error_code,
+        }
+        process_mock.configure_mock(**attrs)
+        popen.return_value = process_mock
+
+        # When
+        body = {
+            "top_repo_path": path,
+            "url": url,
+        }
+        response = self.tester.post(["remote", "add"], body=body)
+
+        # Then
+        popen.assert_called_once_with(
+            ["git", "remote", "add", "origin", url],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=path,
+        )
+        process_mock.communicate.assert_called_once_with()
+
+        assert response.status_code == 500
+        payload = response.json()
+        assert payload == {
+            "code": error_code,
+            "cmd": " ".join(["git", "remote", "add", "origin", url]),
+            "message": error_msg,
+        }
+

--- a/src/gitMenuCommands.ts
+++ b/src/gitMenuCommands.ts
@@ -122,12 +122,12 @@ export function addCommands(
         return;
       }
       let url = args['url'] as string;
-      let name = (args['name'] as string) || 'origin';
+      let name = args['name'] as string;
 
       if (!url) {
         const result = await InputDialog.getText({
           title: 'Add a remote repository',
-          placeholder: 'Remote Git URL'
+          placeholder: 'Remote Git repository URL'
         });
 
         if (result.button.accept) {

--- a/src/gitMenuCommands.ts
+++ b/src/gitMenuCommands.ts
@@ -3,7 +3,8 @@ import {
   Dialog,
   InputDialog,
   MainAreaWidget,
-  showDialog
+  showDialog,
+  showErrorMessage
 } from '@jupyterlab/apputils';
 import { ISettingRegistry } from '@jupyterlab/coreutils';
 import { FileBrowser } from '@jupyterlab/filebrowser';
@@ -135,7 +136,12 @@ export function addCommands(
       }
 
       if (url) {
-        await model.addRemote(url, name);
+        try {
+          await model.addRemote(url, name);
+        } catch (error) {
+          console.error(error);
+          showErrorMessage('Error when adding remote repository', error);
+        }
       }
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,11 +140,14 @@ function createGitMenu(
 
   let menu = new Menu({ commands });
   menu.title.label = 'Git';
-  [CommandIDs.gitUI, CommandIDs.gitTerminalCommand, CommandIDs.gitInit].forEach(
-    command => {
-      menu.addItem({ command });
-    }
-  );
+  [
+    CommandIDs.gitUI,
+    CommandIDs.gitTerminalCommand,
+    CommandIDs.gitInit,
+    CommandIDs.gitAddRemote
+  ].forEach(command => {
+    menu.addItem({ command });
+  });
 
   let tutorial = new Menu({ commands });
   tutorial.title.label = ' Tutorial ';

--- a/src/model.ts
+++ b/src/model.ts
@@ -329,6 +329,35 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
+   * Add a remote Git repository to the current repository
+   *
+   * @param url Remote repository URL
+   * @param name Remote name
+   */
+  async addRemote(url: string, name?: string): Promise<void> {
+    await this.ready;
+    const path = this.pathRepository;
+
+    if (path === null) {
+      return Promise.resolve();
+    }
+
+    try {
+      let response = await httpGitRequest('/git/remote/add', 'POST', {
+        top_repo_path: path,
+        url,
+        name
+      });
+      if (response.status !== 200) {
+        const data = await response.text();
+        throw new ServerConnection.ResponseError(response, data);
+      }
+    } catch (err) {
+      throw new ServerConnection.NetworkError(err);
+    }
+  }
+
+  /**
    * Make request for all git info of the repository
    * (This API is also implicitly used to check if the current repo is a Git repo)
    *

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -103,6 +103,14 @@ export interface IGitExtension extends IDisposable {
   toggleMark(fname: string): void;
 
   /**
+   * Add a remote Git repository to the current repository
+   *
+   * @param url Remote repository URL
+   * @param name Remote name
+   */
+  addRemote(url: string, name?: string): Promise<void>;
+
+  /**
    * Make request for all git info of the repository
    * (This API is also implicitly used to check if the current repo is a Git repo)
    *

--- a/tests/commands.spec.tsx
+++ b/tests/commands.spec.tsx
@@ -1,0 +1,135 @@
+import 'jest';
+import * as git from '../src/git';
+import { GitExtension } from '../src/model';
+import { IGitExtension } from '../src/tokens';
+
+import { CommandIDs, addCommands } from '../src/gitMenuCommands';
+import { CommandRegistry } from '@phosphor/commands';
+import { JupyterFrontEnd } from '@jupyterlab/application';
+
+jest.mock('../src/git');
+
+describe('git-commands', () => {
+  const mockGit = git as jest.Mocked<typeof git>;
+  const fakeRoot = '/path/to/server';
+  let commands: CommandRegistry;
+  let model: IGitExtension;
+  let mockResponses: {
+    [url: string]: {
+      body?: (request: Object) => string;
+      status?: number;
+    };
+  };
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+
+    mockResponses = {
+      '/git/branch': {
+        body: request =>
+          JSON.stringify({
+            code: 0,
+            branches: [],
+            current_branch: null
+          })
+      },
+      '/git/show_top_level': {
+        body: request =>
+          JSON.stringify({
+            code: 0,
+            top_repo_path: (request as any)['current_path']
+          })
+      },
+      '/git/server_root': {
+        body: () =>
+          JSON.stringify({
+            server_root: fakeRoot
+          })
+      },
+      '/git/status': {
+        body: () =>
+          JSON.stringify({
+            code: 0,
+            files: []
+          })
+      }
+    };
+
+    mockGit.httpGitRequest.mockImplementation((url, method, request) => {
+      let response: Response;
+      if (url in mockResponses) {
+        response = new Response(
+          mockResponses[url].body
+            ? mockResponses[url].body(request)
+            : undefined,
+          {
+            status: mockResponses[url].status
+          }
+        );
+      } else {
+        response = new Response(
+          `{"message": "No mock implementation for ${url}."}`,
+          { status: 404 }
+        );
+      }
+      return Promise.resolve(response);
+    });
+
+    commands = new CommandRegistry();
+    const app = {
+      commands,
+      shell: null as any
+    };
+    model = new GitExtension(app as any);
+    addCommands(app as JupyterFrontEnd, model, null, null);
+  });
+
+  describe('git:add-remote', () => {
+    it('should admit user and name arguments', async () => {
+      const name = 'ref';
+      const url = 'https://www.mygitserver.com/me/myrepo.git';
+      const path = '/path/to/repo';
+
+      mockResponses = {
+        ...mockResponses,
+        '/git/remote/add': {
+          body: () => `{"code": 0, "command": "git remote add ${name} ${url}"}`
+        }
+      };
+
+      model.pathRepository = path;
+      await model.ready;
+
+      await commands.execute(CommandIDs.gitAddRemote, { url, name });
+
+      expect(mockGit.httpGitRequest).toBeCalledWith('/git/remote/add', 'POST', {
+        top_repo_path: path,
+        url,
+        name
+      });
+    });
+
+    it('has optional argument name', async () => {
+      const name = 'origin';
+      const url = 'https://www.mygitserver.com/me/myrepo.git';
+      const path = '/path/to/repo';
+
+      mockResponses = {
+        ...mockResponses,
+        '/git/remote/add': {
+          body: () => `{"code": 0, "command": "git remote add ${name} ${url}"}`
+        }
+      };
+
+      model.pathRepository = path;
+      await model.ready;
+
+      await commands.execute(CommandIDs.gitAddRemote, { url });
+
+      expect(mockGit.httpGitRequest).toBeCalledWith('/git/remote/add', 'POST', {
+        top_repo_path: path,
+        url
+      });
+    });
+  });
+});


### PR DESCRIPTION
To start a respository with a remote from scratch, the extension is missing a command to add a remote repository. This PR fix that usage.