### PR TITLE
Stop action click propagation on GitStage header

### DIFF
--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -150,7 +150,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   };
 
   /** Reset all staged files */
-  resetAllStagedFiles = async () => {
+  resetAllStagedFiles = async (event: React.MouseEvent) => {
+    event.stopPropagation();
     await this.props.model.reset();
   };
 
@@ -160,12 +161,16 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   };
 
   /** Add all unstaged files */
-  addAllUnstagedFiles = async () => {
+  addAllUnstagedFiles = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+
     await this.props.model.addAllUnstaged();
   };
 
   /** Discard changes in all unstaged files */
-  discardAllUnstagedFiles = async () => {
+  discardAllUnstagedFiles = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+
     const result = await showDialog({
       title: 'Discard all changes',
       body:
@@ -182,7 +187,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   };
 
   /** Discard changes in all unstaged and staged files */
-  discardAllChanges = async () => {
+  discardAllChanges = async (event: React.MouseEvent) => {
+    event.stopPropagation();
     const result = await showDialog({
       title: 'Discard all changes',
       body:
@@ -209,7 +215,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   };
 
   /** Add all untracked files */
-  addAllUntrackedFiles = async () => {
+  addAllUntrackedFiles = async (event: React.MouseEvent) => {
+    event.stopPropagation();
     await this.props.model.addAllUntracked();
   };
 


### PR DESCRIPTION
If there are modifications (files in the staged group), when clicking the button undo (i.e. remove modification), the group is collapsed because the click event is propagated.

This corrects it.