### PR TITLE
sort master branch to be second in the new branch dialog

### DIFF
--- a/src/components/NewBranchDialog.tsx
+++ b/src/components/NewBranchDialog.tsx
@@ -236,6 +236,11 @@ export class NewBranchDialog extends React.Component<
       } else if (b.name === current) {
         return 1;
       }
+      if (a.name === 'master') {
+        return -1;
+      } else if (b.name === 'master') {
+        return 1;
+      }
       return 0;
     }
   }


### PR DESCRIPTION
closes: https://github.com/jupyterlab/jupyterlab-git/issues/595

The order in the new branch dialog will now be:
- Current branch (if different from master)
- master (if it exists)
- rest of branches