### PR TITLE
Use install instead of link in dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ cd jupyterlab-git
 pip install -e .[test]
 jupyter serverextension enable --py jupyterlab_git --sys-prefix
 
-# Build the labextension and dev-mode link it to jlab
+# Build and install your development version of the extension
 jlpm
-jupyter labextension link .
+jupyter labextension install .
 ```
 
 To rebuild the package after a change and the JupyterLab app:


### PR DESCRIPTION
From discussion here https://gitter.im/jupyterlab/jupyterlab?at=5ee6abf324a3382d5d68b2ae I think that this extension should use install instead of link as it is not a core package

> I think it may be a mistake that the cookiecutter uses link. For most extension authoring, you should use jupyter labextension install. The link functionality is for times when you need to run JupyterLab itself from source or if you are working on an extension that should be in the core set of packages. I hope that helps!