### PR TITLE
Update Diffs when the underlying file is changed

### DIFF
--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -14,6 +14,7 @@ import { openDiffView } from './diff/DiffWidget';
 import { ISpecialRef } from './diff/model';
 import { FileItem } from './FileItem';
 import { GitStage } from './GitStage';
+import { FileBrowserModel } from '@jupyterlab/filebrowser';
 
 export namespace CommandIDs {
   export const gitFileOpen = 'git:context-open';
@@ -34,6 +35,7 @@ export interface IFileListProps {
   model: GitExtension;
   renderMime: IRenderMimeRegistry;
   settings: ISettingRegistry.ISettings;
+  filebrowser: FileBrowserModel;
 }
 
 export class FileList extends React.Component<IFileListProps, IFileListState> {
@@ -72,7 +74,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               previousRef: { gitRef: 'HEAD' }
             },
             this.props.renderMime,
-            !this.state.selectedFile.is_binary
+            !this.state.selectedFile.is_binary,
+            this.props.filebrowser
           );
         }
       });
@@ -91,7 +94,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               previousRef: { gitRef: 'HEAD' }
             },
             this.props.renderMime,
-            !this.state.selectedFile.is_binary
+            !this.state.selectedFile.is_binary,
+            this.props.filebrowser
           );
         }
       });
@@ -673,7 +677,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           currentRef: { specialRef: currentRef }
         },
         this.props.renderMime,
-        !file.is_binary
+        !file.is_binary,
+        this.props.filebrowser
       );
     } catch (reason) {
       console.error(`Failed to open diff view for ${file.to}.\n${reason}`);

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -264,6 +264,7 @@ export class GitPanel extends React.Component<
           model={this.props.model}
           renderMime={this.props.renderMime}
           settings={this.props.settings}
+          filebrowser={this.props.filebrowser}
         />
         {this.props.settings.composite['simpleStaging'] ? (
           <CommitBox

--- a/src/components/diff/Diff.tsx
+++ b/src/components/diff/Diff.tsx
@@ -53,7 +53,7 @@ export function Diff(props: IDiffProps) {
     try {
       return <PlainTextDiff {...props} />;
     } catch (error) {
-      console.log(`Unable to render diff view for ${props.path}:\n${error}`);
+      console.error(`Unable to render diff view for ${props.path}:\n${error}`);
       return null;
     }
   }

--- a/src/components/diff/DiffWidget.tsx
+++ b/src/components/diff/DiffWidget.tsx
@@ -39,24 +39,29 @@ export async function openDiffView(
     }
     if (!mainAreaItem) {
       const serverRepoPath = model.getRelativeFilePath();
-      const nbDiffWidget = ReactWidget.create(
-        <UseSignal
-          signal={filebrowser.fileChanged}
-          shouldUpdate={(sender, change) => {
-            return change.newValue.path === serverRepoPath + '/' + filePath;
-          }}
-        >
-          {(_, change) => (
-            <RenderMimeProvider value={renderMime}>
-              <Diff
-                path={filePath}
-                diffContext={diffContext}
-                topRepoPath={serverRepoPath}
-              />
-            </RenderMimeProvider>
-          )}
-        </UseSignal>
-      );
+      const innerWidget = function() {
+        return (
+          <RenderMimeProvider value={renderMime}>
+            <Diff
+              path={filePath}
+              diffContext={diffContext}
+              topRepoPath={serverRepoPath}
+            />
+          </RenderMimeProvider>
+        );
+      };
+      const nbDiffWidget = filebrowser
+        ? ReactWidget.create(
+            <UseSignal
+              signal={filebrowser.fileChanged}
+              shouldUpdate={(sender, change) => {
+                return change.newValue.path === serverRepoPath + '/' + filePath;
+              }}
+            >
+              {() => innerWidget()}
+            </UseSignal>
+          )
+        : ReactWidget.create(innerWidget());
       nbDiffWidget.id = id;
       nbDiffWidget.title.label = PathExt.basename(filePath);
       nbDiffWidget.title.iconClass = style({

--- a/src/components/diff/PlainTextDiff.tsx
+++ b/src/components/diff/PlainTextDiff.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { IDiffProps } from './Diff';
 import { httpGitRequest } from '../../git';
-import { mergeView } from './mergeview';
+import { mergeView, MergeView } from './mergeview';
 import { IDiffContext } from './model';
 
 interface ICurrentReference {
@@ -33,11 +33,8 @@ export class PlainTextDiff extends React.Component<
     this._mergeViewRef = React.createRef<HTMLDivElement>();
   }
 
-  componentDidMount() {
-    this._performDiff(this.props.diffContext);
-  }
-
   render() {
+    this._performDiff(this.props.diffContext);
     if (this.state.errorMessage !== null) {
       return (
         <div>
@@ -123,17 +120,23 @@ export class PlainTextDiff extends React.Component<
     const mode =
       Mode.findByFileName(this.props.path) || Mode.findBest(this.props.path);
 
-    mergeView(this._mergeViewRef.current, {
-      value: currContent,
-      orig: prevContent,
-      lineNumbers: true,
-      mode: mode.mime,
-      theme: 'jupyter',
-      connect: 'align',
-      collapseIdentical: true,
-      revertButtons: false
-    });
+    if (this._mergeView) {
+      this._mergeView.editor().setValue(currContent);
+      this._mergeView.left.forceUpdate('full');
+    } else {
+      this._mergeView = mergeView(this._mergeViewRef.current, {
+        value: currContent,
+        orig: prevContent,
+        lineNumbers: true,
+        mode: mode.mime,
+        theme: 'jupyter',
+        connect: 'align',
+        collapseIdentical: true,
+        revertButtons: false
+      });
+    }
   }
 
   private _mergeViewRef: React.RefObject<HTMLDivElement>;
+  private _mergeView: MergeView.IMergeViewEditor;
 }

--- a/src/components/diff/mergeview.ts
+++ b/src/components/diff/mergeview.ts
@@ -141,7 +141,7 @@ export namespace MergeView {
     /**
      * Forces the view to reload.
      */
-    forceUpdate(): (mode: string) => void;
+    forceUpdate(mode?: string): void;
 
     /**
      * Sets whether or not the merge view should show the differences between the editor views.


### PR DESCRIPTION
Partial fix for: https://github.com/jupyterlab/jupyterlab-git/issues/628
![update-plain-text-diff](https://user-images.githubusercontent.com/10111092/83984290-65baef80-a902-11ea-95d5-c0c7e53fd5bd.gif)
Following @fcollonval's suggestion I used the `<UseSignal>` component to trigger an update of the diff when the file is changed. 

However, thus I only fixed the updating for non-notebook files. The `NbDiff` `PerformDiff` method contains a `SetState` call https://github.com/jupyterlab/jupyterlab-git/blob/6169af07d306eb07f3aa034e042a103a772a7649/src/components/diff/NbDiff.tsx#L202-L204

so calling it inside of `render` results in an infinite loop :(
I thought of three ways to approach this issue but I'm unsure if any of them are appropriate solutions. Any input would be most welcome:

1. Follow `PlainTextDiff` approach and hold the `nbmodel` outside of the state as a private variable.
    - my sense is that this is an incorrect way to use React.
2. Wrap `nbdModel` in an object that implements an `update` method that could be called.
3. Don't use the `UseSignal` component and instead set up a listener to the signal in the constructor of the individual diff providers. 
     - This puts more onus on each diff provider but would remove the recalculation of diffs from the `render` method. 