### PR TITLE
[WIP] Add merging functionality and UI

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -732,6 +732,18 @@ class Git:
             return {"code": code, "command": " ".join(cmd), "message": error}
         return {"code": code}
 
+    async def merge(self, merge_from, top_repo_path):
+        """
+        Execute git merge command & return the result.
+        """
+        cmd = ["git", "merge", merge_from]
+        code, output, error = await execute(cmd, cwd=top_repo_path)
+
+        if code != 0:
+            return {"code": code, "command": " ".join(cmd), "message": error}
+        return {"code": 0}
+
+
     async def commit(self, commit_msg, top_repo_path):
         """
         Execute git commit <filename> command & return the result.

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -367,6 +367,25 @@ class GitCheckoutHandler(GitHandler):
         self.finish(json.dumps(body))
 
 
+class GitMergeHandler(GitHandler):
+    """
+    Handler for git merge '<merge_from> <merge_into>'. Merges into current working branch
+    """
+    @web.authenticated
+    async def post(self):
+        """
+        POST request handler, merges branches
+        """
+        data = self.get_json_body()
+        merge_from = data["merge_from"]
+        top_repo_path = data["top_repo_path"]
+        body = await self.git.merge(merge_from, top_repo_path)
+
+        if body["code"] != 0:
+            self.set_status(500)
+        self.finish(json.dumps(body))
+
+
 class GitCommitHandler(GitHandler):
     """
     Handler for 'git commit -m <message>'. Commits files.
@@ -557,6 +576,7 @@ def setup_handlers(web_app):
         ("/git/branch", GitBranchHandler),
         ("/git/changed_files", GitChangedFilesHandler),
         ("/git/checkout", GitCheckoutHandler),
+        ("/git/merge", GitMergeHandler),
         ("/git/clone", GitCloneHandler),
         ("/git/commit", GitCommitHandler),
         ("/git/config", GitConfigHandler),

--- a/src/components/BranchDialog.tsx
+++ b/src/components/BranchDialog.tsx
@@ -237,15 +237,22 @@ export class BranchDialog extends React.Component<
     );
   }
   private _renderMergeButton() {
+    let disabled = this.state.base === this.state.current;
     return (
       <button
         className={classes(buttonClass, performMergeClass)}
         type="button"
         title="Merge into current branch."
-        disabled={this.state.base === this.state.current}
+        disabled={disabled}
         onClick={this._onMerge}
       >
-        merge <b>{this.state.base}</b> into <b>{this.state.current}</b>
+        {disabled ? (
+          'Please select a branch'
+        ) : (
+          <div>
+            merge <b>{this.state.base}</b> into <b>{this.state.current}</b>
+          </div>
+        )}
       </button>
     );
   }

--- a/src/components/BranchDialog.tsx
+++ b/src/components/BranchDialog.tsx
@@ -435,7 +435,7 @@ export class BranchDialog extends React.Component<
    * @param event - event object
    */
   private _onMerge = (): void => {
-    const branch = this.state.name;
+    const branch = this.state.base;
 
     // Close the branch dialog:
     this.props.onClose();
@@ -477,9 +477,6 @@ export class BranchDialog extends React.Component<
    * @param branch - branch name
    */
   private _createBranch(branch: string): void {
-    if (branch === ''){
-      showErrorMessage('You need to give the branch a name','')
-    }
     const opts = {
       newBranch: true,
       branchname: branch
@@ -512,16 +509,10 @@ export class BranchDialog extends React.Component<
     }
   }
   private _mergeBranch(branch: string): void {
-    const opts = {
-      newBranch: true,
-      branchname: branch
-    };
-    console.log(opts);
-    console.log('gotta implement git merge!');
-    //    this.props.model
-    //    .merge(opts)
-    //   .then(onResolve)
-    //  .catch(onError);
+    this.props.model
+      .merge(branch)
+      .then(onResolve)
+      .catch(onError);
 
     /**
      * Callback invoked upon promise resolution.
@@ -529,21 +520,20 @@ export class BranchDialog extends React.Component<
      * @private
      * @param result - result
      */
-    /*function onResolve(result: any): void {
+    function onResolve(result: any): void {
       if (result.code !== 0) {
-        showErrorMessage('Error creating branch', result.message);
+        showErrorMessage('Error merging branch', result.message);
       }
     }
-*/
+
     /**
      * Callback invoked upon encountering an error.
      *
      * @private
      * @param err - error
      */
-    /*  function onError(err: any): void {
-      showErrorMessage('Error creating branch', err.message);
+    function onError(err: any): void {
+      showErrorMessage('Error merging branch', err.message);
     }
-    */
   }
 }

--- a/src/components/BranchDialog.tsx
+++ b/src/components/BranchDialog.tsx
@@ -10,7 +10,6 @@ import { Git, IGitExtension } from '../tokens';
 import {
   actionsWrapperClass,
   activeListItemClass,
-  branchDialogClass,
   buttonClass,
   cancelButtonClass,
   closeButtonClass,
@@ -27,7 +26,9 @@ import {
   listItemIconClass,
   listItemTitleClass,
   listWrapperClass,
+  mergeDialogClass,
   nameInputClass,
+  newBranchDialogClass,
   performMergeClass,
   titleClass,
   titleWrapperClass
@@ -142,10 +143,11 @@ export class BranchDialog extends React.Component<
    * @returns React element
    */
   render(): React.ReactElement {
+    let dialogClass = this.props.mergeDialog ? mergeDialogClass : newBranchDialogClass
     return (
       <Dialog
         classes={{
-          paper: branchDialogClass
+          paper: dialogClass 
         }}
         open={this.props.open}
         onClose={this._onClose}

--- a/src/components/BranchMenu.tsx
+++ b/src/components/BranchMenu.tsx
@@ -15,9 +15,10 @@ import {
   listItemIconClass,
   listWrapperClass,
   newBranchButtonClass,
+  mergeBranchButtonClass,
   wrapperClass
 } from '../style/BranchMenu';
-import { NewBranchDialog } from './NewBranchDialog';
+import { BranchDialog } from './BranchDialog';
 
 const CHANGES_ERR_MSG =
   'The current branch contains files with uncommitted changes. Please commit or discard these changes before switching to or creating another branch.';
@@ -47,9 +48,14 @@ export interface IBranchMenuState {
   filter: string;
 
   /**
-   * Boolean indicating whether to show a dialog to create a new branch.
+   * Boolean indicating whether to show a dialog to create or merge branches.
    */
   branchDialog: boolean;
+
+  /**
+   * Boolean indicating whether the branch dialog should be used for merging.
+   */
+  mergeDialog: boolean;
 
   /**
    * Current branch name.
@@ -83,6 +89,7 @@ export class BranchMenu extends React.Component<
     this.state = {
       filter: '',
       branchDialog: false,
+      mergeDialog: false,
       current: repo ? this.props.model.currentBranch.name : '',
       branches: repo ? this.props.model.branches : []
     };
@@ -141,10 +148,19 @@ export class BranchMenu extends React.Component<
         <div className={listWrapperClass}>
           <List disablePadding>{this._renderItems()}</List>
         </div>
-        <NewBranchDialog
+        <button
+          className={mergeBranchButtonClass}
+          type="button"
+          title="Merge a branch into the current branch"
+          onClick={this._onMergeBranchClick}
+        >
+          Choose a branch to merge into <b>{this.state.current}</b>
+        </button>
+        <BranchDialog
           open={this.state.branchDialog}
           model={this.props.model}
           onClose={this._onNewBranchDialogClose}
+          mergeDialog={this.state.mergeDialog}
         />
       </div>
     );
@@ -252,6 +268,13 @@ export class BranchMenu extends React.Component<
       return;
     }
     this.setState({
+      mergeDialog: false,
+      branchDialog: true
+    });
+  };
+  private _onMergeBranchClick = (): void => {
+    this.setState({
+      mergeDialog: true,
       branchDialog: true
     });
   };
@@ -261,6 +284,7 @@ export class BranchMenu extends React.Component<
    */
   private _onNewBranchDialogClose = (): void => {
     this.setState({
+      mergeDialog: false,
       branchDialog: false
     });
   };

--- a/src/model.ts
+++ b/src/model.ts
@@ -468,6 +468,31 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
+   * Merge a branch into the current branch
+   *
+   * @param branch The branch to merge into the current branch
+   */
+  async merge(branch: string): Promise<Response> {
+    try {
+      let response = await httpGitRequest('/git/merge', 'POST', {
+        merge_from: branch,
+        top_repo_path: this.pathRepository
+      });
+      if (response.status !== 200) {
+        return response.json().then((data: any) => {
+          throw new ServerConnection.ResponseError(response, data.message);
+        });
+      }
+
+      await this.refreshStatus();
+
+      return response.json();
+    } catch (err) {
+      throw new ServerConnection.NetworkError(err);
+    }
+  }
+
+  /**
    * Make request for the Git Clone API.
    *
    * @param path Local path in which the repository will be cloned

--- a/src/style/BranchDialog.ts
+++ b/src/style/BranchDialog.ts
@@ -49,7 +49,11 @@ export const titleWrapperClass = style({
 });
 
 export const titleClass = style({
-  fontWeight: 700
+  fontWeight: 700,
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  width: '90%'
 });
 
 export const contentWrapperClass = style({
@@ -254,6 +258,19 @@ export const buttonClass = style({
 
 export const cancelButtonClass = style({
   backgroundColor: '#757575'
+});
+
+export const performMergeClass = style({
+  backgroundColor: 'var(--jp-brand-color1)',
+  width: '100%',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  $nest: {
+    '&:disabled': {
+      backgroundColor: 'black'
+    }
+  }
 });
 
 export const createButtonClass = style({

--- a/src/style/BranchDialog.ts
+++ b/src/style/BranchDialog.ts
@@ -268,7 +268,7 @@ export const performMergeClass = style({
   textOverflow: 'ellipsis',
   $nest: {
     '&:disabled': {
-      backgroundColor: 'black'
+      opacity: "0.3"
     }
   }
 });

--- a/src/style/BranchDialog.ts
+++ b/src/style/BranchDialog.ts
@@ -1,7 +1,17 @@
 import { style } from 'typestyle';
 
-export const branchDialogClass = style({
+export const newBranchDialogClass = style({
   height: '460px',
+  width: '400px',
+
+  color: 'var(--jp-ui-font-color1)!important',
+
+  borderRadius: '3px!important',
+
+  backgroundColor: 'var(--jp-layout-color1)!important'
+});
+export const mergeDialogClass = style({
+  height: '400px',
   width: '400px',
 
   color: 'var(--jp-ui-font-color1)!important',
@@ -268,7 +278,7 @@ export const performMergeClass = style({
   textOverflow: 'ellipsis',
   $nest: {
     '&:disabled': {
-      opacity: "0.3"
+      opacity: '0.3'
     }
   }
 });

--- a/src/style/BranchMenu.ts
+++ b/src/style/BranchMenu.ts
@@ -94,6 +94,25 @@ export const newBranchButtonClass = style({
   borderRadius: '3px'
 });
 
+export const mergeBranchButtonClass = style({
+  boxSizing: 'border-box',
+
+  width: '100%',
+  height: '2em',
+
+  color: 'white',
+  fontSize: 'var(--jp-ui-font-size1)',
+
+  backgroundColor: 'var(--jp-brand-color1)',
+  border: '0',
+  borderRadius: '3px',
+
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  textAlign: 'center'
+});
+
 export const listWrapperClass = style({
   display: 'block',
   width: '100%',

--- a/src/style/BranchMenu.ts
+++ b/src/style/BranchMenu.ts
@@ -107,6 +107,8 @@ export const mergeBranchButtonClass = style({
   border: '0',
   borderRadius: '3px',
 
+  borderTop:
+    'var(--jp-border-width) solid var(--jp-border-color2)!important',
   overflow: 'hidden',
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -134,6 +134,13 @@ export interface IGitExtension extends IDisposable {
   checkout(options?: Git.ICheckoutOptions): Promise<Git.ICheckoutResult>;
 
   /**
+   * Make a request to the Git Merge API.
+   *
+   * @param branch to merge into the current branch
+   */
+  merge(branch: string): Promise<Response>;
+
+  /**
    * Make request for the Git Clone API.
    *
    * @param path Local path in which the repository will be cloned


### PR DESCRIPTION
https://github.com/jupyterlab/jupyterlab-git/issues/310

This PR is an attempt to implement a merging UI similar to what github desktop has. I don't think it's complete but wanted to put it here for any feedback so that if I'm going in the wrong direction I can stop that sooner rather than later. In particular, before I go about writing tests and such. 

I drew pretty heavily from the github desktop UI, but didn't replicate their pre-emptive checking of if a merge is conflict free. Though this looks like it could be figured out with a series of git commands: https://stackoverflow.com/questions/501407/is-there-a-git-merge-dry-run-option

Here's the current UI, I think my one big worry is that was I was too invasive in modifying the existing `newBranchDialog` and should have just made a mergeDialog object. (To be clear the actual UI of the `newBranchDialog` is unchanged)

**Button in BranchMenu to trigger a dialog**:
![image](https://user-images.githubusercontent.com/10111092/79679006-c7e35800-81cf-11ea-8aed-fa6394eba7f0.png)

**Dialog that pops up**:
Before a branch is selected:
![image](https://user-images.githubusercontent.com/10111092/79679024-09740300-81d0-11ea-811f-fca5a8e4be4e.png)

After a branch is selected:
![image](https://user-images.githubusercontent.com/10111092/79679026-1133a780-81d0-11ea-92a3-41c415b0cfcb.png)

**merge conflict**:
The error reporting here could definitely use some work. I think using something other than the default error box will allow for better listing of the files that were the problem.

![failed-merge](https://user-images.githubusercontent.com/10111092/79679180-910e4180-81d1-11ea-9551-e9b117fbac34.gif)

#### merge settings
I just wrote the merge command as `git merge branch` and didn't play arround with the other arguments like `-ff`. I also didn't try to extract the diff stat that merge ouputs in order to display it somewhere because this would have necessitated popping up another dialog.