### PR TITLE
Implement Git context menu in the file browser

### DIFF
--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -852,7 +852,7 @@ export function addFileBrowserContextMenu(
       const items = getSelectedBrowserItems();
       const statuses = new Set<Git.Status>(
         items
-          .map(item => model.getFileStatus(item.path))
+          .map(item => model.getFile(item.path)?.status)
           .filter(status => typeof status !== 'undefined')
       );
 

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -736,11 +736,7 @@ export function addCommands(
 /**
  * Adds commands and menu items.
  *
- * @private
- * @param app - Jupyter front end
- * @param gitExtension - Git extension instance
- * @param fileBrowser - file browser instance
- * @param settings - extension settings
+ * @param commands - Jupyter App commands registry
  * @returns menu
  */
 export function createGitMenu(commands: CommandRegistry): Menu {

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -505,6 +505,21 @@ export function addCommands(
     icon: diffIcon
   });
 
+  commands.addCommand(ContextCommandIDs.gitFileAdd, {
+    label: 'Add',
+    caption: pluralizedContextLabel(
+      'Stage or track the changes to selected file',
+      'Stage or track the changes of selected files'
+    ),
+    execute: async args => {
+      const { files } = (args as any) as CommandArguments.IGitContextAction;
+      for (const file of files) {
+        await model.add(file.to);
+      }
+    },
+    icon: addIcon
+  });
+
   commands.addCommand(ContextCommandIDs.gitFileStage, {
     label: 'Stage',
     caption: pluralizedContextLabel(
@@ -868,6 +883,13 @@ export function addFileBrowserContextMenu(
               command !== ContextCommandIDs.gitFileOpen &&
               command !== ContextCommandIDs.gitFileDelete &&
               typeof command !== 'undefined'
+          )
+          // replace stage and track with a single "add" operation
+          .map(command =>
+            command === ContextCommandIDs.gitFileStage ||
+            command === ContextCommandIDs.gitFileTrack
+              ? ContextCommandIDs.gitFileAdd
+              : command
           )
       );
 

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -591,8 +591,8 @@ export function addCommands(
         title: 'Delete Files',
         body: (
           <span>
-            Are you sure you want to permanently delete
-            {fileList}? This action cannot be undone.
+            Are you sure you want to permanently delete {fileList}? This action
+            cannot be undone.
           </span>
         ),
         buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Delete' })]

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -44,7 +44,7 @@ import {
 import { GitCredentialsForm } from './widgets/CredentialsBox';
 import { GitCloneForm } from './widgets/GitCloneForm';
 import { Contents } from '@jupyterlab/services';
-import { ContextMenuSvg } from '@jupyterlab/ui-components';
+import { closeIcon, ContextMenuSvg } from '@jupyterlab/ui-components';
 import { Message } from '@lumino/messaging';
 import { CONTEXT_COMMANDS } from './components/FileList';
 
@@ -596,7 +596,7 @@ export function addCommands(
         }
       }
     },
-    icon: removeIcon
+    icon: closeIcon
   });
 
   commands.addCommand(ContextCommandIDs.gitFileDiscard, {
@@ -853,8 +853,13 @@ export function addFileBrowserContextMenu(
         // flatten the list of lists of commands
         []
           .concat(...[...statuses].map(status => CONTEXT_COMMANDS[status]))
-          // filter out the Open command as it is not needed in file browser
-          .filter(command => command !== ContextCommandIDs.gitFileOpen)
+          // filter out the Open and Delete commands as
+          // those are not needed in file browser
+          .filter(
+            command =>
+              command !== ContextCommandIDs.gitFileOpen &&
+              command !== ContextCommandIDs.gitFileDelete
+          )
       );
 
       const commandsChanged =

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -813,7 +813,7 @@ export function addMenuItems(
 }
 
 /**
- *
+ * Add Git context (sub)menu to the file browser context menu.
  */
 export function addFileBrowserContextMenu(
   model: IGitExtension,

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -447,6 +447,11 @@ export function addCommands(
       for (const file of files) {
         const { context, filePath, isText, status } = file;
 
+        // nothing to compare to for untracked files
+        if (status === 'untracked') {
+          continue;
+        }
+
         let diffContext = context;
         if (!diffContext) {
           const specialRef = status === 'staged' ? 'INDEX' : 'WORKING';

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -916,7 +916,11 @@ export function addFileBrowserContextMenu(
         addMenuItems(
           commandsList,
           this,
-          paths.map(path => model.getFile(path))
+          paths
+            .map(path => model.getFile(path))
+            // if file cannot be resolved (has no action available),
+            // omit the undefined result
+            .filter(file => typeof file !== 'undefined')
         );
         if (wasShown) {
           // show he menu again after downtime for refresh

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -435,7 +435,7 @@ export function addCommands(
         }
       }
     },
-    icon: openIcon
+    icon: openIcon.bindprops({ stylesheet: 'menuItem' })
   });
 
   commands.addCommand(ContextCommandIDs.gitFileDiff, {
@@ -502,7 +502,7 @@ export function addCommands(
         }
       }
     },
-    icon: diffIcon
+    icon: diffIcon.bindprops({ stylesheet: 'menuItem' })
   });
 
   commands.addCommand(ContextCommandIDs.gitFileAdd, {
@@ -517,7 +517,7 @@ export function addCommands(
         await model.add(file.to);
       }
     },
-    icon: addIcon
+    icon: addIcon.bindprops({ stylesheet: 'menuItem' })
   });
 
   commands.addCommand(ContextCommandIDs.gitFileStage, {
@@ -532,7 +532,7 @@ export function addCommands(
         await model.add(file.to);
       }
     },
-    icon: addIcon
+    icon: addIcon.bindprops({ stylesheet: 'menuItem' })
   });
 
   commands.addCommand(ContextCommandIDs.gitFileTrack, {
@@ -547,7 +547,7 @@ export function addCommands(
         await model.add(file.to);
       }
     },
-    icon: addIcon
+    icon: addIcon.bindprops({ stylesheet: 'menuItem' })
   });
 
   commands.addCommand(ContextCommandIDs.gitFileUnstage, {
@@ -564,7 +564,7 @@ export function addCommands(
         }
       }
     },
-    icon: removeIcon
+    icon: removeIcon.bindprops({ stylesheet: 'menuItem' })
   });
 
   function representFiles(files: Git.IStatusFile[]): JSX.Element {
@@ -611,7 +611,7 @@ export function addCommands(
         }
       }
     },
-    icon: closeIcon
+    icon: closeIcon.bindprops({ stylesheet: 'menuItem' })
   });
 
   commands.addCommand(ContextCommandIDs.gitFileDiscard, {
@@ -661,7 +661,7 @@ export function addCommands(
         }
       }
     },
-    icon: discardIcon
+    icon: discardIcon.bindprops({ stylesheet: 'menuItem' })
   });
 
   commands.addCommand(ContextCommandIDs.gitIgnore, {

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -106,8 +106,6 @@ function pluralizedContextLabel(singular: string, plural: string) {
   };
 }
 
-export const SUBMIT_COMMIT_COMMAND = 'git:submit-commit';
-
 /**
  * Add the commands for the git extension.
  */
@@ -128,7 +126,7 @@ export function addCommands(
    * The label and caption are given to ensure that the command will
    * show up in the shortcut editor UI with a nice description.
    */
-  commands.addCommand(SUBMIT_COMMIT_COMMAND, {
+  commands.addCommand(CommandIDs.gitSubmitCommand, {
     label: 'Commit from the Commit Box',
     caption:
       'Submit the commit using the summary and description from commit box',

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -7,7 +7,7 @@ import {
   commitButtonClass
 } from '../style/CommitBox';
 import { CommandRegistry } from '@lumino/commands';
-import { SUBMIT_COMMIT_COMMAND } from '../commandsAndMenu';
+import { CommandIDs } from '../tokens';
 
 /**
  * Interface describing component properties.
@@ -136,7 +136,7 @@ export class CommitBox extends React.Component<
    */
   private _getSubmitKeystroke = (): string => {
     const binding = this.props.commands.keyBindings.find(
-      binding => binding.command === SUBMIT_COMMIT_COMMAND
+      binding => binding.command === CommandIDs.gitSubmitCommand
     );
     return binding.keys.join(' ');
   };
@@ -201,7 +201,7 @@ export class CommitBox extends React.Component<
     _: CommandRegistry,
     commandArgs: CommandRegistry.ICommandExecutedArgs
   ): void => {
-    if (commandArgs.id === SUBMIT_COMMIT_COMMAND && this._canCommit()) {
+    if (commandArgs.id === CommandIDs.gitSubmitCommand && this._canCommit()) {
       this._onCommitSubmit();
     }
   };

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -8,7 +8,6 @@ import { Signal } from '@lumino/signaling';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import * as React from 'react';
-import { CommandIDs } from '../commandsAndMenu';
 import { Logger } from '../logger';
 import { GitExtension } from '../model';
 import {
@@ -20,7 +19,7 @@ import {
   tabsClass,
   warningTextClass
 } from '../style/GitPanel';
-import { Git, ILogMessage, Level } from '../tokens';
+import { CommandIDs, Git, ILogMessage, Level } from '../tokens';
 import { GitAuthorForm } from '../widgets/AuthorBox';
 import { CommitBox } from './CommitBox';
 import { FileList } from './FileList';

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -3,7 +3,7 @@ import { CommandRegistry } from '@lumino/commands';
 import * as React from 'react';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { classes } from 'typestyle';
-import { CommandIDs } from '../commandsAndMenu';
+import { CommandArguments} from '../commandsAndMenu';
 import { LoggerContext } from '../logger';
 import { GitExtension } from '../model';
 import {
@@ -25,7 +25,7 @@ import {
   iconClass,
   insertionsIconClass
 } from '../style/SinglePastCommitInfo';
-import { Git } from '../tokens';
+import { ContextCommandIDs, Git } from '../tokens';
 import { ActionButton } from './ActionButton';
 import { isDiffSupported } from './diff/Diff';
 import { FilePath } from './FilePath';
@@ -337,18 +337,22 @@ export class SinglePastCommitInfo extends React.Component<
       event.stopPropagation();
 
       try {
-        self.props.commands.execute(CommandIDs.gitFileDiff, {
-          filePath: fpath,
-          isText: bool,
-          context: {
-            previousRef: {
-              gitRef: self.props.commit.pre_commit
-            },
-            currentRef: {
-              gitRef: self.props.commit.commit
+        self.props.commands.execute(ContextCommandIDs.gitFileDiff, ({
+          files: [
+            {
+              filePath: fpath,
+              isText: bool,
+              context: {
+                previousRef: {
+                  gitRef: self.props.commit.pre_commit
+                },
+                currentRef: {
+                  gitRef: self.props.commit.commit
+                }
+              }
             }
-          }
-        });
+          ]
+        } as CommandArguments.IGitFileDiff) as any);
       } catch (err) {
         console.error(`Failed to open diff view for ${fpath}.\n${err}`);
       }

--- a/src/components/SinglePastCommitInfo.tsx
+++ b/src/components/SinglePastCommitInfo.tsx
@@ -3,7 +3,7 @@ import { CommandRegistry } from '@lumino/commands';
 import * as React from 'react';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { classes } from 'typestyle';
-import { CommandArguments} from '../commandsAndMenu';
+import { CommandArguments } from '../commandsAndMenu';
 import { LoggerContext } from '../logger';
 import { GitExtension } from '../model';
 import {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -8,7 +8,6 @@ import { CommandRegistry } from '@lumino/commands';
 import { Badge, Tab, Tabs } from '@material-ui/core';
 import * as React from 'react';
 import { classes } from 'typestyle';
-import { CommandIDs } from '../commandsAndMenu';
 import { Logger } from '../logger';
 import {
   selectedTabClass,
@@ -31,7 +30,7 @@ import {
   toolbarMenuWrapperClass,
   toolbarNavClass
 } from '../style/Toolbar';
-import { Git, IGitExtension, Level } from '../tokens';
+import { CommandIDs, Git, IGitExtension, Level } from '../tokens';
 import { ActionButton } from './ActionButton';
 import { BranchMenu } from './BranchMenu';
 import { TagMenu } from './TagMenu';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { IMainMenu } from '@jupyterlab/mainmenu';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStatusBar } from '@jupyterlab/statusbar';
-import { addCommands, createGitMenu } from './commandsAndMenu';
+import { addCommands, addFileBrowserContextMenu, createGitMenu } from './commandsAndMenu';
 import { GitExtension } from './model';
 import { getServerSettings } from './server';
 import { gitIcon } from './style/icons';
@@ -169,6 +169,9 @@ async function activate(
 
     // Add the status bar widget
     addStatusBarWidget(statusBar, gitExtension, settings);
+
+    // Add the context menu items for the default file browser
+    addFileBrowserContextMenu(gitExtension, factory.tracker, app.commands, app.contextMenu);
   }
 
   return gitExtension;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,11 @@ import { IMainMenu } from '@jupyterlab/mainmenu';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStatusBar } from '@jupyterlab/statusbar';
-import { addCommands, addFileBrowserContextMenu, createGitMenu } from './commandsAndMenu';
+import {
+  addCommands,
+  addFileBrowserContextMenu,
+  createGitMenu
+} from './commandsAndMenu';
 import { GitExtension } from './model';
 import { getServerSettings } from './server';
 import { gitIcon } from './style/icons';
@@ -171,7 +175,12 @@ async function activate(
     addStatusBarWidget(statusBar, gitExtension, settings);
 
     // Add the context menu items for the default file browser
-    addFileBrowserContextMenu(gitExtension, factory.tracker, app.commands, app.contextMenu);
+    addFileBrowserContextMenu(
+      gitExtension,
+      factory.tracker,
+      app.commands,
+      app.contextMenu
+    );
   }
 
   return gitExtension;

--- a/src/model.ts
+++ b/src/model.ts
@@ -248,7 +248,7 @@ export class GitExtension implements IGitExtension {
 
   getFile(path: string): Git.IStatusFile {
     const matchingFiles = this._status.files.filter(status => {
-      return status.to === path;
+      return this.getRelativeFilePath(status.to) === path;
     });
     if (matchingFiles.length === 0) {
       return;

--- a/src/model.ts
+++ b/src/model.ts
@@ -250,7 +250,7 @@ export class GitExtension implements IGitExtension {
    * @param path the file path relative to the server root
    */
   getFile(path: string): Git.IStatusFile {
-    const matchingFiles = this._status.files.filter(status => {
+    const matchingFiles = this._status.files.find(status => {
       return this.getRelativeFilePath(status.to) === path;
     });
     if (matchingFiles.length === 0) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -250,16 +250,9 @@ export class GitExtension implements IGitExtension {
    * @param path the file path relative to the server root
    */
   getFile(path: string): Git.IStatusFile {
-    const matchingFiles = this._status.files.find(status => {
+    return this._status.files.find(status => {
       return this.getRelativeFilePath(status.to) === path;
     });
-    if (matchingFiles.length === 0) {
-      return;
-    }
-    if (matchingFiles.length > 1) {
-      console.warn('More than one file matching given path', path);
-    }
-    return matchingFiles[0];
   }
 
   /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -242,10 +242,13 @@ export class GitExtension implements IGitExtension {
     await this.refreshStatus();
   }
 
-  getFileStatus(path: string): Git.Status {
-    return this.getFile(path)?.status;
-  }
-
+  /**
+   * Match files status information based on a provided file path.
+   *
+   * If the file is tracked and has no changes, undefined will be returned
+   *
+   * @param path the file path relative to the server root
+   */
   getFile(path: string): Git.IStatusFile {
     const matchingFiles = this._status.files.filter(status => {
       return this.getRelativeFilePath(status.to) === path;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -249,16 +249,13 @@ export interface IGitExtension extends IDisposable {
   ensureGitignore(): Promise<void>;
 
   /**
+   * Match files status information based on a provided file path.
    *
-   * @param path
+   * If the file is tracked and has no changes, undefined will be returned
+   *
+   * @param path the file path relative to the server root
    */
   getFile(path: string): Git.IStatusFile;
-
-  /**
-   *
-   * @param path
-   */
-  getFileStatus(path: string): Git.Status;
 
   /**
    * Get current mark of file named fname
@@ -637,7 +634,7 @@ export namespace Git {
 
   /** Interface for changed_files request result
    * lists the names of files that have differences between two commits
-   * or beween two branches, or that were changed by a single commit
+   * or between two branches, or that were changed by a single commit
    */
   export interface IChangedFilesResult {
     code: number;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -249,6 +249,18 @@ export interface IGitExtension extends IDisposable {
   ensureGitignore(): Promise<void>;
 
   /**
+   *
+   * @param path
+   */
+  getFile(path: string): Git.IStatusFile;
+
+  /**
+   *
+   * @param path
+   */
+  getFileStatus(path: string): Git.Status;
+
+  /**
    * Get current mark of file named fname
    *
    * @param fname Filename
@@ -820,4 +832,36 @@ export interface ILogMessage {
    * Message text.
    */
   message: string;
+}
+
+/**
+ * The command IDs used in the git context menus.
+ */
+export enum ContextCommandIDs {
+  gitFileDiff = 'git:context-diff',
+  gitFileDiscard = 'git:context-discard',
+  gitFileDelete = 'git:context-delete',
+  gitFileOpen = 'git:context-open',
+  gitFileUnstage = 'git:context-unstage',
+  gitFileStage = 'git:context-stage',
+  gitFileTrack = 'git:context-track',
+  gitIgnore = 'git:context-ignore',
+  gitIgnoreExtension = 'git:context-ignoreExtension'
+}
+
+/**
+ * The command IDs used by the git plugin.
+ */
+export enum CommandIDs {
+  gitUI = 'git:ui',
+  gitTerminalCommand = 'git:terminal-command',
+  gitInit = 'git:init',
+  gitOpenUrl = 'git:open-url',
+  gitToggleSimpleStaging = 'git:toggle-simple-staging',
+  gitToggleDoubleClickDiff = 'git:toggle-double-click-diff',
+  gitAddRemote = 'git:add-remote',
+  gitClone = 'git:clone',
+  gitOpenGitignore = 'git:open-gitignore',
+  gitPush = 'git:push',
+  gitPull = 'git:pull'
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -862,5 +862,6 @@ export enum CommandIDs {
   gitClone = 'git:clone',
   gitOpenGitignore = 'git:open-gitignore',
   gitPush = 'git:push',
-  gitPull = 'git:pull'
+  gitPull = 'git:pull',
+  gitSubmitCommand = 'git:submit-commit'
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -835,6 +835,7 @@ export interface ILogMessage {
  * The command IDs used in the git context menus.
  */
 export enum ContextCommandIDs {
+  gitFileAdd = 'git:context-add',
   gitFileDiff = 'git:context-diff',
   gitFileDiscard = 'git:context-discard',
   gitFileDelete = 'git:context-delete',

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -846,7 +846,8 @@ export enum ContextCommandIDs {
   gitFileStage = 'git:context-stage',
   gitFileTrack = 'git:context-track',
   gitIgnore = 'git:context-ignore',
-  gitIgnoreExtension = 'git:context-ignoreExtension'
+  gitIgnoreExtension = 'git:context-ignoreExtension',
+  gitNoAction = 'git:no-action'
 }
 
 /**

--- a/src/widgets/gitClone.tsx
+++ b/src/widgets/gitClone.tsx
@@ -7,9 +7,8 @@ import { IChangedArgs } from '@jupyterlab/coreutils';
 import { FileBrowser } from '@jupyterlab/filebrowser';
 import { CommandRegistry } from '@lumino/commands';
 import * as React from 'react';
-import { CommandIDs } from '../commandsAndMenu';
 import { cloneIcon } from '../style/icons';
-import { IGitExtension } from '../tokens';
+import { CommandIDs, IGitExtension } from '../tokens';
 
 export function addCloneButton(
   model: IGitExtension,

--- a/tests/commands.spec.tsx
+++ b/tests/commands.spec.tsx
@@ -2,10 +2,10 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { showDialog } from '@jupyterlab/apputils';
 import { CommandRegistry } from '@lumino/commands';
 import 'jest';
-import { addCommands} from '../src/commandsAndMenu';
+import { CommandArguments, addCommands} from '../src/commandsAndMenu';
 import * as git from '../src/git';
 import { GitExtension } from '../src/model';
-import { CommandIDs, Git } from '../src/tokens';
+import { ContextCommandIDs, CommandIDs, Git } from '../src/tokens';
 import {
   defaultMockedResponses,
   IMockedResponses,
@@ -125,14 +125,14 @@ describe('git-commands', () => {
           model.pathRepository = '/path/to/repo';
           await model.ready;
 
-          await commands.execute(CommandIDs.gitFileDiscard, {
+          await commands.execute(ContextCommandIDs.gitFileDiscard, ({files: [{
             x,
             y: ' ',
             from: 'from',
             to: path,
             status: status as Git.Status,
             is_binary: false
-          });
+          }]} as CommandArguments.IGitContextAction) as any);
 
           if (status === 'staged' || status === 'partially-staged') {
             expect(spyReset).toHaveBeenCalledWith(path);

--- a/tests/commands.spec.tsx
+++ b/tests/commands.spec.tsx
@@ -2,10 +2,10 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { showDialog } from '@jupyterlab/apputils';
 import { CommandRegistry } from '@lumino/commands';
 import 'jest';
-import { addCommands, CommandIDs } from '../src/commandsAndMenu';
+import { addCommands} from '../src/commandsAndMenu';
 import * as git from '../src/git';
 import { GitExtension } from '../src/model';
-import { Git } from '../src/tokens';
+import { CommandIDs, Git } from '../src/tokens';
 import {
   defaultMockedResponses,
   IMockedResponses,

--- a/tests/test-components/CommitBox.spec.tsx
+++ b/tests/test-components/CommitBox.spec.tsx
@@ -3,14 +3,14 @@ import 'jest';
 import { shallow } from 'enzyme';
 import { CommitBox} from '../../src/components/CommitBox';
 import { CommandRegistry } from '@lumino/commands';
-import { SUBMIT_COMMIT_COMMAND } from '../../src/commandsAndMenu';
+import { CommandIDs } from '../../src/tokens';
 
 describe('CommitBox', () => {
 
   const defaultCommands = new CommandRegistry()
   defaultCommands.addKeyBinding({
     keys: ['Accel Enter'],
-    command: SUBMIT_COMMIT_COMMAND,
+    command: CommandIDs.gitSubmitCommand,
     selector: '.jp-git-CommitBox'
   })
 
@@ -59,7 +59,7 @@ describe('CommitBox', () => {
       const adjustedCommands = new CommandRegistry()
       adjustedCommands.addKeyBinding({
         keys: ['Shift Enter'],
-        command: SUBMIT_COMMIT_COMMAND,
+        command: CommandIDs.gitSubmitCommand,
         selector: '.jp-git-CommitBox'
       })
       const props = {

--- a/tests/test-components/Toolbar.spec.tsx
+++ b/tests/test-components/Toolbar.spec.tsx
@@ -2,7 +2,6 @@ import { refreshIcon } from '@jupyterlab/ui-components';
 import { shallow } from 'enzyme';
 import 'jest';
 import * as React from 'react';
-import { CommandIDs } from '../../src/commandsAndMenu';
 import { ActionButton } from '../../src/components/ActionButton';
 import { IToolbarProps, Toolbar } from '../../src/components/Toolbar';
 import * as git from '../../src/git';
@@ -11,6 +10,7 @@ import { GitExtension } from '../../src/model';
 import { pullIcon, pushIcon } from '../../src/style/icons';
 import { toolbarMenuButtonClass } from '../../src/style/Toolbar';
 import { mockedRequestAPI } from '../utils';
+import { CommandIDs } from '../../src/tokens';
 
 jest.mock('../../src/git');
 


### PR DESCRIPTION
Fixes #774

Changes:
- [x] Added Git context menu in File Browser
- [x] Reworked the context commands to accept multiple files (as multiple files can be selected in the file browser)
- [x] Added icons to the commands (they also display in the context menu of the Git panel widget)
- [x] The old context menu and new context menu share the same commands and the same status assignments (the "open"  command is not shown in the file browser as redundant to the browser capabilities); EDIT: "delete" is no longer shown either (GIF was not updated)
- [x] Fixed a typo (`_getPathRespository`)
- [x] Formalize types:
  - for context commands (as distinct from other commands): `ContextCommandIDs`
  - for context commands' arguments (as those were already being cast in type-unsafe way and I needed to change them all): `CommandArguments`

![jupyterlab-git-context-menu](https://user-images.githubusercontent.com/5832902/108583692-4b5f5f80-7333-11eb-831b-45a95b41e004.gif)

The Git panel context menu got icons (updated):

![context-menu-in-git-panel](https://user-images.githubusercontent.com/5832902/109180364-b28d7180-7782-11eb-9439-18c2e62445ce.gif)
