### PR TITLE
don't check for changed files when checking out a new branch

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -384,15 +384,17 @@ export class GitExtension implements IGitExtension {
       'git:checkout',
       async () => {
         let changes;
-        if (body.checkout_branch) {
-          changes = await this._changedFiles(
-            this._currentBranch.name,
-            body.branchname
-          );
-        } else if (body.filename) {
-          changes = { files: [body.filename] };
-        } else {
-          changes = await this._changedFiles('WORKING', 'HEAD');
+        if (!body.new_check) {
+          if (body.checkout_branch && !body.new_check) {
+            changes = await this._changedFiles(
+              this._currentBranch.name,
+              body.branchname
+            );
+          } else if (body.filename) {
+            changes = { files: [body.filename] };
+          } else {
+            changes = await this._changedFiles('WORKING', 'HEAD');
+          }
         }
 
         const d = await requestAPI<Git.ICheckoutResult>(
@@ -401,7 +403,7 @@ export class GitExtension implements IGitExtension {
           body
         );
 
-        changes.files?.forEach(file => this._revertFile(file));
+        changes?.files?.forEach(file => this._revertFile(file));
         return d;
       }
     );


### PR DESCRIPTION
Checking out a new branch will never cause files to change so we don't need to to check changed files. The attempt to check was failing because we were asking for the git diff between the current branch and one that did not yet exist

Fixes: https://github.com/jupyterlab/jupyterlab-git/issues/828