### PR TITLE
add nbgitpuller to binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,4 +3,5 @@ channels:
 dependencies:
 # Jupyter
 - jupyterlab~=2.0
-- nodejs>=11
+- nodejs>=12
+- nbgitpuller

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
 pip install .
+jupyter serverextension enable --sys-prefix --py nbgitpuller
 jupyter lab build


### PR DESCRIPTION
Thanks for this extension!

This adds [nbgitpuller](https://github.com/jupyterhub/nbgitpuller) to the demo binder. With the [generator](https://jupyterhub.github.io/nbgitpuller/link?tab=binder&repo=https://github.com/bollwyvl/jupyterlab-git&branch=add-nbgitpuller), this is can be an interesting way to make links that try out this repo with other repos-of interest, like this, which [brings in JupyterLab master](https://mybinder.org/v2/gh/bollwyvl/jupyterlab-git/add-nbgitpuller?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fjupyterlab%252Fjupyterlab%26urlpath%3Dlab%252Ftree%252Ftree%252FREADME%252Fmd%26branch%3Dmaster).

My ulterior motive here is to demonstrate some behavior at the interplay between these two pieces, namely that the pull button sometimes doesn't work out of the box when checked out with `nbgitpuller`... but this would be nice to have in the binder anyway!