### PR TITLE
Check if repository dir doesn't already exists when cloning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,10 @@ node_modules/
 #editors
 .vscode/
 
+# PyCharm
+.idea/
+*.iml
+
 package-lock.json
 MANIFEST
 jupyterlab_git/labextension/*.tgz

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -170,6 +170,13 @@ class Git:
         :param auth: OPTIONAL dictionary with 'username' and 'password' fields
         :return: response with status code and error message.
         """
+
+        # Validate folder don't already exists
+        dir_name = self._get_git_dir_name(unquote(repo_url))
+        full_dir_name = os.path.join(self.root_dir, current_path, dir_name)
+        if os.path.exists(full_dir_name):
+            raise HTTPError(500, 'Directory {} already exists.'.format(dir_name))
+
         env = os.environ.copy()
         if (auth):
             env["GIT_TERMINAL_PROMPT"] = "1"
@@ -949,3 +956,10 @@ class Git:
         else:
             curr_content = self.show(filename, curr_ref["git"], top_repo_path)
         return {"prev_content": prev_content, "curr_content": curr_content}
+
+    def _get_git_dir_name(self, repo_url):
+        # Get the folder name from the repo_url
+        dir_with_extension = repo_url.split('/')[-1]
+        # remove possible `.git` extension from repo_url
+        dir_name = dir_with_extension.split('.')[0]
+        return dir_name


### PR DESCRIPTION
When trying to clone a repository, if the repository
directory already exists the operation was causing
JupyterLab to hang. With these changes, an error
message is sent if the directory already exists.