### PR TITLE
FIx pushing when there are slashes in branch names or in remote name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:  
+  - '3.5'
   - '3.6'
   - '3.7'
   - '3.8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:  
-  - '3.5'
   - '3.6'
   - '3.7'
   - '3.8'

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -890,12 +890,12 @@ class Git:
         to the `branch` command to get the name.
         See https://git-blame.blogspot.com/2013/06/checking-current-branch-programatically.html
         """
-        command = ["git", "symbolic-ref", "HEAD"]
+        command = ["git", "symbolic-ref", "--short", "HEAD"]
         code, output, error = await execute(
             command, cwd=os.path.join(self.root_dir, current_path)
         )
         if code == 0:
-            return output.split("/")[-1].strip()
+            return output.strip()
         elif "not a symbolic ref" in error.lower():
             current_branch = await self._get_current_branch_detached(current_path)
             return current_branch
@@ -939,18 +939,22 @@ class Git:
         code, output, error = await execute(
             command, cwd=os.path.join(self.root_dir, current_path)
         )
-        if code == 0:
-            return output.strip()
-        elif "fatal: no upstream configured for branch" in error.lower():
-            return None
-        elif "unknown revision or path not in the working tree" in error.lower():
-            return None
-        else:
-            raise Exception(
-                "Error [{}] occurred while executing [{}] command to get upstream branch.".format(
-                    error, " ".join(command)
-                )
-            )
+        if code != 0:
+            return {"code": code, "command": " ".join(cmd), "message": error}
+        rev_parse_output = output.strip()
+
+        command = ["git", "config", "--local", f"branch.{branch_name}.remote"]
+        code, output, error = await execute(
+            command, cwd=os.path.join(self.root_dir, current_path)
+        )
+        if code != 0:
+            return {"code": code, "command": " ".join(cmd), "message": error}
+
+        remote_name = output.strip()
+        remote_branch = rev_parse_output.strip().lstrip(remote_name+"/")
+        return {"code": code, "remote_short_name": remote_name, "remote_branch": remote_branch}
+
+        
 
     async def _get_tag(self, current_path, commit_sha):
         """Execute 'git describe commit_sha' to get

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -943,7 +943,7 @@ class Git:
             return {"code": code, "command": " ".join(command), "message": error}
         rev_parse_output = output.strip()
 
-        command = ["git", "config", "--local", f"branch.{branch_name}.remote"]
+        command = ["git", "config", "--local", "branch.{}.remote".format(branch_name)]
         code, output, error = await execute(
             command, cwd=os.path.join(self.root_dir, current_path)
         )

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -940,7 +940,7 @@ class Git:
             command, cwd=os.path.join(self.root_dir, current_path)
         )
         if code != 0:
-            return {"code": code, "command": " ".join(cmd), "message": error}
+            return {"code": code, "command": " ".join(command), "message": error}
         rev_parse_output = output.strip()
 
         command = ["git", "config", "--local", f"branch.{branch_name}.remote"]

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -437,32 +437,28 @@ class GitPushHandler(GitHandler):
         current_path = data["current_path"]
 
         current_local_branch = await self.git.get_current_branch(current_path)
-        current_upstream_branch = await self.git.get_upstream_branch(
+        upstream = await self.git.get_upstream_branch(
             current_path, current_local_branch
         )
 
-        if current_upstream_branch and current_upstream_branch.strip():
-            upstream = current_upstream_branch.split("/")
-            if len(upstream) == 1:
-                # If upstream is a local branch
-                remote = "."
-                branch = ":".join(["HEAD", upstream[0]])
-            else:
-                # If upstream is a remote branch
-                remote = upstream[0]
-                branch = ":".join(["HEAD", upstream[1]])
-
+        if upstream['code'] == 0:
+            branch = ":".join(["HEAD", upstream['remote_branch']])
             response = await self.git.push(
-                remote, branch, current_path, data.get("auth", None)
+                upstream['remote_short_name'], branch, current_path, data.get("auth", None)
             )
 
         else:
-            response = {
-                "code": 128,
-                "message": "fatal: The current branch {} has no upstream branch.".format(
-                    current_local_branch
-                ),
-            }
+            if ("no upstream configured for branch" in upstream['message'].lower()
+                 or 'unknown revision or path' in upstream['message'].lower()):
+                response = {
+                    "code": 128,
+                    "message": "fatal: The current branch {} has no upstream branch.".format(
+                        current_local_branch
+                    ),
+                }
+            else:
+                self.set_status(500)
+
         self.finish(json.dumps(response))
 
 

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -401,8 +401,10 @@ class GitUpstreamHandler(GitHandler):
         """
         current_path = self.get_json_body()["current_path"]
         current_branch = await self.git.get_current_branch(current_path)
-        upstream = await self.git.get_upstream_branch(current_path, current_branch)
-        self.finish(json.dumps({"upstream": upstream}))
+        response = await self.git.get_upstream_branch(current_path, current_branch)
+        if response['code'] != 0:
+            self.set_status(500)
+        self.finish(json.dumps(upstream))
 
 
 class GitPullHandler(GitHandler):

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -404,7 +404,7 @@ class GitUpstreamHandler(GitHandler):
         response = await self.git.get_upstream_branch(current_path, current_branch)
         if response['code'] != 0:
             self.set_status(500)
-        self.finish(json.dumps(upstream))
+        self.finish(json.dumps(response))
 
 
 class GitPullHandler(GitHandler):

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -44,7 +44,7 @@ async def test_get_current_branch_success():
 
         # Then
         mock_execute.assert_called_once_with(
-            ["git", "symbolic-ref", "HEAD"], cwd=os.path.join("/bin", "test_curr_path")
+            ["git", "symbolic-ref", "--short", "HEAD"], cwd=os.path.join("/bin", "test_curr_path")
         )
         assert "feature-foo" == actual_response
 
@@ -337,11 +337,11 @@ async def test_get_current_branch_failure():
 
         # Then
         mock_execute.assert_called_once_with(
-            ["git", "symbolic-ref", "HEAD"], cwd=os.path.join("/bin", "test_curr_path")
+            ["git", "symbolic-ref", "--short", "HEAD"], cwd=os.path.join("/bin", "test_curr_path")
         )
         assert (
             "Error [fatal: Not a git repository (or any of the parent directories): .git] "
-            "occurred while executing [git symbolic-ref HEAD] command to get current branch."
+            "occurred while executing [git symbolic-ref --short HEAD] command to get current branch."
             == str(error.value)
         )
 
@@ -403,17 +403,20 @@ async def test_get_current_branch_detached_failure():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "branch,upstream",
+    "branch,upstream,remotename",
     [
-        ("feature-foo", "origin/master"),
-        ("master", "origin/master"),
-        ("feature-bar", "feature-foo"),
+        ("feature-foo", "master", "origin/withslash"),
+        ("master", "master", "origin"),
+        ("feature/bar", "feature-foo", ""),
     ],
 )
-async def test_get_upstream_branch_success(branch, upstream):
+async def test_get_upstream_branch_success(branch, upstream, remotename):
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, upstream, ""))
+        mock_execute.side_effect = [
+            maybe_future((0, remotename + '/' + upstream, '')), 
+            maybe_future((0, remotename, ''))
+            ]
 
         # When
         actual_response = await Git(FakeContentManager("/bin")).get_upstream_branch(
@@ -421,11 +424,21 @@ async def test_get_upstream_branch_success(branch, upstream):
         )
 
         # Then
-        mock_execute.assert_called_once_with(
-            ["git", "rev-parse", "--abbrev-ref", "{}@{{upstream}}".format(branch)],
-            cwd=os.path.join("/bin", "test_curr_path"),
+        mock_execute.assert_has_calls(
+            [
+                call(
+                    ["git", "rev-parse", "--abbrev-ref", "{}@{{upstream}}".format(branch)],
+                    cwd=os.path.join("/bin", "test_curr_path"),
+                ),
+                call(
+                    ['git', 'config', '--local', f'branch.{branch}.remote'],
+                     cwd='/bin/test_curr_path',
+                ),
+
+            ],
+            any_order=False,
         )
-        assert upstream == actual_response
+        assert {'code': 0, 'remote_branch': upstream, 'remote_short_name': remotename} == actual_response
 
 
 @pytest.mark.asyncio
@@ -454,17 +467,12 @@ async def test_get_upstream_branch_failure(outputs, message):
         mock_execute.return_value = maybe_future(outputs)
 
         # When
-        if message:
-            with pytest.raises(Exception) as error:
-                await Git(FakeContentManager("/bin")).get_upstream_branch(
-                    current_path="test_curr_path", branch_name="blah"
-                )
-            assert message == str(error.value)
-        else:
-            response = await Git(FakeContentManager("/bin")).get_upstream_branch(
-                current_path="test_curr_path", branch_name="blah"
-            )
-            assert response is None
+        response = await Git(FakeContentManager("/bin")).get_upstream_branch(
+            current_path="test_curr_path", branch_name="blah"
+        )
+        expected = {'code': 128, 'command': 'git rev-parse --abbrev-ref blah@{upstream}', 'message': outputs[2]}
+
+        assert response == expected
 
         # Then
         mock_execute.assert_has_calls(
@@ -807,7 +815,7 @@ async def test_branch_success_detached_head():
                 ),
                 # call to get current branch
                 call(
-                    ["git", "symbolic-ref", "HEAD"],
+                    ["git", "symbolic-ref", "--short", "HEAD"],
                     cwd=os.path.join("/bin", "test_curr_path"),
                 ),
                 # call to get current branch name given a detached head

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -431,7 +431,7 @@ async def test_get_upstream_branch_success(branch, upstream, remotename):
                     cwd=os.path.join("/bin", "test_curr_path"),
                 ),
                 call(
-                    ['git', 'config', '--local', f'branch.{branch}.remote'],
+                    ['git', 'config', '--local', 'branch.{}.remote'.format(branch)],
                      cwd='/bin/test_curr_path',
                 ),
 

--- a/jupyterlab_git/tests/test_handlers.py
+++ b/jupyterlab_git/tests/test_handlers.py
@@ -166,9 +166,13 @@ class TestPush(ServerTest):
     @patch("jupyterlab_git.handlers.GitPushHandler.git", spec=Git)
     def test_push_handler_localbranch(self, mock_git):
         # Given
-        mock_git.get_current_branch.return_value = maybe_future("foo")
+        mock_git.get_current_branch.return_value = maybe_future("localbranch")
         mock_git.get_upstream_branch.return_value = maybe_future(
-            "localbranch"
+            {
+                "code": 0,
+                "remote_short_name": ".",
+                "remote_branch": "localbranch"
+            }
         )
         mock_git.push.return_value = maybe_future({"code": 0})
 
@@ -178,7 +182,7 @@ class TestPush(ServerTest):
 
         # Then
         mock_git.get_current_branch.assert_called_with("test_path")
-        mock_git.get_upstream_branch.assert_called_with("test_path", "foo")
+        mock_git.get_upstream_branch.assert_called_with("test_path", "localbranch")
         mock_git.push.assert_called_with(".", "HEAD:localbranch", "test_path", None)
 
         assert response.status_code == 200
@@ -188,10 +192,11 @@ class TestPush(ServerTest):
     @patch("jupyterlab_git.handlers.GitPushHandler.git", spec=Git)
     def test_push_handler_remotebranch(self, mock_git):
         # Given
-        mock_git.get_current_branch.return_value = maybe_future("foo")
-        mock_git.get_upstream_branch.return_value = maybe_future(
-            "origin/remotebranch"
-        )
+        mock_git.get_current_branch.return_value = maybe_future("foo/bar")
+        upstream = {"code": 0,
+                    "remote_short_name": "origin/something",
+                    "remote_branch": "remote-branch-name"}
+        mock_git.get_upstream_branch.return_value = maybe_future(upstream)
         mock_git.push.return_value = maybe_future({"code": 0})
 
         # When
@@ -200,9 +205,9 @@ class TestPush(ServerTest):
 
         # Then
         mock_git.get_current_branch.assert_called_with("test_path")
-        mock_git.get_upstream_branch.assert_called_with("test_path", "foo")
+        mock_git.get_upstream_branch.assert_called_with("test_path", "foo/bar")
         mock_git.push.assert_called_with(
-            "origin", "HEAD:remotebranch", "test_path", None
+            "origin/something", "HEAD:remote-branch-name", "test_path", None
         )
 
         assert response.status_code == 200
@@ -213,7 +218,12 @@ class TestPush(ServerTest):
     def test_push_handler_noupstream(self, mock_git):
         # Given
         mock_git.get_current_branch.return_value = maybe_future("foo")
-        mock_git.get_upstream_branch.return_value = maybe_future("")
+        upstream = {
+            "code": 128,
+            "command": "",
+            "message": "fatal: no upstream configured for branch 'foo'"
+        }
+        mock_git.get_upstream_branch.return_value = maybe_future(upstream)
         mock_git.push.return_value = maybe_future({"code": 0})
 
         # When
@@ -235,10 +245,13 @@ class TestPush(ServerTest):
 
 class TestUpstream(ServerTest):
     @patch("jupyterlab_git.handlers.GitUpstreamHandler.git", spec=Git)
-    def test_upstream_handler_localbranch(self, mock_git):
+    def test_upstream_handler_forward_slashes(self, mock_git):
         # Given
-        mock_git.get_current_branch.return_value = maybe_future("foo")
-        mock_git.get_upstream_branch.return_value = maybe_future("bar")
+        mock_git.get_current_branch.return_value = maybe_future("foo/bar")
+        upstream = {"code": 0,
+                    "remote_short_name": "origin/something",
+                    "remote_branch": "foo/bar"}
+        mock_git.get_upstream_branch.return_value = maybe_future(upstream)
 
         # When
         body = {"current_path": "test_path"}
@@ -246,11 +259,32 @@ class TestUpstream(ServerTest):
 
         # Then
         mock_git.get_current_branch.assert_called_with("test_path")
-        mock_git.get_upstream_branch.assert_called_with("test_path", "foo")
+        mock_git.get_upstream_branch.assert_called_with("test_path", "foo/bar")
 
         assert response.status_code == 200
         payload = response.json()
-        assert payload == {"upstream": "bar"}
+        assert payload == upstream 
+
+    @patch("jupyterlab_git.handlers.GitUpstreamHandler.git", spec=Git)
+    def test_upstream_handler_localbranch(self, mock_git):
+        # Given
+        mock_git.get_current_branch.return_value = maybe_future("foo/bar")
+        upstream = {"code": 0,
+                    "remote_short_name": ".",
+                    "remote_branch": "foo/bar"}
+        mock_git.get_upstream_branch.return_value = maybe_future(upstream)
+
+        # When
+        body = {"current_path": "test_path"}
+        response = self.tester.post(["upstream"], body=body)
+
+        # Then
+        mock_git.get_current_branch.assert_called_with("test_path")
+        mock_git.get_upstream_branch.assert_called_with("test_path", "foo/bar")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == upstream 
 
 
 class TestDiffContent(ServerTest):


### PR DESCRIPTION
Fixes: https://github.com/jupyterlab/jupyterlab-git/issues/686

- Used an extra git command to allow for `/`s in both the branch and remote names
- tried to bring the returning of errors more in line with the rest of the extension
- Returned more info from the functions in `git.py` to allow the handlers/frontend to deal with rewriting the error messages as necessary.

I changed what is returned by `get_upstream_branch` but this is not used anywhere else in the extension so this shouldn't be a problem. 

