### PR TITLE
Handle not in repository error when we are not in a repository

### DIFF
--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -206,6 +206,9 @@ class GitBranchHandler(GitHandler):
         """
         current_path = self.get_json_body()["current_path"]
         result = await self.git.branch(current_path)
+
+        if result["code"] != 0:
+            self.set_status(500)
         self.finish(json.dumps(result))
 
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -719,16 +719,17 @@ export class GitExtension implements IGitExtension {
     const tid = this._addTask('git:refresh:branches');
     try {
       const response = await this._branch();
-      if (response.code === 0) {
-        this._branches = response.branches;
-        this._currentBranch = response.current_branch;
-        if (this._currentBranch) {
-          // Set up the marker obj for the current (valid) repo/branch combination
-          this._setMarker(this.pathRepository, this._currentBranch.name);
-        }
-      } else {
-        this._branches = [];
-        this._currentBranch = null;
+      this._branches = response.branches;
+      this._currentBranch = response.current_branch;
+      if (this._currentBranch) {
+        // Set up the marker obj for the current (valid) repo/branch combination
+        this._setMarker(this.pathRepository, this._currentBranch.name);
+      }
+    } catch (error) {
+      this._branches = [];
+      this._currentBranch = null;
+      if (!(error instanceof Git.NotInRepository)) {
+        throw error;
       }
     } finally {
       this._removeTask(tid);
@@ -743,13 +744,17 @@ export class GitExtension implements IGitExtension {
   async refreshStatus(): Promise<void> {
     let data: Git.IStatusResult;
 
-    await this.ready;
-
-    const path = this.pathRepository;
-    if (path === null) {
+    let path: string;
+    try {
+      path = await this._getPathRespository();
+    } catch (error) {
       this._setStatus([]);
-      return Promise.resolve();
+      if (!(error instanceof Git.NotInRepository)) {
+        throw error;
+      }
+      return;
     }
+
     const tid = this._addTask('git:refresh:status');
     try {
       data = await requestAPI<Git.IStatusResult>('status', 'POST', {


### PR DESCRIPTION
Follow up #764 

The new error NotInRepository was not handled when not in a Git repository.