### PR TITLE
don't use docmanager reload when opening gitignore

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 pip install .
 jupyter serverextension enable --sys-prefix --py nbgitpuller
-jupyter lab build
+jupyter lab build --dev-build=False --debug

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 pip install .
 jupyter serverextension enable --sys-prefix --py nbgitpuller
-jupyter lab build --dev-build=False --debug
+jupyter lab build --dev-build=False --minimize=False --debug

--- a/src/commandsAndMenu.ts
+++ b/src/commandsAndMenu.ts
@@ -200,10 +200,7 @@ export function addCommands(
     execute: async () => {
       await model.ensureGitignore();
       const gitModel = model as GitExtension;
-      await gitModel.commands.execute('docmanager:reload');
-      await gitModel.commands.execute('docmanager:open', {
-        path: model.getRelativeFilePath('.gitignore')
-      });
+      gitModel.openGitignore();
     }
   });
 

--- a/src/commandsAndMenu.ts
+++ b/src/commandsAndMenu.ts
@@ -12,7 +12,6 @@ import { ITerminal } from '@jupyterlab/terminal';
 import { CommandRegistry } from '@lumino/commands';
 import { Menu } from '@lumino/widgets';
 import { IGitExtension } from './tokens';
-import { GitExtension } from './model';
 import { GitCredentialsForm } from './widgets/CredentialsBox';
 import { doGitClone } from './widgets/gitClone';
 import { GitPullPushDialog, Operation } from './widgets/gitPushPull';

--- a/src/commandsAndMenu.ts
+++ b/src/commandsAndMenu.ts
@@ -199,8 +199,6 @@ export function addCommands(
     isEnabled: () => model.pathRepository !== null,
     execute: async () => {
       await model.ensureGitignore();
-      const gitModel = model as GitExtension;
-      gitModel.openGitignore();
     }
   });
 

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -160,7 +160,6 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         execute: async () => {
           if (this.state.selectedFile) {
             await this.props.model.ignore(this.state.selectedFile.to, false);
-            this.props.model.openGitignore();
           }
         }
       });
@@ -184,7 +183,6 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               });
               if (result.button.label === 'Ignore') {
                 await this.props.model.ignore(this.state.selectedFile.to, true);
-                this.props.model.openGitignore();
               }
             }
           }

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -160,10 +160,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         execute: async () => {
           if (this.state.selectedFile) {
             await this.props.model.ignore(this.state.selectedFile.to, false);
-            await this.props.model.commands.execute('docmanager:reload');
-            await this.props.model.commands.execute('docmanager:open', {
-              path: this.props.model.getRelativeFilePath('.gitignore')
-            });
+            this.props.model.openGitignore();
           }
         }
       });
@@ -187,10 +184,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
               });
               if (result.button.label === 'Ignore') {
                 await this.props.model.ignore(this.state.selectedFile.to, true);
-                await this.props.model.commands.execute('docmanager:reload');
-                await this.props.model.commands.execute('docmanager:open', {
-                  path: this.props.model.getRelativeFilePath('.gitignore')
-                });
+                this.props.model.openGitignore();
               }
             }
           }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1275,6 +1275,20 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
+   * open new editor or show an existing editor of the
+   * .gitignore file. If the editor does not have unsaved changes
+   * then ensure the editor's content matches the file on disk
+   */
+  openGitignore() {
+    const widget = this._docmanager.openOrReveal(
+      this.getRelativeFilePath('.gitignore')
+    );
+    if (widget && !widget.context.model.dirty) {
+      widget.context.revert();
+    }
+  }
+
+  /**
    * Get list of files changed between two commits or two branches
    * @param base id of base commit or base branch for comparison
    * @param remote id of remote commit or remote branch for comparison

--- a/src/model.ts
+++ b/src/model.ts
@@ -1240,6 +1240,7 @@ export class GitExtension implements IGitExtension {
     });
 
     this.refreshStatus();
+    this._openGitignore();
     return Promise.resolve(response);
   }
 
@@ -1271,21 +1272,8 @@ export class GitExtension implements IGitExtension {
     });
 
     this.refreshStatus();
+    this._openGitignore();
     return Promise.resolve(response);
-  }
-
-  /**
-   * open new editor or show an existing editor of the
-   * .gitignore file. If the editor does not have unsaved changes
-   * then ensure the editor's content matches the file on disk
-   */
-  openGitignore() {
-    const widget = this._docmanager.openOrReveal(
-      this.getRelativeFilePath('.gitignore')
-    );
-    if (widget && !widget.context.model.dirty) {
-      widget.context.revert();
-    }
   }
 
   /**
@@ -1435,6 +1423,22 @@ export class GitExtension implements IGitExtension {
   private _generateTaskID(): number {
     this._taskID += 1;
     return this._taskID;
+  }
+
+  /**
+   * open new editor or show an existing editor of the
+   * .gitignore file. If the editor does not have unsaved changes
+   * then ensure the editor's content matches the file on disk
+   */
+  private _openGitignore() {
+    if (this._docmanager) {
+      const widget = this._docmanager.openOrReveal(
+        this.getRelativeFilePath('.gitignore')
+      );
+      if (widget && !widget.context.model.dirty) {
+        widget.context.revert();
+      }
+    }
   }
 
   /**

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -285,6 +285,13 @@ export interface IGitExtension extends IDisposable {
   ensureGitignore(): Promise<Response>;
 
   /**
+   * open new editor or show an existing editor of the
+   * .gitignore file. If the editor does not have unsaved changes
+   * then ensure the editor's content matches the file on disk
+   */
+  openGitignore(): void;
+
+  /**
    * Add an entry in .gitignore file
    *
    * @param filename The name of the entry to ignore

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -285,13 +285,6 @@ export interface IGitExtension extends IDisposable {
   ensureGitignore(): Promise<Response>;
 
   /**
-   * open new editor or show an existing editor of the
-   * .gitignore file. If the editor does not have unsaved changes
-   * then ensure the editor's content matches the file on disk
-   */
-  openGitignore(): void;
-
-  /**
    * Add an entry in .gitignore file
    *
    * @param filename The name of the entry to ignore


### PR DESCRIPTION
fixes: https://github.com/jupyterlab/jupyterlab-git/issues/758

This makes sure that the displayed gitignore file is up to date without running the risk of overwriting unsaved changes in open notebooks.

![gitignore-unsaved-changes-fixed](https://user-images.githubusercontent.com/10111092/91748049-4e9c3e80-eb8d-11ea-808b-fb8ff23cc791.gif)