### PR TITLE
fix branch ordering on firefox

### DIFF
--- a/src/components/NewBranchDialog.tsx
+++ b/src/components/NewBranchDialog.tsx
@@ -233,6 +233,8 @@ export class NewBranchDialog extends React.Component<
     function comparator(a: Git.IBranch, b: Git.IBranch): number {
       if (a.name === current) {
         return -1;
+      } else if (b.name === current) {
+        return 1;
       }
       return 0;
     }


### PR DESCRIPTION
In the new branch dialog that you get from hitting the New Branch button the ordering does not always put the current branch first when using Firefox. This is because the comparison function would sort different depending on which argument the current branch was:
```typescript
comparator('current', 'other branch') => 'current', 'other branch'
comparator('other branch', 'current') => 'other branch', 'current'
```
Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Description this leaves the sorting order undefined (seems that chrome handles this differently than firefox). This result in the current branch not always being sorted to be first:
**Firefox**:
![image](https://user-images.githubusercontent.com/10111092/79269938-3be9cd00-7e6b-11ea-8467-33cd2a92a054.png)

Which does not seem to the the intention of this code:
https://github.com/jupyterlab/jupyterlab-git/blob/2787178ecdf50a8adb3ed576ea03b6de4feddef5/src/components/NewBranchDialog.tsx#L233-L239

With this PR that switches to this:
![image](https://user-images.githubusercontent.com/10111092/79270107-7eaba500-7e6b-11ea-9afe-23e657370dc1.png)

This isn't much of an issue when all the branches fit on the screen, but once there are more branches I found this to be more of a problem.
