### PR TITLE
Refresh file browser on `HEAD` change (#950)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,12 @@ async function activate(
       gitExtension.pathRepository = change.newValue;
     }
   );
+
+  // Whenever the `HEAD` of the Git repository changes, refresh the file browser
+  gitExtension.headChanged.connect(() => {
+    filebrowser.model.refresh();
+  });
+
   // Whenever a user adds/renames/saves/deletes/modifies a file within the lab environment, refresh the Git status
   app.serviceManager.contents.fileChanged.connect(() =>
     gitExtension.refreshStatus()


### PR DESCRIPTION
Refreshes the file browser when the HEAD of the git repository change.

Fixes #950 