### PR TITLE
check if in repo before rendering branch menu

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -246,7 +246,7 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
    * @returns React element
    */
   private _renderBranchMenu(): React.ReactElement | null {
-    if (!this.state.repository) {
+    if (!this.props.model.pathRepository) {
       return null;
     }
     return (


### PR DESCRIPTION
Fixes: https://github.com/jupyterlab/jupyterlab-git/issues/674

Prevents the extension crashing when navigating away from a repo when the branch menu is open. I think the branchmenu was always being rendered even when not in a repo.

@kgryte could you review?