### PR TITLE
Fix staging diff

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -1043,7 +1043,6 @@ class Git:
             command = ["git", "diff", "--numstat", "--cached", "4b825dc642cb6eb9a060e54bf8d69288fbee4904", "--", filename]
         else:
             command = ["git", "diff", "--numstat", "4b825dc642cb6eb9a060e54bf8d69288fbee4904", ref, "--", filename]  # where 4b825... is a magic SHA which represents the empty tree
-        # code, output, error = await execute(command, cwd=top_repo_path)
         code, output, error = await execute(command, cwd=top_repo_path)
 
         if code != 0:

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -1004,12 +1004,26 @@ class Git:
         -   <https://stackoverflow.com/questions/6119956/how-to-determine-if-git-handles-a-file-as-binary-or-as-text/6134127#6134127>
         -   <https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---numstat>
         -   <https://git-scm.com/docs/git-diff#_other_diff_formats>
+
+        Args:
+            filename (str): Filename (relative to the git repository)
+            ref (str): Commit reference or "INDEX" if file is staged
+            top_repo_path (str): Git repository filepath
+
+        Returns:
+            bool: Is file binary?
+        
+        Raises:
+            HTTPError: if git command failed
         """
         if ref == "INDEX":
             command = ["git", "diff", "--numstat", "--cached", "4b825dc642cb6eb9a060e54bf8d69288fbee4904", "--", filename]
         else:
             command = ["git", "diff", "--numstat", "4b825dc642cb6eb9a060e54bf8d69288fbee4904", ref, "--", filename]  # where 4b825... is a magic SHA which represents the empty tree
-        code, output, error = await execute(command, cwd=top_repo_path)
+        # code, output, error = await execute(command, cwd=top_repo_path)
+        r = await execute(command, cwd=top_repo_path)
+        print(r)
+        code, output, error = r
 
         if code != 0:
             err_msg = "fatal: Path '{}' does not exist (neither on disk nor in the index)".format(filename).lower()

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -8,7 +8,7 @@ import tornado
 # local lib
 from jupyterlab_git.git import Git
 
-from .testutils import FakeContentManager
+from .testutils import FakeContentManager, maybe_future
 
 
 def test_is_remote_branch():
@@ -33,7 +33,7 @@ async def test_get_current_branch_success():
 
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future((0, "feature-foo", ""))
+        mock_execute.return_value = maybe_future((0, "feature-foo", ""))
 
         # When
         actual_response = await (
@@ -59,10 +59,10 @@ async def test_checkout_branch_noref_success():
 
     with patch("jupyterlab_git.git.execute") as mock_execute:
         with patch.object(
-            Git, "_get_branch_reference", return_value=tornado.gen.maybe_future(None)
+            Git, "_get_branch_reference", return_value=maybe_future(None)
         ) as mock__get_branch_reference:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (rc, stdout_message, stderr_message)
             )
 
@@ -93,10 +93,10 @@ async def test_checkout_branch_noref_failure():
     rc = 1
     with patch("jupyterlab_git.git.execute") as mock_execute:
         with patch.object(
-            Git, "_get_branch_reference", return_value=tornado.gen.maybe_future(None)
+            Git, "_get_branch_reference", return_value=maybe_future(None)
         ) as mock__get_branch_reference:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (rc, stdout_message, stderr_message)
             )
 
@@ -132,10 +132,10 @@ async def test_checkout_branch_remoteref_success():
         with patch.object(
             Git,
             "_get_branch_reference",
-            return_value=tornado.gen.maybe_future("refs/remotes/remote_branch"),
+            return_value=maybe_future("refs/remotes/remote_branch"),
         ) as mock__get_branch_reference:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (rc, stdout_message, stderr_message)
             )
 
@@ -169,10 +169,10 @@ async def test_checkout_branch_headsref_failure():
         with patch.object(
             Git,
             "_get_branch_reference",
-            return_value=tornado.gen.maybe_future("refs/heads/local_branch"),
+            return_value=maybe_future("refs/heads/local_branch"),
         ) as mock__get_branch_reference:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (rc, stdout_message, stderr_message)
             )
 
@@ -206,10 +206,10 @@ async def test_checkout_branch_headsref_success():
         with patch.object(
             Git,
             "_get_branch_reference",
-            return_value=tornado.gen.maybe_future("refs/heads/local_branch"),
+            return_value=maybe_future("refs/heads/local_branch"),
         ):
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (rc, stdout_message, stderr_message)
             )
 
@@ -239,10 +239,10 @@ async def test_checkout_branch_remoteref_failure():
         with patch.object(
             Git,
             "_get_branch_reference",
-            return_value=tornado.gen.maybe_future("refs/remotes/remote_branch"),
+            return_value=maybe_future("refs/remotes/remote_branch"),
         ):
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (rc, stdout_message, stderr_message)
             )
 
@@ -272,7 +272,7 @@ async def test_get_branch_reference_success():
         branch = "test-branch"
         reference = "refs/remotes/origin/test_branch"
 
-        mock_execute.return_value = tornado.gen.maybe_future((0, reference, ""))
+        mock_execute.return_value = maybe_future((0, reference, ""))
 
         # When
         actual_response = await Git(FakeContentManager("/bin"))._get_branch_reference(
@@ -294,7 +294,7 @@ async def test_get_branch_reference_failure():
         branch = "test-branch"
         reference = "test-branch"
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future(
+        mock_execute.return_value = maybe_future(
             (
                 128,
                 reference,
@@ -321,7 +321,7 @@ async def test_get_branch_reference_failure():
 async def test_get_current_branch_failure():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future(
+        mock_execute.return_value = maybe_future(
             (
                 128,
                 "",
@@ -356,7 +356,7 @@ async def test_get_current_branch_detached_success():
             "  remotes/origin/feature-foo",
             "  remotes/origin/HEAD",
         ]
-        mock_execute.return_value = tornado.gen.maybe_future(
+        mock_execute.return_value = maybe_future(
             (0, "\n".join(process_output), "")
         )
 
@@ -376,7 +376,7 @@ async def test_get_current_branch_detached_success():
 async def test_get_current_branch_detached_failure():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future(
+        mock_execute.return_value = maybe_future(
             (
                 128,
                 "",
@@ -413,7 +413,7 @@ async def test_get_current_branch_detached_failure():
 async def test_get_upstream_branch_success(branch, upstream):
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future((0, upstream, ""))
+        mock_execute.return_value = maybe_future((0, upstream, ""))
 
         # When
         actual_response = await Git(FakeContentManager("/bin")).get_upstream_branch(
@@ -451,7 +451,7 @@ async def test_get_upstream_branch_success(branch, upstream):
 async def test_get_upstream_branch_failure(outputs, message):
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future(outputs)
+        mock_execute.return_value = maybe_future(outputs)
 
         # When
         if message:
@@ -482,7 +482,7 @@ async def test_get_upstream_branch_failure(outputs, message):
 async def test_get_tag_success():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future((0, "v0.3.0", ""))
+        mock_execute.return_value = maybe_future((0, "v0.3.0", ""))
 
         # When
         actual_response = await Git(FakeContentManager("/bin"))._get_tag(
@@ -503,8 +503,8 @@ async def test_get_tag_failure():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.side_effect = [
-            tornado.gen.maybe_future((128, "", "fatal: Not a valid object name blah")),
-            tornado.gen.maybe_future(
+            maybe_future((128, "", "fatal: Not a valid object name blah")),
+            maybe_future(
                 (
                     128,
                     "",
@@ -557,7 +557,7 @@ async def test_get_tag_failure():
 async def test_no_tags():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future(
+        mock_execute.return_value = maybe_future(
             (128, "", "fatal: No names found, cannot describe anything.\n")
         )
 
@@ -590,9 +590,9 @@ async def test_branch_success():
 
         mock_execute.side_effect = [
             # Response for get all refs/heads
-            tornado.gen.maybe_future((0, "\n".join(process_output_heads), "")),
+            maybe_future((0, "\n".join(process_output_heads), "")),
             # Response for get all refs/remotes
-            tornado.gen.maybe_future((0, "\n".join(process_output_remotes), "")),
+            maybe_future((0, "\n".join(process_output_remotes), "")),
         ]
 
         expected_response = {
@@ -694,7 +694,7 @@ async def test_branch_failure():
             "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)",
             "refs/heads/",
         ]
-        mock_execute.return_value = tornado.gen.maybe_future(
+        mock_execute.return_value = maybe_future(
             (
                 128,
                 "",
@@ -738,15 +738,15 @@ async def test_branch_success_detached_head():
 
         mock_execute.side_effect = [
             # Response for get all refs/heads
-            tornado.gen.maybe_future((0, "\n".join(process_output_heads), "")),
+            maybe_future((0, "\n".join(process_output_heads), "")),
             # Response for get current branch
-            tornado.gen.maybe_future(
+            maybe_future(
                 (128, "", "fatal: ref HEAD is not a symbolic ref")
             ),
             # Response for get current branch detached
-            tornado.gen.maybe_future((0, "\n".join(detached_head_output), "")),
+            maybe_future((0, "\n".join(detached_head_output), "")),
             # Response for get all refs/remotes
-            tornado.gen.maybe_future((0, "\n".join(process_output_remotes), "")),
+            maybe_future((0, "\n".join(process_output_remotes), "")),
         ]
 
         expected_response = {

--- a/jupyterlab_git/tests/test_clone.py
+++ b/jupyterlab_git/tests/test_clone.py
@@ -6,7 +6,7 @@ import tornado
 
 from jupyterlab_git.git import Git
 
-from .testutils import FakeContentManager
+from .testutils import FakeContentManager, maybe_future
 
 
 @pytest.mark.asyncio
@@ -14,7 +14,7 @@ async def test_git_clone_success():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future((0, "output", "error"))
+            mock_execute.return_value = maybe_future((0, "output", "error"))
 
             # When
             actual_response = await Git(FakeContentManager("/bin")).clone(
@@ -40,7 +40,7 @@ async def test_git_clone_failure_from_git():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (128, "test_output", "fatal: Not a git repository")
             )
 
@@ -66,7 +66,7 @@ async def test_git_clone_with_auth_success():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_authentication:
             # Given
-            mock_authentication.return_value = tornado.gen.maybe_future((0, "", ""))
+            mock_authentication.return_value = maybe_future((0, "", ""))
 
             # When
             auth = {"username": "asdf", "password": "qwerty"}
@@ -95,7 +95,7 @@ async def test_git_clone_with_auth_wrong_repo_url_failure_from_git():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_authentication:
             # Given
-            mock_authentication.return_value = tornado.gen.maybe_future(
+            mock_authentication.return_value = maybe_future(
                 (128, "", "fatal: repository 'ghjkhjkl' does not exist")
             )
 
@@ -129,7 +129,7 @@ async def test_git_clone_with_auth_auth_failure_from_git():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_authentication:
             # Given
-            mock_authentication.return_value = tornado.gen.maybe_future(
+            mock_authentication.return_value = maybe_future(
                 (
                     128,
                     "",

--- a/jupyterlab_git/tests/test_config.py
+++ b/jupyterlab_git/tests/test_config.py
@@ -7,14 +7,14 @@ import tornado
 from jupyterlab_git.git import Git
 from jupyterlab_git.handlers import GitConfigHandler
 
-from .testutils import FakeContentManager, ServerTest
+from .testutils import FakeContentManager, ServerTest, maybe_future
 
 
 class TestConfig(ServerTest):
     @patch("jupyterlab_git.git.execute")
     def test_git_get_config_success(self, mock_execute):
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future(
+        mock_execute.return_value = maybe_future(
             (0, "user.name=John Snow\nuser.email=john.snow@iscoming.com", "")
         )
 
@@ -52,7 +52,7 @@ class TestConfig(ServerTest):
             '";   };f\n'
             'alias.topic-start=!f(){     topic_branch="$1";     git topic-create "$topic_branch";     git topic-push;   };f'
         )
-        mock_execute.return_value = tornado.gen.maybe_future((0, output, ""))
+        mock_execute.return_value = maybe_future((0, output, ""))
 
         # When
         body = {"path": "test_path"}
@@ -92,7 +92,7 @@ class TestConfig(ServerTest):
             '";   };f\n'
             'alias.topic-start=!f(){     topic_branch="$1";     git topic-create "$topic_branch";     git topic-push;   };f'
         )
-        mock_execute.return_value = tornado.gen.maybe_future((0, output, ""))
+        mock_execute.return_value = maybe_future((0, output, ""))
 
         # When
         body = {"path": "test_path"}
@@ -120,7 +120,7 @@ class TestConfig(ServerTest):
     @patch("jupyterlab_git.git.execute")
     def test_git_set_config_success(self, mock_execute):
         # Given
-        mock_execute.return_value = tornado.gen.maybe_future((0, "", ""))
+        mock_execute.return_value = maybe_future((0, "", ""))
 
         # When
         body = {

--- a/jupyterlab_git/tests/test_detailed_log.py
+++ b/jupyterlab_git/tests/test_detailed_log.py
@@ -29,7 +29,7 @@ async def test_detailed_log():
         ]
 
 
-        mock_execute._mock_return_value = maybe_future(
+        mock_execute.return_value = maybe_future(
             (0, "\x00".join(process_output)+"\x00", "")
         )
 
@@ -45,42 +45,49 @@ async def test_detailed_log():
                     "modified_file_name": "notebook_without_spaces.ipynb",
                     "insertion": "10",
                     "deletion": "3",
+                    "is_binary": False,
                 },
                 {
                     "modified_file_path": "Notebook with spaces.ipynb",
                     "modified_file_name": "Notebook with spaces.ipynb",
                     "insertion": "11",
                     "deletion": "4",
+                    "is_binary": False,
                 },
                 {
                     "modified_file_path": "path/notebook_without_spaces.ipynb",
                     "modified_file_name": "notebook_without_spaces.ipynb",
                     "insertion": "12",
                     "deletion": "5",
+                    "is_binary": False,
                 },
                 {
                     "modified_file_path": "path/Notebook with spaces.ipynb",
                     "modified_file_name": "Notebook with spaces.ipynb",
                     "insertion": "13",
                     "deletion": "6",
+                    "is_binary": False,
                 },
                 {
                     "modified_file_path": "path/Notebook with λ.ipynb",
                     "modified_file_name": "Notebook with λ.ipynb",
                     "insertion": "14",
                     "deletion": "1",
+                    "is_binary": False,
                 },
                 {
                     "modified_file_path": "folder2/file with spaces.py",
                     "modified_file_name": "folder1/file with spaces and λ.py => folder2/file with spaces.py",
                     "insertion": "0",
                     "deletion": "0",
+                    "is_binary": False,
                 },
                 {
                     "modified_file_path": "binary_file.png",
                     "modified_file_name": "binary_file.png",
                     "insertion": "0",
                     "deletion": "0",
+                    "is_binary": True,
                 },
             ],
         }

--- a/jupyterlab_git/tests/test_detailed_log.py
+++ b/jupyterlab_git/tests/test_detailed_log.py
@@ -8,7 +8,7 @@ import tornado
 # local lib
 from jupyterlab_git.git import Git
 
-from .testutils import FakeContentManager
+from .testutils import FakeContentManager, maybe_future
 
 
 @pytest.mark.asyncio
@@ -29,7 +29,7 @@ async def test_detailed_log():
         ]
 
 
-        mock_execute._mock_return_value = tornado.gen.maybe_future(
+        mock_execute._mock_return_value = maybe_future(
             (0, "\x00".join(process_output)+"\x00", "")
         )
 

--- a/jupyterlab_git/tests/test_handlers.py
+++ b/jupyterlab_git/tests/test_handlers.py
@@ -13,7 +13,7 @@ from jupyterlab_git.handlers import (
     setup_handlers,
 )
 
-from .testutils import ServerTest, assert_http_error
+from .testutils import ServerTest, assert_http_error, maybe_future
 
 
 def test_mapping_added():
@@ -33,10 +33,10 @@ class TestAllHistory(ServerTest):
         log = "log_foo"
         status = "status_foo"
 
-        mock_git.show_top_level.return_value = tornado.gen.maybe_future(show_top_level)
-        mock_git.branch.return_value = tornado.gen.maybe_future(branch)
-        mock_git.log.return_value = tornado.gen.maybe_future(log)
-        mock_git.status.return_value = tornado.gen.maybe_future(status)
+        mock_git.show_top_level.return_value = maybe_future(show_top_level)
+        mock_git.branch.return_value = maybe_future(branch)
+        mock_git.log.return_value = maybe_future(log)
+        mock_git.status.return_value = maybe_future(status)
 
         # When
         body = {"current_path": "test_path", "history_count": 25}
@@ -111,7 +111,7 @@ class TestBranch(ServerTest):
             ],
         }
 
-        mock_git.branch.return_value = tornado.gen.maybe_future(branch)
+        mock_git.branch.return_value = maybe_future(branch)
 
         # When
         body = {"current_path": "test_path"}
@@ -130,7 +130,7 @@ class TestLog(ServerTest):
     def test_log_handler(self, mock_git):
         # Given
         log = {"code": 0, "commits": []}
-        mock_git.log.return_value = tornado.gen.maybe_future(log)
+        mock_git.log.return_value = maybe_future(log)
 
         # When
         body = {"current_path": "test_path", "history_count": 20}
@@ -147,7 +147,7 @@ class TestLog(ServerTest):
     def test_log_handler_no_history_count(self, mock_git):
         # Given
         log = {"code": 0, "commits": []}
-        mock_git.log.return_value = tornado.gen.maybe_future(log)
+        mock_git.log.return_value = maybe_future(log)
 
         # When
         body = {"current_path": "test_path"}
@@ -165,11 +165,11 @@ class TestPush(ServerTest):
     @patch("jupyterlab_git.handlers.GitPushHandler.git")
     def test_push_handler_localbranch(self, mock_git):
         # Given
-        mock_git.get_current_branch.return_value = tornado.gen.maybe_future("foo")
-        mock_git.get_upstream_branch.return_value = tornado.gen.maybe_future(
+        mock_git.get_current_branch.return_value = maybe_future("foo")
+        mock_git.get_upstream_branch.return_value = maybe_future(
             "localbranch"
         )
-        mock_git.push.return_value = tornado.gen.maybe_future({"code": 0})
+        mock_git.push.return_value = maybe_future({"code": 0})
 
         # When
         body = {"current_path": "test_path"}
@@ -187,11 +187,11 @@ class TestPush(ServerTest):
     @patch("jupyterlab_git.handlers.GitPushHandler.git")
     def test_push_handler_remotebranch(self, mock_git):
         # Given
-        mock_git.get_current_branch.return_value = tornado.gen.maybe_future("foo")
-        mock_git.get_upstream_branch.return_value = tornado.gen.maybe_future(
+        mock_git.get_current_branch.return_value = maybe_future("foo")
+        mock_git.get_upstream_branch.return_value = maybe_future(
             "origin/remotebranch"
         )
-        mock_git.push.return_value = tornado.gen.maybe_future({"code": 0})
+        mock_git.push.return_value = maybe_future({"code": 0})
 
         # When
         body = {"current_path": "test_path"}
@@ -211,9 +211,9 @@ class TestPush(ServerTest):
     @patch("jupyterlab_git.handlers.GitPushHandler.git")
     def test_push_handler_noupstream(self, mock_git):
         # Given
-        mock_git.get_current_branch.return_value = tornado.gen.maybe_future("foo")
-        mock_git.get_upstream_branch.return_value = tornado.gen.maybe_future("")
-        mock_git.push.return_value = tornado.gen.maybe_future({"code": 0})
+        mock_git.get_current_branch.return_value = maybe_future("foo")
+        mock_git.get_upstream_branch.return_value = maybe_future("")
+        mock_git.push.return_value = maybe_future({"code": 0})
 
         # When
         body = {"current_path": "test_path"}
@@ -236,8 +236,8 @@ class TestUpstream(ServerTest):
     @patch("jupyterlab_git.handlers.GitUpstreamHandler.git")
     def test_upstream_handler_localbranch(self, mock_git):
         # Given
-        mock_git.get_current_branch.return_value = tornado.gen.maybe_future("foo")
-        mock_git.get_upstream_branch.return_value = tornado.gen.maybe_future("bar")
+        mock_git.get_current_branch.return_value = maybe_future("foo")
+        mock_git.get_upstream_branch.return_value = maybe_future("bar")
 
         # When
         body = {"current_path": "test_path"}
@@ -261,10 +261,10 @@ class TestDiffContent(ServerTest):
         content = "dummy content file\nwith multiple lines"
 
         mock_execute.side_effect = [
-            tornado.gen.maybe_future((0, "1\t1\t{}".format(filename), "")),
-            tornado.gen.maybe_future((0, content, "")),
-            tornado.gen.maybe_future((0, "1\t1\t{}".format(filename), "")),
-            tornado.gen.maybe_future((0, content, ""))
+            maybe_future((0, "1\t1\t{}".format(filename), "")),
+            maybe_future((0, content, "")),
+            maybe_future((0, "1\t1\t{}".format(filename), "")),
+            maybe_future((0, content, ""))
         ]
 
         # When
@@ -303,9 +303,9 @@ class TestDiffContent(ServerTest):
         content = "dummy content file\nwith multiple lines"
 
         mock_execute.side_effect = [
-            tornado.gen.maybe_future((0, "1\t1\t{}".format(filename), "")),
-            tornado.gen.maybe_future((0, content, "")),
-            tornado.gen.maybe_future((0, content, ""))
+            maybe_future((0, "1\t1\t{}".format(filename), "")),
+            maybe_future((0, content, "")),
+            maybe_future((0, content, ""))
         ]
 
         dummy_file = os.path.join(self.notebook_dir, top_repo_path, filename)
@@ -344,10 +344,10 @@ class TestDiffContent(ServerTest):
         content = "dummy content file\nwith multiple lines"
 
         mock_execute.side_effect = [
-            tornado.gen.maybe_future((0, "1\t1\t{}".format(filename), "")),
-            tornado.gen.maybe_future((0, content, "")),
-            tornado.gen.maybe_future((0, "1\t1\t{}".format(filename), "")),
-            tornado.gen.maybe_future((0, content, ""))
+            maybe_future((0, "1\t1\t{}".format(filename), "")),
+            maybe_future((0, content, "")),
+            maybe_future((0, "1\t1\t{}".format(filename), "")),
+            maybe_future((0, content, ""))
         ]
 
         # When
@@ -386,10 +386,10 @@ class TestDiffContent(ServerTest):
         content = "dummy content file\nwith multiple lines"
 
         mock_execute.side_effect = [
-            tornado.gen.maybe_future((0, "1\t1\t{}".format(filename), "")),
-            tornado.gen.maybe_future((0, content, "")),
-            tornado.gen.maybe_future((0, "1\t1\t{}".format(filename), "")),
-            tornado.gen.maybe_future((0, content, ""))
+            maybe_future((0, "1\t1\t{}".format(filename), "")),
+            maybe_future((0, content, "")),
+            maybe_future((0, "1\t1\t{}".format(filename), "")),
+            maybe_future((0, content, ""))
         ]
 
         # When
@@ -409,7 +409,7 @@ class TestDiffContent(ServerTest):
         top_repo_path = "path/to/repo"
         filename = "my/file"
 
-        mock_execute.return_value = tornado.gen.maybe_future(
+        mock_execute.return_value = maybe_future(
             (
                 -1,
                 "",
@@ -440,7 +440,7 @@ class TestDiffContent(ServerTest):
         top_repo_path = "path/to/repo"
         filename = "my/file"
 
-        mock_execute.return_value = tornado.gen.maybe_future((0, "-\t-\t{}".format(filename), ""))
+        mock_execute.return_value = maybe_future((0, "-\t-\t{}".format(filename), ""))
 
         # When
         body = {
@@ -460,7 +460,7 @@ class TestDiffContent(ServerTest):
         top_repo_path = "path/to/repo"
         filename = "my/file"
 
-        mock_execute.return_value = tornado.gen.maybe_future((-1, "", "Dummy error"))
+        mock_execute.return_value = maybe_future((-1, "", "Dummy error"))
 
         # When
         body = {
@@ -482,9 +482,9 @@ class TestDiffContent(ServerTest):
         content = "dummy content file\nwith multiple lines"
 
         mock_execute.side_effect = [
-            tornado.gen.maybe_future((0, "1\t1\t{}".format(filename), "")),
-            tornado.gen.maybe_future((0, content, "")),
-            tornado.gen.maybe_future((0, content, ""))
+            maybe_future((0, "1\t1\t{}".format(filename), "")),
+            maybe_future((0, content, "")),
+            maybe_future((0, content, ""))
         ]
 
         # When

--- a/jupyterlab_git/tests/test_pushpull.py
+++ b/jupyterlab_git/tests/test_pushpull.py
@@ -6,7 +6,7 @@ import tornado
 
 from jupyterlab_git.git import Git
 
-from .testutils import FakeContentManager
+from .testutils import FakeContentManager, maybe_future
 
 
 @pytest.mark.asyncio
@@ -14,7 +14,7 @@ async def test_git_pull_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (1, "output", "Authentication failed")
             )
 
@@ -37,7 +37,7 @@ async def test_git_pull_with_conflict_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future((1, "", "Automatic merge failed; fix conflicts and then commit the result."))
+            mock_execute.return_value = maybe_future((1, "", "Automatic merge failed; fix conflicts and then commit the result."))
 
             # When
             actual_response = await Git(FakeContentManager("/bin")).pull("test_curr_path")
@@ -58,7 +58,7 @@ async def test_git_pull_with_auth_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
-            mock_execute_with_authentication.return_value = tornado.gen.maybe_future(
+            mock_execute_with_authentication.return_value = maybe_future(
                 (
                     1,
                     "",
@@ -92,7 +92,7 @@ async def test_git_pull_success():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future((0, "output", ""))
+            mock_execute.return_value = maybe_future((0, "output", ""))
 
             # When
             actual_response = await Git(FakeContentManager("/bin")).pull(
@@ -114,7 +114,7 @@ async def test_git_pull_with_auth_success():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
-            mock_execute_with_authentication.return_value = tornado.gen.maybe_future(
+            mock_execute_with_authentication.return_value = maybe_future(
                 (0, "", "output")
             )
 
@@ -140,7 +140,7 @@ async def test_git_pull_with_auth_success_and_conflict_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
-            mock_execute_with_authentication.return_value = tornado.gen.maybe_future((1, "output", "Automatic merge failed; fix conflicts and then commit the result."))
+            mock_execute_with_authentication.return_value = maybe_future((1, "output", "Automatic merge failed; fix conflicts and then commit the result."))
 
             # When
             auth = {
@@ -167,7 +167,7 @@ async def test_git_push_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (1, "output", "Authentication failed")
             )
 
@@ -191,7 +191,7 @@ async def test_git_push_with_auth_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
-            mock_execute_with_authentication.return_value = tornado.gen.maybe_future(
+            mock_execute_with_authentication.return_value = maybe_future(
                 (
                     1,
                     "",
@@ -225,7 +225,7 @@ async def test_git_push_success():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = tornado.gen.maybe_future(
+            mock_execute.return_value = maybe_future(
                 (0, "output", "does not matter")
             )
 
@@ -249,7 +249,7 @@ async def test_git_push_with_auth_success():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
-            mock_execute_with_authentication.return_value = tornado.gen.maybe_future(
+            mock_execute_with_authentication.return_value = maybe_future(
                 (0, "", "does not matter")
             )
 

--- a/jupyterlab_git/tests/test_status.py
+++ b/jupyterlab_git/tests/test_status.py
@@ -8,7 +8,7 @@ import tornado
 # local lib
 from jupyterlab_git.git import Git
 
-from .testutils import FakeContentManager
+from .testutils import FakeContentManager, maybe_future
 
 
 @pytest.mark.asyncio
@@ -58,7 +58,7 @@ async def test_status(output, expected):
         # Given
         root = "/bin"
         repository = "test_curr_path"
-        mock_execute.return_value = tornado.gen.maybe_future(
+        mock_execute.return_value = maybe_future(
             (0, "\x00".join(output)+"\x00", "")
         )
 

--- a/jupyterlab_git/tests/test_status.py
+++ b/jupyterlab_git/tests/test_status.py
@@ -13,15 +13,21 @@ from .testutils import FakeContentManager, maybe_future
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "output,expected",
+    "output,diff_output,expected",
     [
         (
             (
                 "A  notebook with spaces.ipynb",
                 "M  notebook with λ.ipynb",
+                "M  binary file.gif",
                 "R  renamed_to_θ.py",
                 "originally_named_π.py",
                 "?? untracked.ipynb",
+            ),
+            (
+                "0\t0\tnotebook with spaces.ipynb",
+                "-\t-\tbinary file.gif",
+                "0\t0\trenamed_to_θ.py",
             ),
             [
                 {
@@ -29,38 +35,50 @@ from .testutils import FakeContentManager, maybe_future
                     "y": " ",
                     "to": "notebook with spaces.ipynb",
                     "from": "notebook with spaces.ipynb",
+                    "is_binary": False,
                 },
                 {
                     "x": "M",
                     "y": " ",
                     "to": "notebook with λ.ipynb",
                     "from": "notebook with λ.ipynb",
+                    "is_binary": None,
+                },
+                {
+                    "x": "M",
+                    "y": " ",
+                    "to": "binary file.gif",
+                    "from": "binary file.gif",
+                    "is_binary": True,
                 },
                 {
                     "x": "R",
                     "y": " ",
                     "to": "renamed_to_θ.py",
                     "from": "originally_named_π.py",
+                    "is_binary": False,
                 },
                 {
                     "x": "?",
                     "y": "?",
                     "to": "untracked.ipynb",
                     "from": "untracked.ipynb",
+                    "is_binary": None,
                 },
             ],
         ),
-        ((""), ([])),  # Empty answer
+        ((""), (""), ([])),  # Empty answer
     ],
 )
-async def test_status(output, expected):
+async def test_status(output, diff_output, expected):
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         root = "/bin"
         repository = "test_curr_path"
-        mock_execute.return_value = maybe_future(
-            (0, "\x00".join(output)+"\x00", "")
-        )
+        mock_execute.side_effect = [
+            maybe_future((0, "\x00".join(output) + "\x00", "")),
+            maybe_future((0, "\x00".join(diff_output) + "\x00", "")),
+        ]
 
         # When
         actual_response = await Git(FakeContentManager(root)).status(
@@ -68,9 +86,24 @@ async def test_status(output, expected):
         )
 
         # Then
-        mock_execute.assert_called_once_with(
-            ["git", "status", "--porcelain", "-u", "-z"],
-            cwd=os.path.join(root, repository),
+        mock_execute.assert_has_calls(
+            [
+                call(
+                    ["git", "status", "--porcelain", "-u", "-z"],
+                    cwd=os.path.join(root, repository),
+                ),
+                call(
+                    [
+                        "git",
+                        "diff",
+                        "--numstat",
+                        "-z",
+                        "--cached",
+                        "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+                    ],
+                    cwd=os.path.join(root, repository),
+                ),
+            ]
         )
 
         assert {"code": 0, "files": expected} == actual_response

--- a/jupyterlab_git/tests/testutils.py
+++ b/jupyterlab_git/tests/testutils.py
@@ -4,7 +4,13 @@ import json
 from typing import List
 from unittest.mock import patch
 
+try:
+    from unittest.mock import AsyncMock  # New in Python 3.8 and used by unittest.mock
+except ImportError:
+    AsyncMock = None
+
 import requests
+import tornado
 from traitlets.config import Config
 
 # Shim for notebook server or jupyter_server
@@ -83,3 +89,10 @@ class FakeContentManager:
     
     def get(self, path=None):
         return {"content": ""}
+
+
+def maybe_future(args):
+    if AsyncMock is None:
+        return tornado.gen.maybe_future(args)
+    else:
+        return args

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -71,7 +71,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               currentRef: { specialRef: 'WORKING' },
               previousRef: { gitRef: 'HEAD' }
             },
-            this.props.renderMime
+            this.props.renderMime,
+            !this.state.selectedFile.is_binary
           );
         }
       });
@@ -89,7 +90,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               currentRef: { specialRef: 'INDEX' },
               previousRef: { gitRef: 'HEAD' }
             },
-            this.props.renderMime
+            this.props.renderMime,
+            !this.state.selectedFile.is_binary
           );
         }
       });
@@ -342,7 +344,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               key={file.to}
               actions={
                 <React.Fragment>
-                  {this._createDiffButton(file.to, 'INDEX')}
+                  {this._createDiffButton(file, 'INDEX')}
                   <ActionButton
                     className={hiddenButtonStyle}
                     iconName={'git-remove'}
@@ -405,7 +407,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
                       this.discardChanges(file.to);
                     }}
                   />
-                  {this._createDiffButton(file.to, 'WORKING')}
+                  {this._createDiffButton(file, 'WORKING')}
                   <ActionButton
                     className={hiddenButtonStyle}
                     iconName={'git-add'}
@@ -498,11 +500,11 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
                     this.discardChanges(file.to);
                   }}
                 />
-                {this._createDiffButton(file.to, 'WORKING')}
+                {this._createDiffButton(file, 'WORKING')}
               </React.Fragment>
             );
           } else if (file.status === 'staged') {
-            actions = this._createDiffButton(file.to, 'INDEX');
+            actions = this._createDiffButton(file, 'INDEX');
           }
 
           return (
@@ -526,11 +528,11 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
    * @param currentRef the ref to diff against the git 'HEAD' ref
    */
   private _createDiffButton(
-    path: string,
+    file: Git.IStatusFile,
     currentRef: ISpecialRef['specialRef']
   ): JSX.Element {
     return (
-      isDiffSupported(path) && (
+      (isDiffSupported(file.to) || !file.is_binary) && (
         <ActionButton
           className={hiddenButtonStyle}
           iconName={'git-diff'}
@@ -538,16 +540,19 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           onClick={async () => {
             try {
               await openDiffView(
-                path,
+                file.to,
                 this.props.model,
                 {
                   previousRef: { gitRef: 'HEAD' },
                   currentRef: { specialRef: currentRef }
                 },
-                this.props.renderMime
+                this.props.renderMime,
+                !file.is_binary
               );
             } catch (reason) {
-              console.error(`Fail to open diff view for ${path}.\n${reason}`);
+              console.error(
+                `Fail to open diff view for ${file.to}.\n${reason}`
+              );
             }
           }}
         />

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -230,7 +230,7 @@ export class SinglePastCommitInfo extends React.Component<
    */
   private _renderFile(file: Git.ICommitModifiedFile): React.ReactElement {
     const path = file.modified_file_path;
-    const flg = isDiffSupported(path);
+    const flg = isDiffSupported(path) || !file.is_binary;
     return (
       <li
         className={commitDetailFileClass}
@@ -330,7 +330,8 @@ export class SinglePastCommitInfo extends React.Component<
               gitRef: self.props.commit.commit
             }
           },
-          self.props.renderMime
+          self.props.renderMime,
+          bool
         );
       } catch (err) {
         console.error(`Failed to open diff view for ${fpath}.\n${err}`);

--- a/src/components/diff/Diff.tsx
+++ b/src/components/diff/Diff.tsx
@@ -3,7 +3,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import * as React from 'react';
 import { IDiffContext } from './model';
 import { NBDiff } from './NbDiff';
-import { isText, PlainTextDiff } from './PlainTextDiff';
+import { PlainTextDiff } from './PlainTextDiff';
 
 /**
  * A registry which maintains mappings of file extension to diff provider components.
@@ -18,10 +18,7 @@ const DIFF_PROVIDER_REGISTRY: { [key: string]: typeof React.Component } = {
  * @param path the file path
  */
 export function isDiffSupported(path: string): boolean {
-  return (
-    PathExt.extname(path).toLocaleLowerCase() in DIFF_PROVIDER_REGISTRY ||
-    isText(path)
-  );
+  return PathExt.extname(path).toLocaleLowerCase() in DIFF_PROVIDER_REGISTRY;
 }
 
 /** Diff component properties */
@@ -51,11 +48,14 @@ export function Diff(props: IDiffProps) {
   if (fileExtension in DIFF_PROVIDER_REGISTRY) {
     const DiffProvider = DIFF_PROVIDER_REGISTRY[fileExtension];
     return <DiffProvider {...props} />;
-  } else if (isText(props.path)) {
-    return <PlainTextDiff {...props} />;
   } else {
-    console.log(`Diff is not supported for ${fileExtension} files`);
-    return null;
+    // Fallback to plain text diff
+    try {
+      return <PlainTextDiff {...props} />;
+    } catch (error) {
+      console.log(`Unable to render diff view for ${props.path}:\n${error}`);
+      return null;
+    }
   }
 }
 

--- a/src/components/diff/DiffWidget.tsx
+++ b/src/components/diff/DiffWidget.tsx
@@ -15,15 +15,16 @@ import { GitExtension } from '../../model';
  * @param shell The JupyterLab shell instance
  * @param diffContext the context in which the diff is being requested
  * @param renderMime the renderMime registry instance from the
- * @param topRepoPath the Git repo root path.
+ * @param isText Is the file of textual type?
  */
 export async function openDiffView(
   filePath: string,
   model: GitExtension,
   diffContext: IDiffContext,
-  renderMime: IRenderMimeRegistry
+  renderMime: IRenderMimeRegistry,
+  isText = false
 ) {
-  if (isDiffSupported(filePath)) {
+  if (isDiffSupported(filePath) || isText) {
     const id = `nbdiff-${filePath}-${getRefValue(diffContext.currentRef)}`;
     let mainAreaItems = model.shell.widgets('main');
     let mainAreaItem = mainAreaItems.next();

--- a/src/components/diff/PlainTextDiff.tsx
+++ b/src/components/diff/PlainTextDiff.tsx
@@ -122,7 +122,8 @@ export class PlainTextDiff extends React.Component<
    * @param currContent the raw value of the current content
    */
   private _addDiffViewer(prevContent: string, currContent: string) {
-    const mode = Mode.findBest(this.props.path);
+    const mode =
+      Mode.findByFileName(this.props.path) || Mode.findBest(this.props.path);
 
     mergeView(this._mergeViewRef.current, {
       value: currContent,

--- a/src/components/diff/PlainTextDiff.tsx
+++ b/src/components/diff/PlainTextDiff.tsx
@@ -138,12 +138,3 @@ export class PlainTextDiff extends React.Component<
 
   private _mergeViewRef: React.RefObject<HTMLDivElement>;
 }
-
-/**
- * Checks if a given path is supported language
- *
- * @param path the path of the file
- */
-export function isText(path: string): boolean {
-  return Mode.findBest(path) !== undefined;
-}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -374,6 +374,7 @@ export namespace Git {
     y: string;
     to: string;
     from: string;
+    is_binary: boolean | null;
   }
 
   /**
@@ -410,6 +411,7 @@ export namespace Git {
     modified_file_name: string;
     insertion: string;
     deletion: string;
+    is_binary: boolean | null;
   }
 
   /** Interface for GitDetailedLog request result,

--- a/tests/GitExtension.spec.tsx
+++ b/tests/GitExtension.spec.tsx
@@ -190,7 +190,7 @@ describe('IGitExtension', () => {
 
       model.pathRepository = '/path/to/server/repo';
       await model.ready;
-      status = [{ x: '', y: '', from: '', to: '' }];
+      status = [{ x: '', y: '', from: '', to: '', is_binary: null }];
       await model.refreshStatus();
       expect(model.status).toHaveLength(1);
 
@@ -220,7 +220,7 @@ describe('IGitExtension', () => {
 
       model.pathRepository = '/path/to/server/repo';
       await model.ready;
-      status = [{ x: '', y: '', from: '', to: '' }];
+      status = [{ x: '', y: '', from: '', to: '', is_binary: null }];
       await model.refreshStatus();
       await testSignal;
     });

--- a/tests/test-components/Diff.spec.tsx
+++ b/tests/test-components/Diff.spec.tsx
@@ -40,6 +40,6 @@ describe('Diff', () => {
   );
 
   it('should support diffing all files', function() {
-    expect(isDiffSupported('/path/to/script.unk')).toBeTruthy();
+    expect(isDiffSupported('/path/to/script.unk')).toBeFalsy();
   });
 });

--- a/tests/test-components/FileItem.spec.tsx
+++ b/tests/test-components/FileItem.spec.tsx
@@ -11,6 +11,7 @@ describe('FileItem', () => {
       y: 'M',
       to: 'some/file/path/file-name',
       from: '',
+      is_binary: null,
       status: null
     },
     model: null,


### PR DESCRIPTION
This fixes #585. 

In addition:
- an attribute `is_binary` is sent back to the frontend from the *status* and *detailed log* requests. That attribute is used to restore showing or hiding diff icon.
- the codemirror mode is properly handled to use syntax highlighting in plain text diff widget.