### PR TITLE
Restore preview gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A JupyterLab extension for version control using Git
 
+![ui_glow_up](./docs/figs/preview.gif)
+
 To see the extension in action, open the example notebook included in the Binder [demo](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-git/master?urlpath=lab/tree/examples/demo.ipynb).
 
 ## Requirements


### PR DESCRIPTION
It seems to have been accidentally removed in https://github.com/jupyterlab/jupyterlab-git/pull/818