### PR TITLE
Allow filenames with non-ascii characters

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -264,7 +264,6 @@ class Git:
                 # if file was renamed, next line contains original path
                 "from": next(line_iterable) if line[0]=='R' else line[3:]
             })       
-
         return {"code": code, "files": result}
 
     async def log(self, current_path, history_count=10):

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -200,7 +200,7 @@ class Git:
                 response["command"] = " ".join(cmd)
                 response["message"] = error
             else:
-                response["files"] = output.strip("\x00").split("\x00")
+                response["files"] = self.strip_and_split(output)
 
         return response
 
@@ -256,7 +256,7 @@ class Git:
             }
 
         result = []
-        line_iterable = iter(my_output.strip("\x00").split('\x00'))
+        line_iterable = iter(self.strip_and_split(my_output))
         result = []
         for line in line_iterable:
             x = line[0]
@@ -388,7 +388,7 @@ class Git:
             return {"code": code, "command": " ".join(cmd), "message": my_error}
 
         result = []
-        line_array = my_output.strip('\x00').split('\x00')
+        line_array = strip_and_split(my_output)
         for line in line_array:
             linesplit = line.split()
             result.append(

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -336,7 +336,7 @@ class Git:
                 # we need next two lines of output
                 from_path = next(line_iterable)
                 to_path = next(line_iterable)
-                modified_file_name = from_path + " ⮕ " + to_path
+                modified_file_name = from_path + " => " + to_path
                 modified_file_path = to_path
             else:
                 modified_file_name = file.split("/")[-1]

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -258,12 +258,13 @@ class Git:
         line_iterable = iter(strip_and_split(my_output))
         for line in line_iterable:
             from_path = line[3:]
-            if line[0]=='R':
-                #If file was renamed then we need both this line
-                #and the next line, then we want to move onto the subsequent
-                #line. We can accomplish this by calling next on the iterable
-                from_path = next(line_iterable)
-            result.append({"x": line[0], "y": line[1], "to": line[3:], "from": from_path})
+            result.append({
+                "x": line[0],
+                "y": line[1],
+                "to": line[3:],
+                # if file was renamed, next line contains original path
+                "from": next(line_iterable) if line[0]=='R' else line[3:]
+            })       
 
         return {"code": code, "files": result}
 

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 from urllib.parse import unquote
+from codecs import decode, escape_decode
 
 import pexpect
 import tornado
@@ -262,6 +263,8 @@ class Git:
                 to1 = to1[1:]
             if to1.endswith('"'):
                 to1 = to1[:-1]
+            to1 = decode(escape_decode(to1)[0],'utf-8')
+            from_path = decode(escape_decode(from_path)[0],'utf-8')
             result.append({"x": line[0], "y": line[1], "to": to1, "from": from_path})
         return {"code": code, "files": result}
 

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -257,7 +257,6 @@ class Git:
         result = []
         line_iterable = iter(strip_and_split(my_output))
         for line in line_iterable:
-            from_path = line[3:]
             result.append({
                 "x": line[0],
                 "y": line[1],

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -110,6 +110,13 @@ class Git:
     def __init__(self, contents_manager):
         self.contents_manager = contents_manager
         self.root_dir = os.path.expanduser(contents_manager.root_dir)
+        
+    def strip_and_split(self, s):
+        """strip trailing \x00 and split on \x00
+
+        Useful for parsing output of git commands with -z flag.
+        """
+        return s.strip("\x00").split("\x00")
 
     async def config(self, top_repo_path, **kwargs):
         """Get or set Git options.

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -332,8 +332,7 @@ class Git:
             insertions, deletions, file = line.split('\t')
 
             if file == '':
-                # file was renamed or moved
-                # we need next two lines of output
+                # file was renamed or moved, we need next two lines of output
                 from_path = next(line_iterable)
                 to_path = next(line_iterable)
                 modified_file_name = from_path + " => " + to_path

--- a/jupyterlab_git/tests/test_detailed_log.py
+++ b/jupyterlab_git/tests/test_detailed_log.py
@@ -71,7 +71,7 @@ async def test_detailed_log():
                 },
                 {
                     "modified_file_path": "folder2/file with spaces.py",
-                    "modified_file_name": "folder1/file with spaces and λ.py ⮕ folder2/file with spaces.py",
+                    "modified_file_name": "folder1/file with spaces and λ.py => folder2/file with spaces.py",
                     "insertion": "0",
                     "deletion": "0",
                 },

--- a/jupyterlab_git/tests/test_diff.py
+++ b/jupyterlab_git/tests/test_diff.py
@@ -24,7 +24,7 @@ async def test_changed_files_single_commit():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.return_value = tornado.gen.maybe_future(
-            (0, "file1.ipynb\nfile2.py", "")
+            (0, "file1.ipynb\x00file2.py", "")
         )
 
         # When
@@ -39,6 +39,7 @@ async def test_changed_files_single_commit():
                 "diff",
                 "64950a634cd11d1a01ddfedaeffed67b531cb11e^!",
                 "--name-only",
+                "-z",
             ],
             cwd="/bin",
         )
@@ -50,7 +51,7 @@ async def test_changed_files_working_tree():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.return_value = tornado.gen.maybe_future(
-            (0, "file1.ipynb\nfile2.py", "")
+            (0, "file1.ipynb\x00file2.py", "")
         )
 
         # When
@@ -60,7 +61,7 @@ async def test_changed_files_working_tree():
 
         # Then
         mock_execute.assert_called_once_with(
-            ["git", "diff", "HEAD", "--name-only"], cwd="/bin"
+            ["git", "diff", "HEAD", "--name-only", "-z"], cwd="/bin"
         )
         assert {"code": 0, "files": ["file1.ipynb", "file2.py"]} == actual_response
 
@@ -70,7 +71,7 @@ async def test_changed_files_index():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.return_value = tornado.gen.maybe_future(
-            (0, "file1.ipynb\nfile2.py", "")
+            (0, "file1.ipynb\x00file2.py", "")
         )
 
         # When
@@ -80,7 +81,7 @@ async def test_changed_files_index():
 
         # Then
         mock_execute.assert_called_once_with(
-            ["git", "diff", "--staged", "HEAD", "--name-only"], cwd="/bin"
+            ["git", "diff", "--staged", "HEAD", "--name-only", "-z"], cwd="/bin"
         )
         assert {"code": 0, "files": ["file1.ipynb", "file2.py"]} == actual_response
 
@@ -90,7 +91,7 @@ async def test_changed_files_two_commits():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.return_value = tornado.gen.maybe_future(
-            (0, "file1.ipynb\nfile2.py", "")
+            (0, "file1.ipynb\x00file2.py", "")
         )
 
         # When
@@ -100,7 +101,7 @@ async def test_changed_files_two_commits():
 
         # Then
         mock_execute.assert_called_once_with(
-            ["git", "diff", "HEAD", "origin/HEAD", "--name-only"], cwd="/bin"
+            ["git", "diff", "HEAD", "origin/HEAD", "--name-only", "-z"], cwd="/bin"
         )
         assert {"code": 0, "files": ["file1.ipynb", "file2.py"]} == actual_response
 
@@ -118,6 +119,6 @@ async def test_changed_files_git_diff_error():
 
         # Then
         mock_execute.assert_called_once_with(
-            ["git", "diff", "HEAD", "origin/HEAD", "--name-only"], cwd="/bin"
+            ["git", "diff", "HEAD", "origin/HEAD", "--name-only", "-z"], cwd="/bin"
         )
         assert {"code": 128, "message": "error message"} == actual_response

--- a/jupyterlab_git/tests/test_status.py
+++ b/jupyterlab_git/tests/test_status.py
@@ -1,0 +1,46 @@
+# python lib
+import os
+from unittest.mock import Mock, call, patch
+
+import pytest
+import tornado
+
+# local lib
+from jupyterlab_git.git import Git
+
+from .testutils import FakeContentManager
+
+@pytest.mark.asyncio
+async def test_status():
+    with patch("jupyterlab_git.git.execute") as mock_execute:
+        # Given
+        process_output = (
+        "A  notebook with spaces.ipynb",
+        "M  notebook with λ.ipynb",
+        "R  renamed_to_θ.py",
+        "originally_named_π.py",
+        "?? untracked.ipynb",
+        )
+
+        expected_resonse = [
+            {"x": "A", "y": " ", "to": "notebook with spaces.ipynb", "from": "notebook with spaces.ipynb"},
+            {"x": "M", "y": " ", "to": "notebook with λ.ipynb", "from": "notebook with λ.ipynb"},
+            {"x": "R", "y": " ", "to": "renamed_to_θ.py", "from": "originally_named_π.py"},
+            {"x": "?", "y": "?", "to": "untracked.ipynb", "from": "untracked.ipynb"},
+        ]
+        mock_execute.return_value = tornado.gen.maybe_future(
+            (0, "\x00".join(process_output), "")
+
+        )
+
+        # When
+        actual_response = await Git(FakeContentManager("/bin")).status(
+            current_path="test_curr_path"
+        )
+
+        # Then
+        mock_execute.assert_called_once_with(
+            ["git", "status", "--porcelain" , "-u", "-z"], cwd="/bin/test_curr_path"
+        )
+
+        assert {"code": 0, "files": expected_resonse} == actual_response


### PR DESCRIPTION
This encodes the filenames from `git status` to utf-8. With this change the filenames are properly displayed in the UI and git commands such as add, and push still function as expected as git can accept filenames in utf-8 encoding because "Git is to some extent character encoding agnostic." see: https://git-scm.com/docs/git-commit/2.13.4#_discussion

Fixes https://github.com/jupyterlab/jupyterlab-git/issues/543 and https://github.com/jupyterlab/jupyterlab-git/pull/545
<details><summary>gif of this working</summary>


![working](https://user-images.githubusercontent.com/10111092/75832466-400ecf00-5d84-11ea-9919-5e9e061e9109.gif)
</details>
