### PR TITLE
Add `authenticated` decorator on handler

### DIFF
--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from notebook.utils import url_path_join as ujoin, url2path
 from notebook.base.handlers import APIHandler
+import tornado
 
 
 class GitHandler(APIHandler):
@@ -20,6 +21,7 @@ class GitHandler(APIHandler):
 
 
 class GitCloneHandler(GitHandler):
+    @tornado.web.authenticated
     def post(self):
         """
         Handler for the `git clone`
@@ -50,6 +52,7 @@ class GitAllHistoryHandler(GitHandler):
     Called on refresh of extension's widget
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, calls individual handlers for
@@ -85,6 +88,7 @@ class GitShowTopLevelHandler(GitHandler):
     Displays the git root directory inside a repository.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, displays the git root directory inside a repository.
@@ -101,6 +105,7 @@ class GitShowPrefixHandler(GitHandler):
     with respect to the root directory.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, displays the prefix path of a directory in a repository,
@@ -116,6 +121,7 @@ class GitStatusHandler(GitHandler):
     Handler for 'git status --porcelain', fetches the git status.
     """
 
+    @tornado.web.authenticated
     def get(self):
         """
         GET request handler, shows file status, used in refresh method.
@@ -126,6 +132,7 @@ class GitStatusHandler(GitHandler):
             )
         )
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, fetches the git status.
@@ -141,6 +148,7 @@ class GitLogHandler(GitHandler):
     Fetches Commit SHA, Author Name, Commit Date & Commit Message.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler,
@@ -160,6 +168,7 @@ class GitDetailedLogHandler(GitHandler):
     deletions in that commit.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, fetches file names of committed files, Number of
@@ -177,6 +186,7 @@ class GitDiffHandler(GitHandler):
     Handler for 'git diff --numstat'. Fetches changes between commits & working tree.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, fetches differences between commits & current working
@@ -192,6 +202,7 @@ class GitBranchHandler(GitHandler):
     Handler for 'git branch -a'. Fetches list of all branches in current repository
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, fetches all branches in current repository.
@@ -207,6 +218,7 @@ class GitAddHandler(GitHandler):
     Adds one or all files to the staging area.
     """
 
+    @tornado.web.authenticated
     def get(self):
         """
         GET request handler, adds files to the staging area.
@@ -217,6 +229,7 @@ class GitAddHandler(GitHandler):
             )
         )
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, adds one or all files into the staging area.
@@ -237,6 +250,7 @@ class GitAddAllUnstagedHandler(GitHandler):
     untracked or staged files.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, adds all the changed files.
@@ -250,6 +264,7 @@ class GitAddAllUntrackedHandler(GitHandler):
     untracked files, does not touch unstaged or staged files.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, adds all the untracked files.
@@ -263,6 +278,7 @@ class GitResetHandler(GitHandler):
     Moves one or all files from the staged to the unstaged area.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler,
@@ -284,6 +300,7 @@ class GitDeleteCommitHandler(GitHandler):
     Deletes the specified commit from the repository, leaving history intact.
     """
 
+    @tornado.web.authenticated
     def post(self):
         data = self.get_json_body()
         top_repo_path = data["top_repo_path"]
@@ -298,6 +315,7 @@ class GitResetToCommitHandler(GitHandler):
     Deletes all commits from head to the specified commit, making the specified commit the new head.
     """
 
+    @tornado.web.authenticated
     def post(self):
         data = self.get_json_body()
         top_repo_path = data["top_repo_path"]
@@ -311,6 +329,7 @@ class GitCheckoutHandler(GitHandler):
     Handler for 'git checkout <branchname>'. Changes the current working branch.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, changes between branches.
@@ -336,6 +355,7 @@ class GitCommitHandler(GitHandler):
     Handler for 'git commit -m <message>'. Commits files.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, commits files.
@@ -348,6 +368,7 @@ class GitCommitHandler(GitHandler):
 
 
 class GitUpstreamHandler(GitHandler):
+    @tornado.web.authenticated
     def post(self):
         """
         Handler for the `git rev-parse --abbrev-ref $CURRENT_BRANCH_NAME@{upstream}` on the repo. Used to check if there
@@ -369,6 +390,7 @@ class GitPullHandler(GitHandler):
     Handler for 'git pull'. Pulls files from a remote branch.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, pulls files from a remote branch to your current branch.
@@ -385,6 +407,7 @@ class GitPushHandler(GitHandler):
     Pushes committed files to a remote branch.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler,
@@ -428,6 +451,7 @@ class GitInitHandler(GitHandler):
     Handler for 'git init'. Initializes a repository.
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST request handler, initializes a repository.
@@ -438,6 +462,7 @@ class GitInitHandler(GitHandler):
 
 
 class GitChangedFilesHandler(GitHandler):
+    @tornado.web.authenticated
     def post(self):
         self.finish(json.dumps(self.git.changed_files(**self.get_json_body())))
 
@@ -447,6 +472,7 @@ class GitConfigHandler(GitHandler):
     Handler for 'git config' commands
     """
 
+    @tornado.web.authenticated
     def post(self):
         """
         POST get (if no options are passed) or set configuration options
@@ -469,6 +495,7 @@ class GitDiffContentHandler(GitHandler):
     Returns `prev_content` and `curr_content` with content of given file.
     """
 
+    @tornado.web.authenticated
     def post(self):
         cm = self.contents_manager
         data = self.get_json_body()
@@ -481,6 +508,7 @@ class GitDiffContentHandler(GitHandler):
 
 
 class GitServerRootHandler(GitHandler):
+    @tornado.web.authenticated
     def get(self):
         # Similar to https://github.com/jupyter/nbdime/blob/master/nbdime/webapp/nb_server_extension.py#L90-L91
         root_dir = getattr(self.contents_manager, "root_dir", None)


### PR DESCRIPTION
This fixes the security hole discovered thanks to #526 

When adding the decorator `@tornado.web.authenticated` to the handlers, they returned the following message instead of the valid answer:
```
{"message": "Forbidden", "reason": null}
```