### PR TITLE
Update README.md for installing project locally from source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ Requires NodeJS
 # Install new-ish JupyterLab
 pip install -U jupyterlab
 
-# Clone the repo to your local environment
-git clone https://github.com/jupyterlab/jupyterlab-git.git
+# Clone the repo to your local environment, ensure the git branch name is jlab-2
+git clone -b jlab-2 https://github.com/jupyterlab/jupyterlab-git.git
 cd jupyterlab-git
 
 # Install the server extension in development mode and enable it


### PR DESCRIPTION
At this moment, jupyterlab 2.x and 3.x has slight different build process. Jupyterlab 3.x version source code does not work at build time with build commands of jupyterlab 2.x. To install jupyterlab 2.x on local, while cloning repo, contributor has to ensure the branch of the jupyterlab git to be jlab-2. This change request has very minor change to add branch name while cloning the repository for building & installing locally.