### PR TITLE
Avoid 500 error messages when current working directory in Jupyter Lab is not a git repo

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -684,7 +684,7 @@ class Git:
         else:
             # Handle special case where cwd not inside a git repo
             lower_error = my_error.lower()
-            if "fatal: not a git repository (or any" in lower_error:
+            if "fatal: not a git repository" in lower_error:
                 return {"code": 0, "top_repo_path": None}
 
             return {

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -682,6 +682,11 @@ class Git:
         if code == 0:
             return {"code": code, "top_repo_path": my_output.strip("\n")}
         else:
+            # Handle special case where cwd not inside a git repo
+            lower_error = my_error.lower()
+            if "fatal: not a git repository (or any" in lower_error:
+                return {"code": 0, "top_repo_path": None}
+
             return {
                 "code": code,
                 "command": " ".join(cmd),

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -74,7 +74,7 @@ class GitAllHistoryHandler(GitHandler):
         history_count = body["history_count"]
 
         show_top_level = await self.git.show_top_level(current_path)
-        if show_top_level["code"] != 0:
+        if show_top_level.get("top_repo_path") is None:
             self.set_status(500)
             self.finish(json.dumps(show_top_level))
         else:

--- a/jupyterlab_git/tests/test_handlers.py
+++ b/jupyterlab_git/tests/test_handlers.py
@@ -28,7 +28,7 @@ def test_mapping_added():
 @patch("jupyterlab_git.handlers.GitAllHistoryHandler.git", spec=Git)
 async def test_all_history_handler_localbranch(mock_git, jp_fetch):
     # Given
-    show_top_level = {"code": 0, "foo": "top_level"}
+    show_top_level = {"code": 0, "top_repo_path": "foo"}
     branch = "branch_foo"
     log = "log_foo"
     status = "status_foo"

--- a/jupyterlab_git/tests/test_handlers.py
+++ b/jupyterlab_git/tests/test_handlers.py
@@ -83,7 +83,7 @@ async def test_git_show_top_level(mock_execute, jp_fetch, jp_root_dir):
     mock_execute.assert_has_calls(
         [
             call(
-                ["git", "show", "rev-parse", "--show-toplevel"],
+                ["git", "rev-parse", "--show-toplevel"],
                 cwd=str(jp_root_dir / top_repo_path / "subfolder"),
             ),
         ]
@@ -114,7 +114,7 @@ async def test_git_show_top_level_not_a_git_repo(mock_execute, jp_fetch, jp_root
     mock_execute.assert_has_calls(
         [
             call(
-                ["git", "show", "rev-parse", "--show-toplevel"],
+                ["git", "rev-parse", "--show-toplevel"],
                 cwd=str(jp_root_dir / top_repo_path / "subfolder"),
             ),
         ]


### PR DESCRIPTION
Discussed: #842

Proposal to avoid long 500 error messages in terminal when current working directory in Jupyter Lab is not a git repository:
```
[E 20:39:53.188 LabApp] 500 POST /git/show_top_level?1607891993159 (127.0.0.1) 23.65ms referer=https://127.0.0.1:8888/lab?
```

Instead, print a message to terminal (`self.log.info`) of the git command and of the error message:

```
[I 21:54:40.644 LabApp] [jupyterlab_git] Failed to execute 'git' command: git rev-parse --show-toplevel, with message: fatal: not a git repository (or any of the parent directories): .git
```

Cheers
