### PR TITLE
Fix #551

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ cd jupyterlab-git
 
 # Install the server extension in development mode and enable it
 pip install -e .[test]
-jupyter serverextension enable --py jupyterlab_git
+jupyter serverextension enable --py jupyterlab_git --sys-prefix
 
 # Build the labextension and dev-mode link it to jlab
-jlpm build
+jlpm
 jupyter labextension link .
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "build:labextension": "jlpm build && jlpm clean:labextension && mkdirp jupyterlab_git/labextension && cd jupyterlab_git/labextension && npm pack ../..",
+    "build:labextension": "jlpm && jlpm clean:labextension && mkdirp jupyterlab_git/labextension && cd jupyterlab_git/labextension && npm pack ../..",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
     "clean:more": "jlpm clean && rimraf build dist MANIFEST",
     "clean:labextension": "rimraf jupyterlab_git/labextension",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jupyterlab-extension"
   ],
   "scripts": {
-    "build": "jlpm install && tsc",
+    "build": "tsc",
     "build:labextension": "jlpm build && jlpm clean:labextension && mkdirp jupyterlab_git/labextension && cd jupyterlab_git/labextension && npm pack ../..",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
     "clean:more": "jlpm clean && rimraf build dist MANIFEST",
@@ -23,6 +23,7 @@
     "lint": "eslint . --ext .ts,.tsx --fix",
     "test": "jest",
     "eslint-check": "eslint . --ext .ts,.tsx",
+    "prepare": "jlpm run build",
     "watch": "tsc -w"
   },
   "files": [


### PR DESCRIPTION
To have install + build, just execute `jlpm`.

As the clean command is not set in the _prepare_ stage, this avoid multiple compilation (the reason it was remove in 49e3261e9214b27441f0d0e1de7d1a0aa674a600).