### PR TITLE
add clone to commands and to git menu

### DIFF
--- a/src/gitMenuCommands.ts
+++ b/src/gitMenuCommands.ts
@@ -147,7 +147,7 @@ export function addCommands(
       }
     }
   });
-  
+
   /** Add git clone command */
   commands.addCommand(CommandIDs.gitClone, {
     label: 'Clone',

--- a/src/gitMenuCommands.ts
+++ b/src/gitMenuCommands.ts
@@ -152,6 +152,7 @@ export function addCommands(
   commands.addCommand(CommandIDs.gitClone, {
     label: 'Clone',
     caption: 'Clone a repository from a URL',
+    isEnabled: () => model.pathRepository === null,
     execute: async () => {
       await doGitClone(model, fileBrowser.model.path);
       fileBrowser.model.refresh();

--- a/src/gitMenuCommands.ts
+++ b/src/gitMenuCommands.ts
@@ -10,6 +10,7 @@ import { ISettingRegistry } from '@jupyterlab/coreutils';
 import { FileBrowser } from '@jupyterlab/filebrowser';
 import { ITerminal } from '@jupyterlab/terminal';
 import { IGitExtension } from './tokens';
+import { doGitClone } from './widgets/gitClone';
 
 /**
  * The command IDs used by the git plugin.
@@ -21,6 +22,7 @@ export namespace CommandIDs {
   export const gitOpenUrl = 'git:open-url';
   export const gitToggleSimpleStaging = 'git:toggle-simple-staging';
   export const gitAddRemote = 'git:add-remote';
+  export const gitClone = 'git:clone';
 }
 
 /**
@@ -143,6 +145,16 @@ export function addCommands(
           showErrorMessage('Error when adding remote repository', error);
         }
       }
+    }
+  });
+  
+  /** Add git clone command */
+  commands.addCommand(CommandIDs.gitClone, {
+    label: 'Clone',
+    caption: 'Clone a repository from a URL',
+    execute: async () => {
+      await doGitClone(model, fileBrowser.model.path);
+      fileBrowser.model.refresh();
     }
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,7 @@ function createGitMenu(
     CommandIDs.gitUI,
     CommandIDs.gitTerminalCommand,
     CommandIDs.gitInit,
+    CommandIDs.gitClone,
     CommandIDs.gitAddRemote
   ].forEach(command => {
     menu.addItem({ command });

--- a/src/widgets/gitClone.tsx
+++ b/src/widgets/gitClone.tsx
@@ -103,7 +103,7 @@ async function makeApiCall(
  * 1. Invokes a new dialog box with form fields.
  * 2. Invokes the server API with the form input.
  */
-async function doGitClone(model: IGitExtension, path: string): Promise<void> {
+export async function doGitClone(model: IGitExtension, path: string): Promise<void> {
   const result = await showDialog({
     title: 'Clone a repo',
     body: new GitCloneForm(),

--- a/src/widgets/gitClone.tsx
+++ b/src/widgets/gitClone.tsx
@@ -103,7 +103,10 @@ async function makeApiCall(
  * 1. Invokes a new dialog box with form fields.
  * 2. Invokes the server API with the form input.
  */
-export async function doGitClone(model: IGitExtension, path: string): Promise<void> {
+export async function doGitClone(
+  model: IGitExtension,
+  path: string
+): Promise<void> {
   const result = await showDialog({
     title: 'Clone a repo',
     body: new GitCloneForm(),


### PR DESCRIPTION
I added the the clone command to the git menu:
![image](https://user-images.githubusercontent.com/10111092/79644240-9b025700-8175-11ea-9b7a-84087f5a4f0b.png)

If `init` is in this menu then I think it makes sense to also include `clone`. Also, making `clone` available as a command will make it easier to incorporate a clone button to the updated not in repo panel.