### PR TITLE
Style improvement and fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,20 @@ script:
   - pip install jupyterlab_git[test] --pre --no-index --find-links=dist --no-deps --no-cache-dir -v
   # Install the extension dependencies based on the current setup.py
   - pip install jupyterlab_git[test]
+  # Log the current state of jupyterlab's extensions
   - jupyter labextension list
-  - jupyter lab build
-  - pytest jupyterlab_git -r ap
-  - jlpm run test
-  - python -m jupyterlab.browser_check
+
+  # Do a tslint check
   - jlpm run lint
+
+  # Rebuild jupyterlab to include our extension
+  - jupyter lab build
+
+  # Run the Python tests
+  - pytest jupyterlab_git -r ap
+  # Run the TS/JS tests
+  - jlpm run test
+  # Run the standard jupyterlab browser integration test
+  - python -m jupyterlab.browser_check
+  # Run our extension-specific browser integration test
   - python tests/test-browser/run_browser_test.py

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -184,13 +184,13 @@ export class SinglePastCommitInfo extends React.Component<
             Changed
             <ActionButton
               className={actionButtonClass}
-              iconName="git-rewind"
+              iconName="git-discard"
               title="Revert changes introduced by this commit"
               onClick={this._onRevertClick}
             />
             <ActionButton
               className={actionButtonClass}
-              iconName="git-discard"
+              iconName="git-rewind"
               title="Discard changes introduced *after* this commit (hard reset)"
               onClick={this._onResetClick}
             />

--- a/src/style/ActionButtonStyle.ts
+++ b/src/style/ActionButtonStyle.ts
@@ -12,6 +12,11 @@ export const actionButtonStyle = style({
   cursor: 'pointer',
 
   $nest: {
+    '&:active': {
+      transform: 'scale(1.272019649)',
+      overflow: 'hidden'
+    },
+
     '&:disabled': {
       cursor: 'default'
     }

--- a/src/style/SinglePastCommitInfo.ts
+++ b/src/style/SinglePastCommitInfo.ts
@@ -26,8 +26,7 @@ export const commitOverviewNumbersClass = style({
 
 export const commitDetailClass = style({
   flex: '1 1 auto',
-  margin: '0',
-  overflow: 'auto'
+  margin: '0'
 });
 
 export const commitDetailHeaderClass = style({


### PR DESCRIPTION
In the PR https://github.com/jupyterlab/jupyterlab-git/pull/521/files#diff-2161a1eeaacb5d5f156905ee326dd170 I unfortunately invert the icon for reverting to and discarding an past commit. This fixes it.

Moreover I added an effect (scale up) on `ActionButton` to provide a visual feedback to the user when it click on it.

![preview](https://user-images.githubusercontent.com/8435071/77516265-5fc47f00-6e7a-11ea-9713-7ab556b21845.gif)
