### PR TITLE
Check extension in binder build process

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+set -e
+
 pip install .
 jupyter serverextension enable --sys-prefix --py nbgitpuller
 jupyter lab build --dev-build=False --minimize=False --debug
+
+jupyter serverextension list 1>serverextensions 2>&1
+cat serverextensions | grep "jupyterlab_git.*OK"
+jupyter labextension list 1>labextensions 2>&1
+cat labextensions | grep "@jupyterlab/git.*OK"


### PR DESCRIPTION
This is not really a fix for #839 But more a patch to ensure binder does not validate a docker image that is not built correctly.