### PR TITLE
Add setting support for canceling a pull if merge conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-git/master?urlpath=lab/tree/examples/demo.ipynb) [![Build Status](https://travis-ci.org/jupyterlab/jupyterlab-git.svg?branch=master)](https://travis-ci.org/jupyterlab/jupyterlab-git) [![Version](https://img.shields.io/npm/v/@jupyterlab/git.svg)](https://www.npmjs.com/package/@jupyterlab/git) [![Version](https://img.shields.io/pypi/v/jupyterlab-git.svg)](https://pypi.org/project/jupyterlab-git/) [![Downloads](https://img.shields.io/npm/dm/@jupyterlab/git.svg)](https://www.npmjs.com/package/@jupyterlab/git) [![Version](https://img.shields.io/conda/vn/conda-forge/jupyterlab-git.svg)](https://anaconda.org/conda-forge/jupyterlab-git) [![Downloads](https://img.shields.io/conda/dn/conda-forge/jupyterlab-git.svg)](https://anaconda.org/conda-forge/jupyterlab-git)
 
-A JupyterLab extension for version control using git
+A JupyterLab extension for version control using Git
 
 ![](http://g.recordit.co/N9Ikzbyk8P.gif)
 
@@ -11,10 +11,11 @@ To see the extension in action, open the example notebook included in the Binder
 ## Prerequisites
 
 - JupyterLab
+- Git (version `>=1.7.0`)
 
 ## Usage
 
-- Open the git extension from the _Git_ tab on the left panel
+- Open the Git extension from the _Git_ tab on the left panel
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To see the extension in action, open the example notebook included in the Binder
 ## Prerequisites
 
 - JupyterLab
-- Git (version `>=1.7.0`)
+- Git (version `>=1.7.4`)
 
 ## Usage
 

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -708,17 +708,17 @@ class Git:
         if auth:
             env["GIT_TERMINAL_PROMPT"] = "1"
             p = GitAuthInputWrapper(
-                command='git pull --no-commit',
+                command="git pull --no-commit",
                 cwd=os.path.join(self.root_dir, curr_fb_path),
                 env=env,
-                username=auth['username'],
-                password=auth['password']
+                username=auth["username"],
+                password=auth["password"]
             )
             output, error = p.communicate()
         else:
             env["GIT_TERMINAL_PROMPT"] = "0"
             p = subprocess.Popen(
-                ['git', 'pull', '--no-commit'],
+                ["git", "pull", "--no-commit"],
                 stdout=PIPE,
                 stderr=PIPE,
                 env=env,
@@ -730,18 +730,22 @@ class Git:
         response = {"code": code}
 
         if code != 0:
-            if cancel_on_conflict and "automatic merge failed; fix conflicts and then commit the result." in output.decode("utf-8").lower():
+            output = output.decode("utf-8").strip()
+            has_conflict = "automatic merge failed; fix conflicts and then commit the result." in output.lower()
+            if cancel_on_conflict and has_conflict:
                 p = subprocess.Popen(
-                    ['git', 'merge', '--abort'],
+                    ["git", "merge", "--abort"],
                     stdout=PIPE,
                     stderr=PIPE,
                     cwd=os.path.join(self.root_dir, curr_fb_path),
                 )
                 _, error = p.communicate()
                 if p.returncode == 0:
-                    response["message"] = 'Unable to pull latest changes as doing so would result in a merge conflict. In order to push your local changes, you may want to consider creating a new branch based on your current work and pushing the new branch. Provided your repository is hosted (e.g., on GitHub), once pushed, you can create a pull request against the original branch on the remote repository and manually resolve the conflicts during pull request review.'
+                    response["message"] = "Unable to pull latest changes as doing so would result in a merge conflict. In order to push your local changes, you may want to consider creating a new branch based on your current work and pushing the new branch. Provided your repository is hosted (e.g., on GitHub), once pushed, you can create a pull request against the original branch on the remote repository and manually resolve the conflicts during pull request review."
                 else:
                     response["message"] = error.decode("utf-8").strip()
+            elif has_conflict:
+                response["message"] = output
             else:
                 response["message"] = error.decode("utf-8").strip()
 
@@ -758,14 +762,14 @@ class Git:
                 command='git push {} {}'.format(remote, branch),
                 cwd=os.path.join(self.root_dir, curr_fb_path),
                 env=env,
-                username=auth['username'],
-                password=auth['password']
+                username=auth["username"],
+                password=auth["password"]
             )
             _, error = p.communicate()
         else:
             env["GIT_TERMINAL_PROMPT"] = "0"
             p = subprocess.Popen(
-                ['git', 'push', remote, branch],
+                ["git", "push", remote, branch],
                 stdout=PIPE,
                 stderr=PIPE,
                 env=env,

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -57,12 +57,12 @@ class GitAuthInputWrapper:
             self.returncode = p.wait()
             p.close()
             
-            return ('', response)
+            return (''.encode('utf-8'), response)
         except pexpect.exceptions.EOF: #In case of pexpect failure
             response = p.before
             self.returncode = p.exitstatus
             p.close() #close process
-            return ('', response)
+            return (''.encode('utf-8'), response)
 
 
 class Git:

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -699,20 +699,20 @@ class Git:
         )
         return my_output
             
-    def pull(self, curr_fb_path, auth=None):
+    def pull(self, curr_fb_path, auth=None, cancel_on_conflict=False):
         """
         Execute git pull --no-commit.  Disables prompts for the password to avoid the terminal hanging while waiting
         for auth.
         """
         env = os.environ.copy()
-        if (auth):
+        if auth:
             env["GIT_TERMINAL_PROMPT"] = "1"
             p = GitAuthInputWrapper(
-                command = 'git pull --no-commit',
-                cwd = os.path.join(self.root_dir, curr_fb_path),
-                env = env,
-                username = auth['username'],
-                password = auth['password']
+                command='git pull --no-commit',
+                cwd=os.path.join(self.root_dir, curr_fb_path),
+                env=env,
+                username=auth['username'],
+                password=auth['password']
             )
             error = p.communicate()
         else:
@@ -721,7 +721,16 @@ class Git:
                 ['git', 'pull', '--no-commit'],
                 stdout=PIPE,
                 stderr=PIPE,
-                env = env,
+                env=env,
+                cwd=os.path.join(self.root_dir, curr_fb_path),
+            )
+            _, error = p.communicate()
+
+        if p.returncode != 0 and cancel_on_conflict:
+            p = subprocess.Popen(
+                ['git', 'reset', '--merge', 'ORIG_HEAD'],
+                stdout=PIPE,
+                stderr=PIPE,
                 cwd=os.path.join(self.root_dir, curr_fb_path),
             )
             _, error = p.communicate()
@@ -741,11 +750,11 @@ class Git:
         if (auth):
             env["GIT_TERMINAL_PROMPT"] = "1"
             p = GitAuthInputWrapper(
-                command = 'git push {} {}'.format(remote, branch),
-                cwd = os.path.join(self.root_dir, curr_fb_path),
-                env = env,
-                username = auth['username'],
-                password = auth['password']
+                command='git push {} {}'.format(remote, branch),
+                cwd=os.path.join(self.root_dir, curr_fb_path),
+                env=env,
+                username=auth['username'],
+                password=auth['password']
             )
             error = p.communicate()
         else:
@@ -754,7 +763,7 @@ class Git:
                 ['git', 'push', remote, branch],
                 stdout=PIPE,
                 stderr=PIPE,
-                env = env,
+                env=env,
                 cwd=os.path.join(self.root_dir, curr_fb_path),
             )
             _, error = p.communicate()

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -374,7 +374,7 @@ class GitPullHandler(GitHandler):
         POST request handler, pulls files from a remote branch to your current branch.
         """
         data = self.get_json_body()
-        response = self.git.pull(data["current_path"], data.get("auth", None))
+        response = self.git.pull(data["current_path"], data.get("auth", None), data.get("cancel_on_conflict", False))
 
         self.finish(json.dumps(response))
 

--- a/jupyterlab_git/tests/test_clone.py
+++ b/jupyterlab_git/tests/test_clone.py
@@ -13,7 +13,7 @@ def test_git_clone_success(mock_subproc_popen):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('output', 'error'.encode('utf-8')),
+        'communicate.return_value': ('output'.encode('utf-8'), 'error'.encode('utf-8')),
         'returncode': 0
     }
     process_mock.configure_mock(**attrs)
@@ -47,7 +47,7 @@ def test_git_clone_failure_from_git(mock_subproc_popen):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('test_output', 'fatal: Not a git repository'.encode('utf-8')),
+        'communicate.return_value': ('test_output'.encode('utf-8'), 'fatal: Not a git repository'.encode('utf-8')),
         'returncode': 128
     }
     process_mock.configure_mock(**attrs)
@@ -75,7 +75,7 @@ def test_git_clone_with_auth_success(mock_GitAuthInputWrapper):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': '',
+        'communicate.return_value': ('output'.encode('utf-8'), ''.encode('utf-8')),
         'returncode': 0
     }
     process_mock.configure_mock(**attrs)
@@ -112,7 +112,7 @@ def test_git_clone_with_auth_wrong_repo_url_failure_from_git(mock_GitAuthInputWr
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': "fatal: repository 'ghjkhjkl' does not exist".encode('utf-8'),
+        'communicate.return_value': ('output'.encode('utf-8'), "fatal: repository 'ghjkhjkl' does not exist".encode('utf-8')),
         'returncode': 128
     }
     process_mock.configure_mock(**attrs)
@@ -149,7 +149,7 @@ def test_git_clone_with_auth_auth_failure_from_git(mock_GitAuthInputWrapper):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': "remote: Invalid username or password.\r\nfatal: Authentication failed for 'ghjkhjkl'".encode('utf-8'),
+        'communicate.return_value': ('output'.encode('utf-8'), "remote: Invalid username or password.\r\nfatal: Authentication failed for 'ghjkhjkl'".encode('utf-8')),
         'returncode': 128
     }
     process_mock.configure_mock(**attrs)

--- a/jupyterlab_git/tests/test_pushpull.py
+++ b/jupyterlab_git/tests/test_pushpull.py
@@ -12,7 +12,7 @@ def test_git_pull_fail(mock_subproc_popen):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('output', 'Authentication failed'.encode('utf-8')),
+        'communicate.return_value': ('output'.encode('utf-8'), 'Authentication failed'.encode('utf-8')),
         'returncode': 1
     }
     process_mock.configure_mock(**attrs)
@@ -40,7 +40,7 @@ def test_git_pull_with_auth_fail(mock_GitAuthInputWrapper):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'".encode('utf-8'),
+        'communicate.return_value': ('output'.encode('utf-8'), "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'".encode('utf-8')),
         'returncode': 1
     }
     process_mock.configure_mock(**attrs)
@@ -73,7 +73,7 @@ def test_git_pull_success(mock_subproc_popen):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('output', ''.encode('utf-8')),
+        'communicate.return_value': ('output'.encode('utf-8'), ''.encode('utf-8')),
         'returncode': 0
     }
     process_mock.configure_mock(**attrs)
@@ -101,7 +101,7 @@ def test_git_pull_with_auth_success(mock_GitAuthInputWrapper):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('output', ''.encode('utf-8')),
+        'communicate.return_value': ('output'.encode('utf-8'), ''.encode('utf-8')),
         'returncode': 0
     }
     process_mock.configure_mock(**attrs)
@@ -133,7 +133,7 @@ def test_git_push_fail(mock_subproc_popen):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('output', 'Authentication failed'.encode('utf-8')),
+        'communicate.return_value': ('output'.encode('utf-8'), 'Authentication failed'.encode('utf-8')),
         'returncode': 1
     }
     process_mock.configure_mock(**attrs)
@@ -161,7 +161,7 @@ def test_git_push_with_auth_fail(mock_GitAuthInputWrapper):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'".encode('utf-8'),
+        'communicate.return_value': ('output'.encode('utf-8'), "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'".encode('utf-8')),
         'returncode': 1
     }
     process_mock.configure_mock(**attrs)
@@ -194,7 +194,7 @@ def test_git_push_success(mock_subproc_popen):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': ('output', 'does not matter'.encode('utf-8')),
+        'communicate.return_value': ('output'.encode('utf-8'), 'does not matter'.encode('utf-8')),
         'returncode': 0
     }
     process_mock.configure_mock(**attrs)
@@ -222,7 +222,7 @@ def test_git_push_with_auth_success(mock_GitAuthInputWrapper):
     # Given
     process_mock = Mock()
     attrs = {
-        'communicate.return_value': 'does not matter'.encode('utf-8'),
+        'communicate.return_value': ('output'.encode('utf-8'), 'does not matter'.encode('utf-8')),
         'returncode': 0
     }
     process_mock.configure_mock(**attrs)

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -23,6 +23,12 @@
       "description": "Number of milliseconds between polling the file system for changes.",
       "default": 3000
     },
+    "cancelPullMergeConflict": {
+      "type": "boolean",
+      "title": "Cancel pull merge conflict",
+      "description": "If true, when fetching and integrating changes from a remote repository, a conflicting merge is canceled and the working tree left untouched.",
+      "default": false
+    },
     "simpleStaging": {
       "type": "boolean",
       "title": "Simple staging flag",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -5,6 +5,12 @@
   "description": "jupyterlab-git settings.",
   "type": "object",
   "properties": {
+    "cancelPullMergeConflict": {
+      "type": "boolean",
+      "title": "Cancel pull merge conflict",
+      "description": "If true, when fetching and integrating changes from a remote repository, a conflicting merge is canceled and the working tree left untouched.",
+      "default": false
+    },
     "disableBranchWithChanges": {
       "type": "boolean",
       "title": "Disable branch with changes",
@@ -22,12 +28,6 @@
       "title": "Refresh interval",
       "description": "Number of milliseconds between polling the file system for changes.",
       "default": 3000
-    },
-    "cancelPullMergeConflict": {
-      "type": "boolean",
-      "title": "Cancel pull merge conflict",
-      "description": "If true, when fetching and integrating changes from a remote repository, a conflicting merge is canceled and the working tree left untouched.",
-      "default": false
     },
     "simpleStaging": {
       "type": "boolean",

--- a/src/model.ts
+++ b/src/model.ts
@@ -23,6 +23,7 @@ export class GitExtension implements IGitExtension {
   ) {
     const model = this;
     this._app = app;
+    this._settings = settings || null;
 
     // Load the server root path
     this._getServerRoot()
@@ -712,7 +713,10 @@ export class GitExtension implements IGitExtension {
     try {
       let obj: Git.IPushPull = {
         current_path: path,
-        auth
+        auth,
+        cancel_on_conflict: this._settings
+          ? (this._settings.composite['resetPullMergeConflict'] as boolean)
+          : false
       };
 
       let response = await httpGitRequest('/git/pull', 'POST', obj);
@@ -1004,6 +1008,7 @@ export class GitExtension implements IGitExtension {
   private _readyPromise: Promise<void> = Promise.resolve();
   private _pendingReadyPromise = 0;
   private _poll: Poll;
+  private _settings: ISettingRegistry.ISettings | null;
   private _headChanged = new Signal<IGitExtension, void>(this);
   private _markChanged = new Signal<IGitExtension, void>(this);
   private _repositoryChanged = new Signal<

--- a/src/model.ts
+++ b/src/model.ts
@@ -715,7 +715,7 @@ export class GitExtension implements IGitExtension {
         current_path: path,
         auth,
         cancel_on_conflict: this._settings
-          ? (this._settings.composite['resetPullMergeConflict'] as boolean)
+          ? (this._settings.composite['cancelPullMergeConflict'] as boolean)
           : false
       };
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -445,6 +445,7 @@ export namespace Git {
   export interface IPushPull {
     current_path: string;
     auth?: IAuth;
+    cancel_on_conflict?: boolean;
   }
 
   /**


### PR DESCRIPTION
## Background

Currently, the extension does not provide a means for easily resolving merge conflicts. When the extension pulls changes from a remote repository branch, if a conflict exists, the extension displays an error dialog (without an actual error message!), claiming that the `pull` failed; however, changes are still merged. A user must manually go through the changed files and resolve conflicts by modifying the source. Especially, for those unfamiliar with Git, this is error prone and a potentially frustrating experience.

## Overview

This PR

-   adds a new setting: `cancelPullMergeConflict`. This setting is geared toward users who have limited Git experience, thus building on the "simple Git" concept. The main purpose of this setting is to guard against dirtying a user's working tree when conflicts with a user's current tree exist in a remote repository. As documented in the error message when this setting is `true`, for inexperienced Git users, perhaps a better route rather than attempting to resolve conflicts by digging through files in JLab is to create a new branch based on the current `HEAD`, push the new branch, and then create a PR against the old branch which offers the opportunity for review and out-of-extension merge conflict resolution (e.g., via GitHub's UI).
-   when `cancelPullMergeConflict` is `false` (i.e., the current default behavior), fixes the error dialog message, indicating to the user that merge conflicts exist. Otherwise, a user may be caught unaware and wondering why, if a `pull` "failed", changes were introduced and reflected in the "staging" area.
-    updates and adds corresponding tests.

## Screenshots

-   Resolved error dialog messaging:

<img width="1437" alt="Screen Shot 2020-02-25 at 9 46 30 PM" src="https://user-images.githubusercontent.com/2643044/75318035-2e767600-581e-11ea-8d53-3e5e63787684.png">

-   Error dialog upon canceling a `pull`:

<img width="1437" alt="Screen Shot 2020-02-25 at 9 02 10 PM" src="https://user-images.githubusercontent.com/2643044/75318083-4817bd80-581e-11ea-838f-f9cc32d2ac99.png">

