### PR TITLE
Prevent empty JSON body from causing None error in git config endpoint

### DIFF
--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -646,8 +646,8 @@ class GitConfigHandler(GitHandler):
         """
         POST get (if no options are passed) or set configuration options
         """
-        data = self.get_json_body()
-        options = data.get("options", {}) if data else {}
+        data = self.get_json_body() or {}
+        options = data.get("options", {})
 
         filtered_options = {k: v for k, v in options.items() if k in ALLOWED_OPTIONS}
         response = await self.git.config(self.url2localpath(path), **filtered_options)

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -647,7 +647,7 @@ class GitConfigHandler(GitHandler):
         POST get (if no options are passed) or set configuration options
         """
         data = self.get_json_body()
-        options = data.get("options", {})
+        options = data.get("options", {}) if data else {}
 
         filtered_options = {k: v for k, v in options.items() if k in ALLOWED_OPTIONS}
         response = await self.git.config(self.url2localpath(path), **filtered_options)


### PR DESCRIPTION
### Notes
- Address #958 

### Tests
- `pytest jupyterlab_git`, verified all tests pass