### PR TITLE
use overflow: 'auto' for historywrapper and branchmenuwrapper

### DIFF
--- a/src/style/BranchMenu.ts
+++ b/src/style/BranchMenu.ts
@@ -101,7 +101,7 @@ export const listWrapperClass = style({
   maxHeight: '400px',
 
   overflow: 'hidden',
-  overflowY: 'scroll'
+  overflowY: 'auto'
 });
 
 export const listItemClass = style({

--- a/src/style/HistorySideBarStyle.ts
+++ b/src/style/HistorySideBarStyle.ts
@@ -10,5 +10,5 @@ export const historySideBarStyle = style({
   marginBlockEnd: 0,
   paddingLeft: 0,
 
-  overflowY: 'scroll'
+  overflowY: 'auto'
 });


### PR DESCRIPTION
fixes: https://github.com/jupyterlab/jupyterlab-git/issues/590
**Original**:
![image](https://user-images.githubusercontent.com/10111092/79253909-ece36e00-7e51-11ea-8f79-6df9fd771e1e.png)

**This PR**:
![image](https://user-images.githubusercontent.com/10111092/79253991-0c7a9680-7e52-11ea-9455-3eef6b8b7a7c.png)

