### PR TITLE
Ensure button styles for toolbar are applied

### DIFF
--- a/src/style/Toolbar.ts
+++ b/src/style/Toolbar.ts
@@ -84,13 +84,14 @@ export const toolbarMenuButtonSubtitleClass = style({
   fontWeight: 700
 });
 
+// Styles overriding default button style are marked as important to ensure application
 export const toolbarButtonClass = style({
   boxSizing: 'border-box',
   height: '24px',
-  width: 'var(--jp-private-running-button-width)',
+  width: 'var(--jp-private-running-button-width) !important',
 
   margin: 'auto 0 auto 0',
-  padding: '0px 6px',
+  padding: '0px 6px !important',
 
   border: 'none',
   outline: 'none',


### PR DESCRIPTION
Reusing `ActionButton` in https://github.com/jupyterlab/pull-requests shows that the CSS class was reloaded for `ActionButton`. That results in style override for the toolbar buttons.