### PR TITLE
Switch branch header tab order

### DIFF
--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -129,17 +129,6 @@ export class BranchHeader extends React.Component<
       <div className={this.getBranchStyle()}>
         <div style={{ display: 'flex' }}>
           <div
-            className={this.getHistoryHeaderStyle()}
-            onClick={
-              this.props.sideBarExpanded
-                ? null
-                : () => this.props.toggleSidebar()
-            }
-            title={'Show commit history'}
-          >
-            <h3 className={historyLabelStyle}>History</h3>
-          </div>
-          <div
             className={this.getBranchHeaderStyle()}
             onClick={
               this.props.sideBarExpanded
@@ -183,6 +172,17 @@ export class BranchHeader extends React.Component<
                   {this.props.upstreamBranch}
                 </h3>
               )}
+          </div>
+          <div
+            className={this.getHistoryHeaderStyle()}
+            onClick={
+              this.props.sideBarExpanded
+                ? null
+                : () => this.props.toggleSidebar()
+            }
+            title={'Show commit history'}
+          >
+            <h3 className={historyLabelStyle}>History</h3>
           </div>
         </div>
         {!this.props.sideBarExpanded && (


### PR DESCRIPTION
This PR

-   switches the tab order in the Git panel.
-   aligns the UI more closely with GitHub desktop.
-   works for both default and simplified staging.

Proposed change:

<img width="357" alt="Screen Shot 2019-12-26 at 10 44 13 PM" src="https://user-images.githubusercontent.com/2643044/71505291-79c9d380-2831-11ea-91bc-12c88590b12f.png">

GitHub desktop:

<img width="254" alt="Screen Shot 2019-12-26 at 10 44 41 PM" src="https://user-images.githubusercontent.com/2643044/71505306-7fbfb480-2831-11ea-9b51-1e4368726d95.png">
