### PR TITLE
Restore R icon in the file list

### DIFF
--- a/src/style/FileListStyle.ts
+++ b/src/style/FileListStyle.ts
@@ -44,6 +44,6 @@ export const pythonFileIconStyle = style({
   backgroundImage: 'var(--jp-icon-python)'
 });
 
-export const kernelFileIconStyle = style({
-  backgroundImage: 'var(--jp-icon-r)'
+export const rKernelFileIconStyle = style({
+  backgroundImage: 'var(--jp-icon-r-kernel)'
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import {
   genericFileIconStyle,
   imageFileIconStyle,
   jsonFileIconStyle,
-  kernelFileIconStyle,
+  rKernelFileIconStyle,
   markdownFileIconStyle,
   notebookFileIconStyle,
   pythonFileIconStyle,
@@ -64,7 +64,7 @@ export function getFileIconClassName(path: string): string {
     case '.xlsx':
       return spreadsheetFileIconStyle;
     case '.r':
-      return kernelFileIconStyle;
+      return rKernelFileIconStyle;
     case '.yml':
     case '.yaml':
       return yamlFileIconStyle;


### PR DESCRIPTION
Fixes #771.  FYI, the current pattern in jupterlab is to [get the style directly from DocumentRegistry.IFileType](https://github.com/jupyterlab/jupyterlab/blob/f06c41601b45724ef40963217c575546b6f8bac2/packages/filebrowser/src/listing.ts#L1900-L1902), roughly:

```typescript
const registry: DocumentRegistry;
let fileType: DocumentRegistry.IFileType = registry.getFileTypeForModel(item);
fileType = fileType || DocumentRegistry.getDefaultTextFileType(translator);
const { icon, name } = fileType;   # note iconClass exists but is empty
```

adopting such an approach would prevent disparities between the icons shown in the file browser those in the Git panel.
- for example, [the PDF icon](https://github.com/jupyterlab/jupyterlab/blob/46908b566e84d2f025db509f0591b9d86522e796/packages/docregistry/src/registry.ts#L1371) was recently added in lab but not here.
- there are also custom file types registered by third-party extensions which are not being handled in the Git panel currently but would be should the DocumentRegistry be used

though I fully understand the potential performance considerations (looking forward to windowing!)

After the change:

![Screenshot from 2020-09-16 19-58-04](https://user-images.githubusercontent.com/5832902/93380313-fa64b000-f856-11ea-99b9-0e7687d299b8.png)
