### PR TITLE
Pin nbdime release compatible with JLab 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup_args = dict(
     ],
     install_requires = [
         'notebook',
-        'nbdime >= 1.1.0',
+        'nbdime >= 1.1.0, < 2.0.0',
         'pexpect'
     ],
     extras_require = {


### PR DESCRIPTION
The latest nbdime release is not compatible with JupyterLab 1.x, this PR pin to a nbdime release that is compatible with JupyterLab 1.x