### PR TITLE
Correct repository as root case

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -7,6 +7,7 @@ import pathlib
 import re
 import shlex
 import subprocess
+import traceback
 from urllib.parse import unquote
 
 import nbformat
@@ -152,7 +153,8 @@ async def execute(
         get_logger().debug(
             "Code: {}\nOutput: {}\nError: {}".format(code, log_output, log_error)
         )
-    except BaseException:
+    except BaseException as e:
+        code, output, error = -1, "", traceback.format_exc()
         get_logger().warning("Fail to execute {!s}".format(cmdline), exc_info=True)
     finally:
         execution_lock.release()

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -277,7 +277,7 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
   render(): React.ReactElement {
     return (
       <div className={panelWrapperClass}>
-        {this.state.repository ? (
+        {this.state.repository !== null ? (
           <React.Fragment>
             {this._renderToolbar()}
             {this._renderMain()}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -235,7 +235,7 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
           className={toolbarMenuButtonClass}
           title={this.props.trans.__(
             'Current repository: %1',
-            this.props.repository
+            '/' + this.props.repository
           )}
         >
           <desktopIcon.react className={toolbarMenuButtonIconClass} />
@@ -245,7 +245,7 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
               {this.props.trans.__('Current Repository')}{' '}
             </p>
             <p className={toolbarMenuButtonSubtitleClass}>
-              {PathExt.basename(this.props.repository)}
+              {PathExt.basename(this.props.repository) || '/'}
             </p>
           </div>
         </button>

--- a/src/model.ts
+++ b/src/model.ts
@@ -147,11 +147,18 @@ export class GitExtension implements IGitExtension {
     } else {
       const currentReady = this._readyPromise;
       this._pendingReadyPromise += 1;
-      this._readyPromise = Promise.all([currentReady, this.showPrefix(v)])
+      const currentFolder = v;
+      this._readyPromise = Promise.all([
+        currentReady,
+        this.showPrefix(currentFolder)
+      ])
         .then(([_, path]) => {
           if (path !== null) {
             // Remove relative path to get the Git repository root path
-            path = v.slice(0, v.length - path.length);
+            path = currentFolder.slice(
+              0,
+              Math.max(0, currentFolder.length - path.length)
+            );
           }
           change.newValue = this._pathRepository = path;
 
@@ -162,7 +169,9 @@ export class GitExtension implements IGitExtension {
         })
         .catch(reason => {
           this._pendingReadyPromise -= 1;
-          console.error(`Fail to find Git top level for path ${v}.\n${reason}`);
+          console.error(
+            `Fail to find Git top level for path ${currentFolder}.\n${reason}`
+          );
         });
     }
   }


### PR DESCRIPTION
Fixes #960

This correct the execute git command to return a code and the traceback when unexpected error occurred.

This correct the repository path setter when the server root is a git repository