### PR TITLE
Update README.md:Git panel is not visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ If they do not match or one is missing, please [reinstall the package](README.md
     jupyter labextension install @jupyterlab/git
     ```
     
-    If you see `@jupyterlab/git` under the  `Uninstalled core extensions: ` remove jupyter\lab\settings\build_config.json and re-install.
+    If you see `@jupyterlab/git`, your installation may have been corrupted. You can run `jupyter lab clean --all` and
+    reinstall all your extensions.
     
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ If they do not match or one is missing, please [reinstall the package](README.md
     ```bash
     jupyter labextension install @jupyterlab/git
     ```
-
+    
+    If you see `@jupyterlab/git` under the  `Uninstalled core extensions: ` remove jupyter\lab\settings\build_config.json and re-install.
+    
 ## Contributing
 
 If you would like to contribute to the project, please read our [contributor documentation](https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Even if the package is installed, it does not work unless it is in the uninstalled packages list. It is caused by a bug in jupyterlab according to this issue https://github.com/jupyterlab/jupyterlab/issues/8122