### PR TITLE
Allow binary files in detailed log + update tests

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -330,6 +330,8 @@ class Git:
         line_iterable = iter(strip_and_split(my_output)[1:])
         for line in line_iterable:
             insertions, deletions, file = line.split('\t')
+            insertions = insertions.replace('-', '0')
+            deletions = deletions.replace('-', '0')
 
             if file == '':
                 # file was renamed or moved, we need next two lines of output

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -256,7 +256,7 @@ class Git:
             }
 
         result = []
-        line_iterable = line_iterable = (line for line in strip_and_split(my_output) if line)
+        line_iterable = (line for line in strip_and_split(my_output) if line)
         for line in line_iterable:
             result.append({
                 "x": line[0],

--- a/jupyterlab_git/tests/test_detailed_log.py
+++ b/jupyterlab_git/tests/test_detailed_log.py
@@ -24,7 +24,8 @@ async def test_detailed_log():
             "14\t1\tpath/Notebook with λ.ipynb",
             "0\t0\t",
             "folder1/file with spaces and λ.py",
-            "folder2/file with spaces.py"
+            "folder2/file with spaces.py",
+            "-\t-\tbinary_file.png",
         ]
 
 
@@ -34,8 +35,8 @@ async def test_detailed_log():
 
         expected_response = {
             "code": 0,
-            "modified_file_note": "6 files changed, 60 insertions(+), 19 deletions(-)",
-            "modified_files_count": "6",
+            "modified_file_note": "7 files changed, 60 insertions(+), 19 deletions(-)",
+            "modified_files_count": "7",
             "number_of_insertions": "60",
             "number_of_deletions": "19",
             "modified_files": [
@@ -72,6 +73,12 @@ async def test_detailed_log():
                 {
                     "modified_file_path": "folder2/file with spaces.py",
                     "modified_file_name": "folder1/file with spaces and λ.py => folder2/file with spaces.py",
+                    "insertion": "0",
+                    "deletion": "0",
+                },
+                {
+                    "modified_file_path": "binary_file.png",
+                    "modified_file_name": "binary_file.png",
                     "insertion": "0",
                     "deletion": "0",
                 },

--- a/jupyterlab_git/tests/test_detailed_log.py
+++ b/jupyterlab_git/tests/test_detailed_log.py
@@ -30,7 +30,7 @@ async def test_detailed_log():
 
 
         mock_execute._mock_return_value = tornado.gen.maybe_future(
-            (0, "\x00".join(process_output), "")
+            (0, "\x00".join(process_output)+"\x00", "")
         )
 
         expected_response = {

--- a/jupyterlab_git/tests/test_diff.py
+++ b/jupyterlab_git/tests/test_diff.py
@@ -24,7 +24,7 @@ async def test_changed_files_single_commit():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.return_value = tornado.gen.maybe_future(
-            (0, "file1.ipynb\x00file2.py", "")
+            (0, "file1.ipynb\x00file2.py\x00", "")
         )
 
         # When

--- a/jupyterlab_git/tests/test_status.py
+++ b/jupyterlab_git/tests/test_status.py
@@ -59,7 +59,7 @@ async def test_status(output, expected):
         root = "/bin"
         repository = "test_curr_path"
         mock_execute.return_value = tornado.gen.maybe_future(
-            (0, "\x00".join(output), "")
+            (0, "\x00".join(output)+"\x00", "")
         )
 
         # When


### PR DESCRIPTION
This should fix: https://github.com/jupyterlab/jupyterlab-git/issues/578 as the only non-numeric characters expected should be hyphens (https://git-scm.com/docs/git-log#Documentation/git-log.txt---numstat)

> Similar to --stat, but shows number of added and deleted lines in decimal notation and pathname without abbreviation, to make it more machine friendly. For binary files, outputs two - instead of saying 0 0.

I also added trailing `\x00` to input for tests to accurately reflect what  `git ___ -z` outputs, as well as added a binary file test case to detailed log.

Finally I cleaned up the double definition of `line_iterable` in status