### PR TITLE
Fix add_all_untracked and add_all_unstaged

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -592,7 +592,7 @@ class Git:
 
         if code != 0:
             return {"code": code, "command": " ".join(cmd), "message": error}
-        return {"result": code}
+        return {"code": code}
 
     async def add_all_untracked(self, top_repo_path):
         """

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -596,14 +596,18 @@ class Git:
 
     async def add_all_untracked(self, top_repo_path):
         """
-        Execute git add all untracked command & return the result.
+        Find all untracked files, execute git add & return the result.
         """
-        cmd = ["echo", "a\n*\nq\n", "|", "git", "add", "-i"]
-        code, _, error = await execute(cmd, cwd=top_repo_path)
+        status = await self.status(top_repo_path)
+        if status["code"] != 0:
+            return status
 
-        if code != 0:
-            return {"code": code, "command": " ".join(cmd), "message": error}
-        return {"code": code}
+        unstaged = []
+        for f in status["files"]:
+            if f["x"]=="?" and f["y"]=="?":
+                unstaged.append(f["from"].strip('"'))
+
+        return await self.add(unstaged, top_repo_path)
 
     async def reset(self, filename, top_repo_path):
         """

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -25,7 +25,7 @@ async def execute(
     password: "Optional[str]" = None,
 ) -> "Tuple[int, str, str]":
     """Asynchronously execute a command.
-    
+
     Args:
         cmdline (List[str]): Command line to be executed
         cwd (Optional[str]): Current working directory
@@ -113,7 +113,7 @@ class Git:
 
     async def config(self, top_repo_path, **kwargs):
         """Get or set Git options.
-        
+
         If no kwargs, all options are returned. Otherwise kwargs are set.
         """
         response = {"code": 1}
@@ -154,12 +154,12 @@ class Git:
         There are two reserved "refs" for the base
             1. WORKING : Represents the Git working tree
             2. INDEX: Represents the Git staging area / index
-        
+
         Keyword Arguments:
             single_commit {string} -- The single commit ref
             base {string} -- the base Git ref
             remote {string} -- the remote Git ref
-        
+
         Returns:
             dict -- the response of format {
                 "code": int, # Command status code
@@ -602,12 +602,12 @@ class Git:
         if status["code"] != 0:
             return status
 
-        unstaged = []
+        untracked = []
         for f in status["files"]:
             if f["x"]=="?" and f["y"]=="?":
-                unstaged.append(f["from"].strip('"'))
+                untracked.append(f["from"].strip('"'))
 
-        return await self.add(unstaged, top_repo_path)
+        return await self.add(untracked, top_repo_path)
 
     async def reset(self, filename, top_repo_path):
         """

--- a/src/model.ts
+++ b/src/model.ts
@@ -258,6 +258,8 @@ export class GitExtension implements IGitExtension {
         const data = await response.json();
         throw new ServerConnection.ResponseError(response, data.message);
       }
+
+      this.refreshStatus();
       return response.json();
     } catch (err) {
       throw new ServerConnection.NetworkError(err);
@@ -291,6 +293,7 @@ export class GitExtension implements IGitExtension {
         const data = await response.json();
         throw new ServerConnection.ResponseError(response, data.message);
       }
+
       this.refreshStatus();
       return response.json();
     } catch (err) {


### PR DESCRIPTION
Fixes: https://github.com/jupyterlab/jupyterlab-git/issues/552

These buttons:
![image](https://user-images.githubusercontent.com/10111092/76651277-8c9f9a80-653a-11ea-9592-f31df1bf6a42.png)
currently fail to add any files, and `add_all_untracked` doesn't produce and error message because of how it fails.

### Changes:  
Change the key in the dictionary returned by `add_all_unstaged` and make `add_all_untracked` no longer require an interactive bash shell that doesn't work with current `execute` function.