### PR TITLE
Display message when server extension unavailable

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -1023,7 +1023,9 @@ export class GitExtension implements IGitExtension {
       if (response.status === 404) {
         throw new ServerConnection.ResponseError(
           response,
-          'Required Git serverextension not available.'
+          'Git server extension is unavailable. Please ensure you have installed the ' +
+            'JupyterLab Git server extension by running: pip install --upgrade jupyterlab-git. ' +
+            'To confirm that the server extension is installed, run: jupyter serverextension list.'
         );
       }
       const data = await response.json();


### PR DESCRIPTION
When, for some reason, the jupyterlab_git jupyter server_extension
is not installed or available the user experience was just receiving a
json response error message. 

This pr extends the code around the first invocation to the backend
api and add better error handling around 404 errors to provide a better
user experience. 