### PR TITLE
Allow to commit with ctrl + enter

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -59,5 +59,12 @@
       "description": "If true, use a simplified concept of staging. Only files with changes are shown (instead of showing staged/changed/untracked), and all files with changes will be automatically staged",
       "default": false
     }
-  }
+  },
+  "jupyter.lab.shortcuts": [
+    {
+      "command": "git:submit-commit",
+      "keys": ["Accel Enter"],
+      "selector": ".jp-git-CommitBox"
+    }
+  ]
 }

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -87,6 +87,8 @@ export namespace CommandIDs {
   export const gitIgnoreExtension = 'git:context-ignoreExtension';
 }
 
+export const SUBMIT_COMMIT_COMMAND = 'git:submit-commit';
+
 /**
  * Add the commands for the git extension.
  */
@@ -98,6 +100,22 @@ export function addCommands(
   renderMime: IRenderMimeRegistry
 ) {
   const { commands, shell } = app;
+
+  /**
+   * Commit using a keystroke combination when in CommitBox.
+   *
+   * This command is not accessible from the user interface (not visible),
+   * as it is handled by a signal listener in the CommitBox component instead.
+   * The label and caption are given to ensure that the command will
+   * show up in the shortcut editor UI with a nice description.
+   */
+  commands.addCommand(SUBMIT_COMMIT_COMMAND, {
+    label: 'Commit from the Commit Box',
+    caption:
+      'Submit the commit using the summary and description from commit box',
+    execute: () => void 0,
+    isVisible: () => false
+  });
 
   /**
    * Add open terminal in the Git repository

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -91,6 +91,7 @@ export class CommitBox extends React.Component<
           title="Enter a commit message description"
           value={this.state.description}
           onChange={this._onDescriptionChange}
+          onKeyPress={this._onDescriptionKeyPress}
         />
         <input
           className={commitButtonClass}
@@ -106,8 +107,6 @@ export class CommitBox extends React.Component<
 
   /**
    * Callback invoked upon clicking a commit message submit button.
-   *
-   * @param event - event object
    */
   private _onCommitClick = (): void => {
     const msg = this.state.summary + '\n\n' + this.state.description + '\n';
@@ -145,14 +144,33 @@ export class CommitBox extends React.Component<
    * ## Notes
    *
    * -   Prevents triggering a `'submit'` action when hitting the `ENTER` key while entering a commit message summary.
+   * -   Triggers the `'submit'` action when hitting `Ctrl` + `ENTER`
    *
    * @param event - event object
    */
-  private _onSummaryKeyPress(event: any): void {
-    if (event.which === 13) {
+  private _onSummaryKeyPress = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Enter') {
       event.preventDefault();
+      if (event.getModifierState('Control')) {
+        this._onCommitClick();
+      }
     }
-  }
+  };
+
+  /**
+   * Callback invoked upon a `'keypress'` event when entering a commit message description.
+   *
+   * ## Notes
+   *
+   * -   Triggers the `'submit'` action when hitting `Ctrl` + `ENTER`
+   *
+   * @param event - event object
+   */
+  private _onDescriptionKeyPress = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Enter' && event.getModifierState('Control')) {
+      this._onCommitClick();
+    }
+  };
 
   /**
    * Resets component state (e.g., in order to re-initialize the commit message input box).

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -372,11 +372,13 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           <CommitBox
             hasFiles={this._markedFiles.length > 0}
             onCommit={this.commitMarkedFiles}
+            commands={this.props.commands}
           />
         ) : (
           <CommitBox
             hasFiles={this._hasStagedFile()}
             onCommit={this.commitStagedFiles}
+            commands={this.props.commands}
           />
         )}
       </React.Fragment>

--- a/tests/test-components/CommitBox.spec.tsx
+++ b/tests/test-components/CommitBox.spec.tsx
@@ -1,14 +1,25 @@
 import * as React from 'react';
 import 'jest';
 import { shallow } from 'enzyme';
-import { CommitBox } from '../../src/components/CommitBox';
+import { CommitBox} from '../../src/components/CommitBox';
+import { CommandRegistry } from '@lumino/commands';
+import { SUBMIT_COMMIT_COMMAND } from '../../src/commandsAndMenu';
 
 describe('CommitBox', () => {
+
+  const defaultCommands = new CommandRegistry()
+  defaultCommands.addKeyBinding({
+    keys: ['Accel Enter'],
+    command: SUBMIT_COMMIT_COMMAND,
+    selector: '.jp-git-CommitBox'
+  })
+
   describe('#constructor()', () => {
     it('should return a new instance', () => {
       const box = new CommitBox({
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       });
       expect(box).toBeInstanceOf(CommitBox);
     });
@@ -16,7 +27,8 @@ describe('CommitBox', () => {
     it('should set the default commit message summary to an empty string', () => {
       const box = new CommitBox({
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       });
       expect(box.state.summary).toEqual('');
     });
@@ -24,7 +36,8 @@ describe('CommitBox', () => {
     it('should set the default commit message description to an empty string', () => {
       const box = new CommitBox({
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       });
       expect(box.state.description).toEqual('');
     });
@@ -34,17 +47,36 @@ describe('CommitBox', () => {
     it('should display placeholder text for the commit message summary', () => {
       const props = {
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="text"]').first();
-      expect(node.prop('placeholder')).toEqual('Summary (required)');
+      expect(node.prop('placeholder')).toEqual('Summary (Ctrl+Enter to commit)');
+    });
+
+    it('should adjust placeholder text for the commit message summary when keybinding changes', () => {
+      const adjustedCommands = new CommandRegistry()
+      adjustedCommands.addKeyBinding({
+        keys: ['Shift Enter'],
+        command: SUBMIT_COMMIT_COMMAND,
+        selector: '.jp-git-CommitBox'
+      })
+      const props = {
+        onCommit: async () => {},
+        hasFiles: false,
+        commands: adjustedCommands
+      };
+      const component = shallow(<CommitBox {...props} />);
+      const node = component.find('input[type="text"]').first();
+      expect(node.prop('placeholder')).toEqual('Summary (Shift+Enter to commit)');
     });
 
     it('should set a `title` attribute on the input element to provide a commit message summary', () => {
       const props = {
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="text"]').first();
@@ -54,17 +86,19 @@ describe('CommitBox', () => {
     it('should display placeholder text for the commit message description', () => {
       const props = {
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('TextareaAutosize').first();
-      expect(node.prop('placeholder')).toEqual('Description');
+      expect(node.prop('placeholder')).toEqual('Description (optional)');
     });
 
     it('should set a `title` attribute on the input element to provide a commit message description', () => {
       const props = {
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('TextareaAutosize').first();
@@ -74,7 +108,8 @@ describe('CommitBox', () => {
     it('should display a button to commit changes', () => {
       const props = {
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="button"]').first();
@@ -84,7 +119,8 @@ describe('CommitBox', () => {
     it('should set a `title` attribute on the button to commit changes', () => {
       const props = {
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="button"]').first();
@@ -94,7 +130,8 @@ describe('CommitBox', () => {
     it('should apply a class to disable the commit button when no files have changes to commit', () => {
       const props = {
         onCommit: async () => {},
-        hasFiles: false
+        hasFiles: false,
+        commands: defaultCommands
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="button"]').first();
@@ -105,7 +142,8 @@ describe('CommitBox', () => {
     it('should apply a class to disable the commit button when files have changes to commit, but the user has not entered a commit message summary', () => {
       const props = {
         onCommit: async () => {},
-        hasFiles: true
+        hasFiles: true,
+        commands: defaultCommands
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="button"]').first();
@@ -116,7 +154,8 @@ describe('CommitBox', () => {
     it('should not apply a class to disable the commit button when files have changes to commit and the user has entered a commit message summary', () => {
       const props = {
         onCommit: async () => {},
-        hasFiles: true
+        hasFiles: true,
+        commands: defaultCommands
       };
       const component = shallow(<CommitBox {...props} />);
       component.setState({


### PR DESCRIPTION
Fixes #773

Also:
- replaces deprecated `which` with `key`. Some browsers already dropped `which` (see the big red box on [MDN]( https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/which)
- Remove incorrect  `@param event - event object` from `_onCommitClick` documentation
- Use appropriate type for `_onSummaryKeyPress` `event` argument