### PR TITLE
Don't track all untracked files in all subdirectories

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -243,7 +243,7 @@ class Git:
         """
         Execute git status command & return the result.
         """
-        cmd = ["git", "status", "--porcelain", "-u", "-z"]
+        cmd = ["git", "status", "--porcelain", "-z"]
         code, my_output, my_error = await execute(
             cmd, cwd=os.path.join(self.root_dir, current_path),
         )

--- a/jupyterlab_git/tests/test_status.py
+++ b/jupyterlab_git/tests/test_status.py
@@ -89,7 +89,7 @@ async def test_status(output, diff_output, expected):
         mock_execute.assert_has_calls(
             [
                 call(
-                    ["git", "status", "--porcelain", "-u", "-z"],
+                    ["git", "status", "--porcelain", "-z"],
                     cwd=os.path.join(root, repository),
                 ),
                 call(


### PR DESCRIPTION
Please see #703 for more context around this issue before this PR.

The -u option has side-effects that make JupterLab unusable and hang user browsers.