### PR TITLE
Duplicate prettier configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,9 +122,6 @@
       "git add"
     ]
   },
-  "prettier": {
-    "singleQuote": true
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jupyterlab/jupyterlab-git.git"


### PR DESCRIPTION
Prettier configuration is done through file .prettierrc and .prettierignore.

This should be removed.