### PR TITLE
Init button

### DIFF
--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -314,8 +314,8 @@ export class GitPanel extends React.Component<
           ) : (
             'You are not currently in'
           )}{' '}
-          a git repository. To use git navigate to a local repository, intialize
-          a repository here, or clone an existing repository.
+          a Git repository. To use Git, navigate to a local repository,
+          initialize a repository here, or clone an existing repository.
         </div>
         <button
           className={repoButtonClass}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -14,6 +14,7 @@ import {
   tabClass,
   tabsClass,
   tabIndicatorClass,
+  warningTextClass,
   warningWrapperClass
 } from '../style/GitPanel';
 import { Git } from '../tokens';
@@ -305,11 +306,11 @@ export class GitPanel extends React.Component<
 
     return (
       <div className={warningWrapperClass}>
-        <div>
+        <div className={warningTextClass}>
           {!!path ? (
-            <span>
+            <React.Fragment>
               <b title={path}>{PathExt.basename(path)}</b> is not
-            </span>
+            </React.Fragment>
           ) : (
             'You are not currently in'
           )}{' '}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -1,29 +1,29 @@
-import * as React from 'react';
-import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
-import { showErrorMessage, showDialog } from '@jupyterlab/apputils';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { showDialog, showErrorMessage } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
+import { FileBrowserModel } from '@jupyterlab/filebrowser';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { JSONObject } from '@lumino/coreutils';
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import * as React from 'react';
 import { GitExtension } from '../model';
 import {
   panelWrapperClass,
   repoButtonClass,
   selectedTabClass,
   tabClass,
-  tabsClass,
   tabIndicatorClass,
-  warningTextClass,
-  warningWrapperClass
+  tabsClass,
+  warningTextClass
 } from '../style/GitPanel';
 import { Git } from '../tokens';
 import { GitAuthorForm } from '../widgets/AuthorBox';
+import { CommitBox } from './CommitBox';
 import { FileList } from './FileList';
 import { HistorySideBar } from './HistorySideBar';
 import { Toolbar } from './Toolbar';
-import { CommitBox } from './CommitBox';
-import { FileBrowser } from '@jupyterlab/filebrowser';
+import { CommandIDs } from '../gitMenuCommands';
 
 /** Interface for GitPanel component state */
 export interface IGitSessionNodeState {
@@ -40,7 +40,7 @@ export interface IGitSessionNodeProps {
   model: GitExtension;
   renderMime: IRenderMimeRegistry;
   settings: ISettingRegistry.ISettings;
-  filebrowser: FileBrowser;
+  filebrowser: FileBrowserModel;
 }
 
 /** A React component for the git extension's main display */
@@ -302,10 +302,11 @@ export class GitPanel extends React.Component<
    * @returns React element
    */
   private _renderWarning(): React.ReactElement {
-    const path = this.props.filebrowser.model.path;
+    const path = this.props.filebrowser.path;
+    const { commands } = this.props.model;
 
     return (
-      <div className={warningWrapperClass}>
+      <React.Fragment>
         <div className={warningTextClass}>
           {path ? (
             <React.Fragment>
@@ -313,33 +314,33 @@ export class GitPanel extends React.Component<
             </React.Fragment>
           ) : (
             'You are not currently in'
-          )}{' '}
-          a Git repository. To use Git, navigate to a local repository,
-          initialize a repository here, or clone an existing repository.
+          )}
+          {
+            ' a Git repository. To use Git, navigate to a local repository, initialize a repository here, or clone an existing repository.'
+          }
         </div>
         <button
           className={repoButtonClass}
-          onClick={() =>
-            this.props.model.commands.execute('filebrowser:toggle-main')
-          }
+          onClick={() => commands.execute('filebrowser:toggle-main')}
         >
           Open the FileBrowser
         </button>
-        <br />
         <button
           className={repoButtonClass}
-          onClick={() => this.props.model.commands.execute('git:init')}
+          onClick={() => commands.execute(CommandIDs.gitInit)}
         >
           Initialize a Repository
         </button>
-        <br />
         <button
           className={repoButtonClass}
-          onClick={() => this.props.model.commands.execute('git:clone')}
+          onClick={async () => {
+            await commands.execute(CommandIDs.gitClone);
+            await commands.execute('filebrowser:toggle-main');
+          }}
         >
           Clone a Repository
         </button>
-      </div>
+      </React.Fragment>
     );
   }
 

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -302,12 +302,12 @@ export class GitPanel extends React.Component<
    * @returns React element
    */
   private _renderWarning(): React.ReactElement {
-    let path = this.props.filebrowser.model.path;
+    const path = this.props.filebrowser.model.path;
 
     return (
       <div className={warningWrapperClass}>
         <div className={warningTextClass}>
-          {!!path ? (
+          {path ? (
             <React.Fragment>
               <b title={path}>{PathExt.basename(path)}</b> is not
             </React.Fragment>

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ async function activate(
       gitExtension,
       settings,
       renderMime,
-      factory.defaultBrowser
+      factory.defaultBrowser.model
     );
     gitPlugin.id = 'jp-git-sessions';
     gitPlugin.title.icon = gitIcon;

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,12 @@ async function activate(
   // Provided we were able to load application settings, create the extension widgets
   if (settings) {
     // Create the Git widget sidebar
-    const gitPlugin = new GitWidget(gitExtension, settings, renderMime);
+    const gitPlugin = new GitWidget(
+      gitExtension,
+      settings,
+      renderMime,
+      factory.defaultBrowser
+    );
     gitPlugin.id = 'jp-git-sessions';
     gitPlugin.title.icon = gitIcon;
     gitPlugin.title.caption = 'Git';

--- a/src/style/GitPanel.ts
+++ b/src/style/GitPanel.ts
@@ -7,29 +7,22 @@ export const panelWrapperClass = style({
   overflowY: 'auto'
 });
 
-export const warningWrapperClass = style({
-  marginTop: '9px',
-  textAlign: 'center',
-
-  /* top | right | bottom | left */
-  padding: '4px 11px 4px 11px!important',
-
-  fontSize: 'var(--jp-ui-font-size1)',
-  lineHeight: '1.5em'
-});
-
 export const warningTextClass = style({
+  fontSize: 'var(--jp-ui-font-size1)',
+  lineHeight: 'var(--jp-content-line-height)',
+  margin: '13px 11px 4px 11px',
   textAlign: 'left'
 });
 
 export const repoButtonClass = style({
+  alignSelf: 'center',
   boxSizing: 'border-box',
 
   height: '2em',
   width: '12em',
   marginTop: '5px',
 
-  color: 'white',
+  color: 'var(--jp-ui-inverse-font-color1)',
   fontSize: 'var(--jp-ui-font-size1)',
 
   backgroundColor: 'var(--jp-brand-color1)',

--- a/src/style/GitPanel.ts
+++ b/src/style/GitPanel.ts
@@ -18,6 +18,10 @@ export const warningWrapperClass = style({
   lineHeight: '1.5em'
 });
 
+export const warningTextClass = style({
+  textAlign: 'left'
+});
+
 export const repoButtonClass = style({
   boxSizing: 'border-box',
 

--- a/src/style/GitPanel.ts
+++ b/src/style/GitPanel.ts
@@ -9,13 +9,28 @@ export const panelWrapperClass = style({
 
 export const warningWrapperClass = style({
   marginTop: '9px',
-  textAlign: 'center'
+  textAlign: 'center',
+
+  /* top | right | bottom | left */
+  padding: '4px 11px 4px 11px!important',
+
+  fontSize: 'var(--jp-ui-font-size1)',
+  lineHeight: '1.5em'
 });
 
 export const repoButtonClass = style({
+  boxSizing: 'border-box',
+
+  height: '2em',
+  width: '12em',
   marginTop: '5px',
+
   color: 'white',
-  backgroundColor: 'var(--jp-brand-color1)'
+  fontSize: 'var(--jp-ui-font-size1)',
+
+  backgroundColor: 'var(--jp-brand-color1)',
+  border: '0',
+  borderRadius: '3px'
 });
 
 export const tabsClass = style({

--- a/src/widgets/GitWidget.tsx
+++ b/src/widgets/GitWidget.tsx
@@ -6,6 +6,7 @@ import { GitPanel } from '../components/GitPanel';
 import { GitExtension } from '../model';
 import { gitWidgetStyle } from '../style/GitWidgetStyle';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { FileBrowser } from '@jupyterlab/filebrowser';
 
 /**
  * A class that exposes the git plugin Widget.
@@ -15,6 +16,7 @@ export class GitWidget extends ReactWidget {
     model: GitExtension,
     settings: ISettingRegistry.ISettings,
     renderMime: IRenderMimeRegistry,
+    filebrowser: FileBrowser,
     options?: Widget.IOptions
   ) {
     super(options);
@@ -24,6 +26,7 @@ export class GitWidget extends ReactWidget {
     this._model = model;
     this._renderMime = renderMime;
     this._settings = settings;
+    this._filebrowser = filebrowser;
   }
 
   render() {
@@ -32,6 +35,7 @@ export class GitWidget extends ReactWidget {
         model={this._model}
         renderMime={this._renderMime}
         settings={this._settings}
+        filebrowser={this._filebrowser}
       />
     );
   }
@@ -39,4 +43,5 @@ export class GitWidget extends ReactWidget {
   private _model: GitExtension;
   private _renderMime: IRenderMimeRegistry;
   private _settings: ISettingRegistry.ISettings;
+  private _filebrowser: FileBrowser;
 }

--- a/src/widgets/GitWidget.tsx
+++ b/src/widgets/GitWidget.tsx
@@ -6,7 +6,7 @@ import { GitPanel } from '../components/GitPanel';
 import { GitExtension } from '../model';
 import { gitWidgetStyle } from '../style/GitWidgetStyle';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { FileBrowser } from '@jupyterlab/filebrowser';
+import { FileBrowserModel } from '@jupyterlab/filebrowser';
 
 /**
  * A class that exposes the git plugin Widget.
@@ -16,7 +16,7 @@ export class GitWidget extends ReactWidget {
     model: GitExtension,
     settings: ISettingRegistry.ISettings,
     renderMime: IRenderMimeRegistry,
-    filebrowser: FileBrowser,
+    filebrowser: FileBrowserModel,
     options?: Widget.IOptions
   ) {
     super(options);
@@ -43,5 +43,5 @@ export class GitWidget extends ReactWidget {
   private _model: GitExtension;
   private _renderMime: IRenderMimeRegistry;
   private _settings: ISettingRegistry.ISettings;
-  private _filebrowser: FileBrowser;
+  private _filebrowser: FileBrowserModel;
 }

--- a/tests/test-components/GitPanel.spec.tsx
+++ b/tests/test-components/GitPanel.spec.tsx
@@ -79,7 +79,8 @@ describe('GitPanel', () => {
     const props: IGitSessionNodeProps = {
       model: null,
       renderMime: null,
-      settings: null
+      settings: null,
+      filebrowser: null
     };
 
     beforeEach(async () => {


### PR DESCRIPTION
Closes: https://github.com/jupyterlab/jupyterlab-git/issues/589

New UI:
![image](https://user-images.githubusercontent.com/10111092/79645238-12d38000-817c-11ea-9a3b-37f6a7e665d4.png)

I think this still needs some work on where to put and how to style the file path. The two big issues are:
1. If you are in the jupyter root directory the file path looks weird:
![image](https://user-images.githubusercontent.com/10111092/79645265-3ac2e380-817c-11ea-8614-bbb32a2cf5ce.png)
I didn't see an easy way to get the absolute file path from the filebrowser in order to get the folder name in this case.

2. A really long folder name renders poorly
![image](https://user-images.githubusercontent.com/10111092/79645293-752c8080-817c-11ea-85a5-9f274727e38e.png)


I briefly explored the suggestion of replacing the Current Repository header with the name of the current repo but didn't see a super easy way to do this. 

### Better styling ideas:

Maybe just don't list the name of the current folder. i.e. say: "You aren't currently in a git repository you can either ...."

Or: style the filepath text differently and limit its length.

### Slow refresh:
I also found that sometimes the filepath can be slow to update:
![slow](https://user-images.githubusercontent.com/10111092/79651606-6eebd380-817f-11ea-9956-bebe17e09ba2.gif)
![slow2](https://user-images.githubusercontent.com/10111092/79651610-6f846a00-817f-11ea-99b2-127db9b21447.gif)

### Adding a clone button
If https://github.com/jupyterlab/jupyterlab-git/pull/596 gets merged then it would be nice to add a third button for cloning to this interface.