### PR TITLE
:bug: hack fix for normalizing paths for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "react": "~16.8.4",
     "react-dom": "~16.8.4",
     "react-textarea-autosize": "^7.1.2",
-    "typestyle": "^2.0.1"
+    "typestyle": "^2.0.1",
+    "upath": "^1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",

--- a/src/model.ts
+++ b/src/model.ts
@@ -11,6 +11,7 @@ import { JSONObject } from '@phosphor/coreutils';
 import { ISignal, Signal } from '@phosphor/signaling';
 import { httpGitRequest } from './git';
 import { IGitExtension, Git } from './tokens';
+import { normalize } from 'upath';
 
 // Default refresh interval (in milliseconds) for polling the current Git status (NOTE: this value should be the same value as in the plugin settings schema):
 const DEFAULT_REFRESH_INTERVAL = 3000; // ms
@@ -623,8 +624,10 @@ export class GitExtension implements IGitExtension {
       return null;
     }
 
+    let serverRoot = normalize(this._serverRoot);
+    let pathRepository = normalize(this.pathRepository);
     return PathExt.join(
-      PathExt.relative(this._serverRoot, this.pathRepository),
+      PathExt.relative(serverRoot, pathRepository),
       path || ''
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6178,6 +6178,11 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+upath@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"


### PR DESCRIPTION
this is my attempt to address #471

I added the package upath and it appears to be working for me. Although git filters (such as nbstripout) appear fail with a bad exit code.