### PR TITLE
Bump to beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/git",
-  "version": "0.30.0-beta.1",
+  "version": "0.30.0-beta.2",
   "description": "A JupyterLab extension for version control using git",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Bump to beta.2 to publish a beta version with #863 to reduce trouble with JupyterHub installation.