### PR TITLE
add @web.authenticated to all handlers

### DIFF
--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -4,6 +4,7 @@ Module with all the individual handlers, which execute git commands and return t
 import json
 import os
 from pathlib import Path
+from tornado import web
 
 from notebook.base.handlers import APIHandler
 from notebook.utils import url_path_join as ujoin, url2path
@@ -21,6 +22,7 @@ class GitHandler(APIHandler):
 
 
 class GitCloneHandler(GitHandler):
+    @web.authenticated
     async def post(self):
         """
         Handler for the `git clone`
@@ -51,6 +53,7 @@ class GitAllHistoryHandler(GitHandler):
     Called on refresh of extension's widget
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, calls individual handlers for
@@ -86,6 +89,7 @@ class GitShowTopLevelHandler(GitHandler):
     Displays the git root directory inside a repository.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, displays the git root directory inside a repository.
@@ -102,6 +106,7 @@ class GitShowPrefixHandler(GitHandler):
     with respect to the root directory.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, displays the prefix path of a directory in a repository,
@@ -117,6 +122,7 @@ class GitStatusHandler(GitHandler):
     Handler for 'git status --porcelain', fetches the git status.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, fetches the git status.
@@ -132,6 +138,7 @@ class GitLogHandler(GitHandler):
     Fetches Commit SHA, Author Name, Commit Date & Commit Message.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler,
@@ -151,6 +158,7 @@ class GitDetailedLogHandler(GitHandler):
     deletions in that commit.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, fetches file names of committed files, Number of
@@ -168,6 +176,7 @@ class GitDiffHandler(GitHandler):
     Handler for 'git diff --numstat'. Fetches changes between commits & working tree.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, fetches differences between commits & current working
@@ -183,6 +192,7 @@ class GitBranchHandler(GitHandler):
     Handler for 'git branch -a'. Fetches list of all branches in current repository
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, fetches all branches in current repository.
@@ -198,6 +208,7 @@ class GitAddHandler(GitHandler):
     Adds one or all files to the staging area.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, adds one or all files into the staging area.
@@ -221,6 +232,7 @@ class GitAddAllUnstagedHandler(GitHandler):
     untracked or staged files.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, adds all the changed files.
@@ -237,6 +249,7 @@ class GitAddAllUntrackedHandler(GitHandler):
     untracked files, does not touch unstaged or staged files.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, adds all the untracked files.
@@ -270,6 +283,7 @@ class GitResetHandler(GitHandler):
     Moves one or all files from the staged to the unstaged area.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler,
@@ -294,6 +308,7 @@ class GitDeleteCommitHandler(GitHandler):
     Deletes the specified commit from the repository, leaving history intact.
     """
 
+    @web.authenticated
     async def post(self):
         data = self.get_json_body()
         top_repo_path = data["top_repo_path"]
@@ -311,6 +326,7 @@ class GitResetToCommitHandler(GitHandler):
     Deletes all commits from head to the specified commit, making the specified commit the new head.
     """
 
+    @web.authenticated
     async def post(self):
         data = self.get_json_body()
         top_repo_path = data["top_repo_path"]
@@ -327,6 +343,7 @@ class GitCheckoutHandler(GitHandler):
     Handler for 'git checkout <branchname>'. Changes the current working branch.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, changes between branches.
@@ -355,6 +372,7 @@ class GitCommitHandler(GitHandler):
     Handler for 'git commit -m <message>'. Commits files.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, commits files.
@@ -370,6 +388,7 @@ class GitCommitHandler(GitHandler):
 
 
 class GitUpstreamHandler(GitHandler):
+    @web.authenticated
     async def post(self):
         """
         Handler for the `git rev-parse --abbrev-ref $CURRENT_BRANCH_NAME@{upstream}` on the repo. Used to check if there
@@ -391,6 +410,7 @@ class GitPullHandler(GitHandler):
     Handler for 'git pull'. Pulls files from a remote branch.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, pulls files from a remote branch to your current branch.
@@ -407,6 +427,7 @@ class GitPushHandler(GitHandler):
     Pushes committed files to a remote branch.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler,
@@ -450,6 +471,7 @@ class GitInitHandler(GitHandler):
     Handler for 'git init'. Initializes a repository.
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST request handler, initializes a repository.
@@ -464,6 +486,7 @@ class GitInitHandler(GitHandler):
 
 
 class GitChangedFilesHandler(GitHandler):
+    @web.authenticated
     async def post(self):
         body = await self.git.changed_files(**self.get_json_body())
         self.finish(json.dumps(body))
@@ -474,6 +497,7 @@ class GitConfigHandler(GitHandler):
     Handler for 'git config' commands
     """
 
+    @web.authenticated
     async def post(self):
         """
         POST get (if no options are passed) or set configuration options
@@ -496,6 +520,7 @@ class GitDiffContentHandler(GitHandler):
     Returns `prev_content` and `curr_content` with content of given file.
     """
 
+    @web.authenticated
     async def post(self):
         cm = self.contents_manager
         data = self.get_json_body()
@@ -510,7 +535,8 @@ class GitDiffContentHandler(GitHandler):
 
 
 class GitServerRootHandler(GitHandler):
-    def get(self):
+    @web.authenticated
+    async def get(self):
         # Similar to https://github.com/jupyter/nbdime/blob/master/nbdime/webapp/nb_server_extension.py#L90-L91
         root_dir = getattr(self.contents_manager, "root_dir", None)
         server_root = None if root_dir is None else Path(root_dir).as_posix()


### PR DESCRIPTION
fix #526, supercede #527

This is a replacement for #527, where @fcollonval said:

> This fixes the security hole discovered thanks to #526
> 
> When adding the decorator `@tornado.web.authenticated` to the handlers, they returned the following message instead of the valid answer:
> 
> ```
> {"message": "Forbidden", "reason": null}
> ```

