### PR TITLE
Ease release through Github workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,21 +18,22 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.x'     
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install jupyterlab packaging setuptools twine wheel
     - name: Test version are matching
-      run: python -c "from release import assertEqualVersion; assertEqualVersion()" 
-    - name: Publish the NPM package
-      run: npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - name: Build and publish the Python package
+      run: python -c "from release import assertEqualVersion; assertEqualVersion()"
+    - name: Publish the Python package
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/jupyterlab_git-*
+        twine upload dist/*
+    - name: Publish the NPM package
+      run: |
+        npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'     
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install jupyterlab packaging setuptools twine wheel
+    - name: Test version are matching
+      run: python -c "from release import assertEqualVersion; assertEqualVersion()" 
+    - name: Publish the NPM package
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Build and publish the Python package
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/jupyterlab_git-*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,4 @@
- ## CI/CD: 
- - CD: Trigger releases on tags.
-   - **What?** Add CD capabilities to trigger a release when a tag is pushed.
-   - **Why?** Save maintainer manual effort on releases. Increase cadence of releases.
- - Combining the Python and JS files into one installable package
-   - **What?** Provide a single installation  for both the frontend and the server package
-   - **Why?** Reduce number of issues from users have different versions of the NPM and Python packages. Easier installation for users
+ ## CI/CD:
  - Integration Testing
    - **What?** Test suite that actually exercises UI and API against an actual Git repo without mocking out Git calls.
    - **Why?** Enables us to better test against an actual Git process. Stepping stone to x-OS testing such as Windows.

--- a/release.py
+++ b/release.py
@@ -2,10 +2,18 @@
 import argparse as argpar
 import json
 import subprocess
+from packaging.version import parse
 
 from setupbase import get_version
 
 VERSION_PY = 'jupyterlab_git/_version.py'
+
+def assertEqualVersion():
+    serverVersion = parse(serverExtensionVersion())
+    frontendVersion = parse(labExtensionVersion())
+
+    error_msg = "Frontend ({}) and server ({}) version do not match".format(frontendVersion, serverVersion)
+    assert serverVersion == frontendVersion, error_msg
 
 def prepLabextensionBundle():
     subprocess.run(['jlpm', 'clean:slate'])


### PR DESCRIPTION
@telamonian I propose this PR to ease the release; i.e. it will release each time a GitHub release is published (and a git tag will be also created) - the version of npm and Python are tested to avoid publishing non-matching packages.