### PR TITLE
Update git-icon svg width/height size

### DIFF
--- a/style/images/git-icon.svg
+++ b/style/images/git-icon.svg
@@ -10,8 +10,8 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    xml:space="preserve"
-   width="114.8625"
-   height="114.8625"
+   width="20"
+   height="20"
    viewBox="0 0 114.8625 114.8625"
    sodipodi:docname="Git-Icon-Black.svg">
    <metadata id="metadata8">


### PR DESCRIPTION
In git-icon.svg it had hard coded width/height of 114.8625. Changed to standard size of 20.

Fixes #604 