### PR TITLE
show both staged and unstaged changes for a file

### DIFF
--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -34,6 +34,7 @@ export interface IFileItemProps {
   onDoubleClick: () => void;
   selected?: boolean;
   selectFile?: (file: Git.IStatusFile | null) => void;
+  staged?: boolean;
 }
 
 export interface IGitMarkBoxProps {
@@ -74,9 +75,10 @@ export class FileItem extends React.Component<IFileItemProps> {
   }
 
   render() {
-    const status =
-      this.getFileChangedLabel(this.props.file.y as any) ||
-      this.getFileChangedLabel(this.props.file.x as any);
+    const status_code = this.props.staged
+      ? this.props.file.x
+      : this.props.file.y;
+    const status = this.getFileChangedLabel(status_code as any);
 
     return (
       <li
@@ -110,9 +112,7 @@ export class FileItem extends React.Component<IFileItemProps> {
         />
         {this.props.actions}
         <span className={this.getFileChangedLabelClass(this.props.file.y)}>
-          {this.props.file.y === '?'
-            ? 'U'
-            : this.props.file.y.trim() || this.props.file.x}
+          {this.props.file.y === '?' ? 'U' : status_code}
         </span>
       </li>
     );

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -34,7 +34,6 @@ export interface IFileItemProps {
   onDoubleClick: () => void;
   selected?: boolean;
   selectFile?: (file: Git.IStatusFile | null) => void;
-  staged?: boolean;
 }
 
 export interface IGitMarkBoxProps {
@@ -75,9 +74,8 @@ export class FileItem extends React.Component<IFileItemProps> {
   }
 
   render() {
-    const status_code = this.props.staged
-      ? this.props.file.x
-      : this.props.file.y;
+    const { file } = this.props;
+    const status_code = file.status === 'staged' ? file.x : file.y;
     const status = this.getFileChangedLabel(status_code as any);
 
     return (

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -628,6 +628,14 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
                   onClick={openFile}
                 />
                 {diffButton}
+                <ActionButton
+                  className={hiddenButtonStyle}
+                  iconName={'git-discard'}
+                  title={'Discard changes'}
+                  onClick={() => {
+                    this.discardChanges(file);
+                  }}
+                />
               </React.Fragment>
             );
             onDoubleClick = doubleClickDiff

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -44,6 +44,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     this._contextMenuStaged = new Menu({ commands });
     this._contextMenuUnstaged = new Menu({ commands });
     this._contextMenuUntracked = new Menu({ commands });
+    this._contextMenuSimpleUntracked = new Menu({ commands });
+    this._contextMenuSimpleTracked = new Menu({ commands });
 
     this.state = {
       selectedFile: null
@@ -159,6 +161,18 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     [CommandIDs.gitFileOpen, CommandIDs.gitFileTrack].forEach(command => {
       this._contextMenuUntracked.addItem({ command });
     });
+
+    [
+      CommandIDs.gitFileOpen,
+      CommandIDs.gitFileDiscard,
+      CommandIDs.gitFileDiffWorking
+    ].forEach(command => {
+      this._contextMenuSimpleTracked.addItem({ command });
+    });
+
+    [CommandIDs.gitFileOpen].forEach(command => {
+      this._contextMenuSimpleUntracked.addItem({ command });
+    });
   }
 
   /** Handle right-click on a staged file */
@@ -177,6 +191,18 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   contextMenuUntracked = (event: React.MouseEvent) => {
     event.preventDefault();
     this._contextMenuUntracked.open(event.clientX, event.clientY);
+  };
+
+  /** Handle right-click on an untracked file in Simple mode*/
+  contextMenuSimpleUntracked = (event: React.MouseEvent) => {
+    event.preventDefault();
+    this._contextMenuSimpleUntracked.open(event.clientX, event.clientY);
+  };
+
+  /** Handle right-click on an tracked file in Simple mode*/
+  contextMenuSimpleTracked = (event: React.MouseEvent) => {
+    event.preventDefault();
+    this._contextMenuSimpleTracked.open(event.clientX, event.clientY);
   };
 
   /** Reset all staged files */
@@ -588,6 +614,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
             ? (): void => undefined
             : openFile;
 
+          let contextMenu = this.contextMenuSimpleUntracked;
+
           if (
             file.status === 'unstaged' ||
             file.status === 'partially-staged'
@@ -617,6 +645,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
                 ? () => this._openDiffView(file, 'WORKING')
                 : () => undefined
               : openFile;
+            contextMenu = this.contextMenuSimpleTracked;
           } else if (file.status === 'staged') {
             const diffButton = this._createDiffButton(file, 'INDEX');
             actions = (
@@ -643,6 +672,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
                 ? () => this._openDiffView(file, 'INDEX')
                 : () => undefined
               : openFile;
+            contextMenu = this.contextMenuSimpleTracked;
           }
 
           return (
@@ -653,6 +683,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               markBox={true}
               model={this.props.model}
               onDoubleClick={onDoubleClick}
+              contextMenu={contextMenu}
+              selectFile={this.updateSelectedFile}
             />
           );
         })}
@@ -712,4 +744,6 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   private _contextMenuStaged: Menu;
   private _contextMenuUnstaged: Menu;
   private _contextMenuUntracked: Menu;
+  private _contextMenuSimpleTracked: Menu;
+  private _contextMenuSimpleUntracked: Menu;
 }

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -297,9 +297,15 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           case 'untracked':
             untrackedFiles.push(file);
             break;
-          case 'staged-and-unstaged':
-            stagedFiles.push(file);
-            unstagedFiles.push(file);
+          case 'partially-staged':
+            stagedFiles.push({
+              ...file,
+              status: 'staged'
+            });
+            unstagedFiles.push({
+              ...file,
+              status: 'unstaged'
+            });
             break;
 
           default:
@@ -329,7 +335,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       this.state.selectedFile.x === candidate.x &&
       this.state.selectedFile.y === candidate.y &&
       this.state.selectedFile.from === candidate.from &&
-      this.state.selectedFile.to === candidate.to
+      this.state.selectedFile.to === candidate.to &&
+      this.state.selectedFile.status === candidate.status
     );
   }
 
@@ -579,7 +586,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           let actions = null;
           if (
             file.status === 'unstaged' ||
-            file.status === 'staged-and-unstaged'
+            file.status === 'partially-staged'
           ) {
             actions = (
               <React.Fragment>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -297,6 +297,10 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           case 'untracked':
             untrackedFiles.push(file);
             break;
+          case 'staged-and-unstaged':
+            stagedFiles.push(file);
+            unstagedFiles.push(file);
+            break;
 
           default:
             break;
@@ -557,14 +561,13 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           };
 
           // Default value for actions and double click
-          let actions: JSX.Element = (
-            <ActionButton
-              className={hiddenButtonStyle}
-              iconName={'open-file'}
-              title={'Open this file'}
-              onClick={openFile}
-            />
-          );
+          // let actions: JSX.Element = ( <ActionButton
+          //     className={hiddenButtonStyle}
+          //     iconName={'open-file'}
+          //     title={'Open this file'}
+          //     onClick={openFile}
+          //   />
+          // );
           let onDoubleClick = doubleClickDiff
             ? (): void => undefined
             : openFile;
@@ -572,6 +575,12 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           let diffButton: JSX.Element;
           if (file.status === 'unstaged') {
             diffButton = this._createDiffButton(file, 'WORKING');
+          }
+          let actions = null;
+          if (
+            file.status === 'unstaged' ||
+            file.status === 'staged-and-unstaged'
+          ) {
             actions = (
               <React.Fragment>
                 <ActionButton

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -247,8 +247,13 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     });
     if (result.button.accept) {
       try {
-        await this.props.model.reset(file.to);
-        if (file.x !== 'A') {
+        if (file.status === 'staged' || file.status === 'partially-staged') {
+          await this.props.model.reset(file.to);
+        }
+        if (
+          file.status === 'unstaged' ||
+          (file.status === 'partially-staged' && file.x !== 'A')
+        ) {
           // resetting an added file moves it to untracked category => checkout will fail
           await this.props.model.checkout({ filename: file.to });
         }

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -418,11 +418,15 @@ export class GitPanel extends React.Component<
   }
 
   private _hasStagedFile(): boolean {
-    return this.state.files.some(file => file.status === 'staged');
+    return this.state.files.some(
+      file => file.status === 'staged' || file.status === 'partially-staged'
+    );
   }
 
   private _hasUnStagedFile(): boolean {
-    return this.state.files.some(file => file.status === 'unstaged');
+    return this.state.files.some(
+      file => file.status === 'unstaged' || file.status === 'partially-staged'
+    );
   }
 
   /**

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -497,6 +497,6 @@ export namespace Git {
     | 'untracked'
     | 'staged'
     | 'unstaged'
-    | 'staged-and-unstaged'
+    | 'partially-staged'
     | null;
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -493,5 +493,10 @@ export namespace Git {
     toggle(fname: string): void;
   }
 
-  export type Status = 'untracked' | 'staged' | 'unstaged' | null;
+  export type Status =
+    | 'untracked'
+    | 'staged'
+    | 'unstaged'
+    | 'staged-and-unstaged'
+    | null;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,12 +40,8 @@ export function decodeStage(x: string, y: string): Git.Status {
     return 'untracked';
   } else {
     // If file is staged
-    if (x !== ' ' && y !== 'D') {
-      if (y !== ' ') {
-        return 'partially-staged';
-      } else {
-        return 'staged';
-      }
+    if (x !== ' ') {
+      return y !== ' ' ? 'partially-staged' : 'staged';
     }
     // If file is unstaged but tracked
     if (y !== ' ') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export function decodeStage(x: string, y: string): Git.Status {
     // If file is staged
     if (x !== ' ' && y !== 'D') {
       if (y !== ' ') {
-        return 'staged-and-unstaged';
+        return 'partially-staged';
       } else {
         return 'staged';
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,11 @@ export function decodeStage(x: string, y: string): Git.Status {
   } else {
     // If file is staged
     if (x !== ' ' && y !== 'D') {
-      return 'staged';
+      if (y !== ' ') {
+        return 'staged-and-unstaged';
+      } else {
+        return 'staged';
+      }
     }
     // If file is unstaged but tracked
     if (y !== ' ') {

--- a/tests/test-components/FileList.spec.tsx
+++ b/tests/test-components/FileList.spec.tsx
@@ -4,7 +4,7 @@ import 'jest';
 import { GitExtension } from '../../src/model';
 import { FileList } from '../../src/components/FileList';
 
-import * as git from '../../src/git';
+import { httpGitRequest } from '../../src/git';
 
 jest.mock('../../src/git');
 jest.mock('@jupyterlab/apputils');
@@ -74,8 +74,10 @@ describe('FileList', () => {
         };
       });
 
-      const mock = git as jest.Mocked<typeof git>;
-      mock.httpGitRequest.mockImplementation(request);
+      const mockRequest = httpGitRequest as jest.MockedFunction<
+        typeof httpGitRequest
+      >;
+      mockRequest.mockImplementation(request);
 
       model = await createModel();
     });

--- a/tests/test-components/FileList.spec.tsx
+++ b/tests/test-components/FileList.spec.tsx
@@ -1,0 +1,131 @@
+import { showDialog } from '@jupyterlab/apputils';
+import { CommandRegistry } from '@lumino/commands';
+import 'jest';
+import { GitExtension } from '../../src/model';
+import { FileList } from '../../src/components/FileList';
+
+import * as git from '../../src/git';
+
+jest.mock('../../src/git');
+jest.mock('@jupyterlab/apputils');
+jest.mock('@lumino/commands');
+
+function request(url: string, method: string, request: Object | null) {
+  let response: Response;
+  switch (url) {
+    case '/git/branch':
+      response = new Response(
+        JSON.stringify({
+          code: 0,
+          branches: [],
+          current_branch: null
+        })
+      );
+      break;
+    case '/git/server_root':
+      response = new Response(
+        JSON.stringify({
+          server_root: '/foo'
+        })
+      );
+      break;
+    case '/git/show_top_level':
+      response = new Response(
+        JSON.stringify({
+          code: 0,
+          top_repo_path: (request as any)['current_path']
+        })
+      );
+      break;
+    case '/git/status':
+      response = new Response(
+        JSON.stringify({
+          code: 0,
+          files: []
+        })
+      );
+      break;
+    default:
+      response = new Response(
+        `{"message": "No mock implementation for ${url}."}`,
+        { status: 404 }
+      );
+  }
+  return Promise.resolve(response);
+}
+
+async function createModel() {
+  const model = new GitExtension();
+  model.pathRepository = '/path/to/repo';
+  const mockedCommands = jest.spyOn(model, 'commands', 'get');
+  mockedCommands.mockImplementation(() => new CommandRegistry());
+
+  await model.ready;
+  return model;
+}
+
+describe('FileList', () => {
+  describe('#discardChanges', () => {
+    let model: GitExtension;
+    beforeAll(async () => {
+      (CommandRegistry as any).mockImplementation(() => {
+        return {
+          hasCommand: () => true
+        };
+      });
+
+      const mock = git as jest.Mocked<typeof git>;
+      mock.httpGitRequest.mockImplementation(request);
+
+      model = await createModel();
+    });
+
+    [' ', 'M', 'A'].forEach(x => {
+      it(`should reset${x !== 'A' ? ' and checkout' : ''}`, async () => {
+        const mockDialog = showDialog as jest.MockedFunction<typeof showDialog>;
+        mockDialog.mockResolvedValue({
+          button: {
+            accept: true,
+            caption: '',
+            className: '',
+            displayType: 'default',
+            iconClass: '',
+            iconLabel: '',
+            label: ''
+          },
+          value: undefined
+        });
+        const spyReset = jest.spyOn(model, 'reset');
+        spyReset.mockResolvedValueOnce(undefined);
+        const spyCheckout = jest.spyOn(model, 'checkout');
+        spyReset.mockResolvedValueOnce(undefined);
+
+        const path = 'file/path.ext';
+
+        const component = new FileList({
+          model,
+          files: [],
+          renderMime: null,
+          settings: null
+        });
+        await component.discardChanges({
+          x,
+          y: ' ',
+          from: 'from',
+          to: path,
+          status: 'staged',
+          is_binary: false
+        });
+        expect(spyReset).toHaveBeenCalledWith(path);
+        if (x !== 'A') {
+          expect(spyCheckout).toHaveBeenCalledWith({ filename: path });
+        } else {
+          expect(spyCheckout).not.toHaveBeenCalled();
+        }
+
+        spyReset.mockRestore();
+        spyCheckout.mockRestore();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/jupyterlab/jupyterlab-git/issues/627

As discussed in the issue if you have both staged and unstaged changes to a file:
![image](https://user-images.githubusercontent.com/10111092/80768706-1cb09800-8b19-11ea-8f45-aa7abf70da75.png)

then the file will only show in the Staged Files list in jupyterlab-git. 

I added another option to the Status token that accounts for this state and modified the FileList and FileItem accordingly. Note how the same file appears in both Staged and Unstaged lists with different status codes, and these give different results for the diff.
![staged-unstaged](https://user-images.githubusercontent.com/10111092/80768868-9183d200-8b19-11ea-9712-71808b18d60e.gif)

When you select one instance of the file both list items are selected. I can't decide if this is a feature or a bug. But it seems that this didn't affected any of the context menu commands that depend on tracking which file is selected.

In simple staging mode it reduces to showing the diff from WORKING to HEAD:
![image](https://user-images.githubusercontent.com/10111092/80770656-d52d0a80-8b1e-11ea-863b-c6738e8a2ddb.png)
