### PR TITLE
sort main branch in NewBranchDialog

### DIFF
--- a/src/components/NewBranchDialog.tsx
+++ b/src/components/NewBranchDialog.tsx
@@ -283,6 +283,11 @@ export class NewBranchDialog extends React.Component<
       } else if (b.name === 'master') {
         return 1;
       }
+      if (a.name === 'main') {
+        return -1;
+      } else if (b.name === 'main') {
+        return 1;
+      }
       return 0;
     }
   }


### PR DESCRIPTION
As of yesterday the new default branch on Github will be called `main` ([ref](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/)). This means that a sizeable number of new repos will have `main` as the default branch when people copy-paste the github new repo instructions:
![image](https://user-images.githubusercontent.com/10111092/94888391-f041d480-0446-11eb-9fa7-0dff166f48a7.png)

To account for that this PR adds the `main` branch to special cases when sorting branches in the newBranchDialog. The sorting order will now be:
1. `current branch`
2. `master` (if exists)
3. `main` (if exists)
4. other