### PR TITLE
Preserve commit message when switching to the History tab (#931) (#836)

### DIFF
--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -61,7 +61,7 @@ export interface ICommitBoxProps {
   /**
    * Callback invoked upon clicking a commit message submit button or otherwise submitting the form.
    */
-  onCommitSubmit: () => void;
+  onCommitSubmit: () => Promise<void>;
 }
 
 /**

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -45,23 +45,25 @@ export interface ICommitBoxProps {
   description: string;
 
   /**
-   * Callback invoked upon updating a commit message summary.
+   * Updates the commit message summary.
    *
-   * @param event - event object
+   * @param summary - commit message summary
    */
-  onSummaryChange: (event: any) => void;
+  setSummary: (summary: string) => void;
 
   /**
-   * Callback invoked upon updating a commit message description.
+   * Updates the commit message description.
    *
-   * @param event - event object
+   * @param description - commit message description
    */
-  onDescriptionChange: (event: any) => void;
+  setDescription: (description: string) => void;
 
   /**
-   * Callback invoked upon clicking a commit message submit button or otherwise submitting the form.
+   * Callback to invoke in order to commit changes.
+   *
+   * @returns a promise which commits changes
    */
-  onCommitSubmit: () => Promise<void>;
+  onCommit: () => Promise<void>;
 }
 
 /**
@@ -116,7 +118,7 @@ export class CommitBox extends React.Component<ICommitBoxProps> {
             'Enter a commit message summary (a single line, preferably less than 50 characters)'
           )}
           value={this.props.summary}
-          onChange={this.props.onSummaryChange}
+          onChange={this._onSummaryChange}
           onKeyPress={this._onSummaryKeyPress}
         />
         <TextareaAutosize
@@ -125,7 +127,7 @@ export class CommitBox extends React.Component<ICommitBoxProps> {
           placeholder={this.props.trans.__('Description (optional)')}
           title={this.props.trans.__('Enter a commit message description')}
           value={this.props.description}
-          onChange={this.props.onDescriptionChange}
+          onChange={this._onDescriptionChange}
         />
         <input
           className={commitButtonClass}
@@ -133,7 +135,7 @@ export class CommitBox extends React.Component<ICommitBoxProps> {
           title={title}
           value={this.props.label}
           disabled={disabled}
-          onClick={this.props.onCommitSubmit}
+          onClick={this.props.onCommit}
         />
       </form>
     );
@@ -154,6 +156,24 @@ export class CommitBox extends React.Component<ICommitBoxProps> {
       binding => binding.command === CommandIDs.gitSubmitCommand
     );
     return binding.keys.join(' ');
+  };
+
+  /**
+   * Callback invoked upon updating a commit message description.
+   *
+   * @param event - event object
+   */
+  private _onDescriptionChange = (event: any): void => {
+    this.props.setDescription(event.target.value);
+  };
+
+  /**
+   * Callback invoked upon updating a commit message summary.
+   *
+   * @param event - event object
+   */
+  private _onSummaryChange = (event: any): void => {
+    this.props.setSummary(event.target.value);
   };
 
   /**
@@ -184,7 +204,7 @@ export class CommitBox extends React.Component<ICommitBoxProps> {
     commandArgs: CommandRegistry.ICommandExecutedArgs
   ): void => {
     if (commandArgs.id === CommandIDs.gitSubmitCommand && this._canCommit()) {
-      this.props.onCommitSubmit();
+      this.props.onCommit();
     }
   };
 }

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -35,19 +35,6 @@ export interface ICommitBoxProps {
   trans: TranslationBundle;
 
   /**
-   * Callback to invoke in order to commit changes.
-   *
-   * @param msg - commit message
-   * @returns a promise which commits changes
-   */
-  onCommit: (msg: string) => Promise<void>;
-}
-
-/**
- * Interface describing component state.
- */
-export interface ICommitBoxState {
-  /**
    * Commit message summary.
    */
   summary: string;
@@ -56,15 +43,31 @@ export interface ICommitBoxState {
    * Commit message description.
    */
   description: string;
+
+  /**
+   * Callback invoked upon updating a commit message summary.
+   *
+   * @param event - event object
+   */
+  onSummaryChange: (event: any) => void;
+
+  /**
+   * Callback invoked upon updating a commit message description.
+   *
+   * @param event - event object
+   */
+  onDescriptionChange: (event: any) => void;
+
+  /**
+   * Callback invoked upon clicking a commit message submit button or otherwise submitting the form.
+   */
+  onCommitSubmit: () => void;
 }
 
 /**
  * React component for entering a commit message.
  */
-export class CommitBox extends React.Component<
-  ICommitBoxProps,
-  ICommitBoxState
-> {
+export class CommitBox extends React.Component<ICommitBoxProps> {
   /**
    * Returns a React component for entering a commit message.
    *
@@ -73,10 +76,6 @@ export class CommitBox extends React.Component<
    */
   constructor(props: ICommitBoxProps) {
     super(props);
-    this.state = {
-      summary: '',
-      description: ''
-    };
   }
 
   componentDidMount(): void {
@@ -96,7 +95,7 @@ export class CommitBox extends React.Component<
     const disabled = !this._canCommit();
     const title = !this.props.hasFiles
       ? this.props.trans.__('Disabled: No files are staged for commit')
-      : !this.state.summary
+      : !this.props.summary
       ? this.props.trans.__('Disabled: No commit message summary')
       : this.props.label;
 
@@ -116,8 +115,8 @@ export class CommitBox extends React.Component<
           title={this.props.trans.__(
             'Enter a commit message summary (a single line, preferably less than 50 characters)'
           )}
-          value={this.state.summary}
-          onChange={this._onSummaryChange}
+          value={this.props.summary}
+          onChange={this.props.onSummaryChange}
           onKeyPress={this._onSummaryKeyPress}
         />
         <TextareaAutosize
@@ -125,8 +124,8 @@ export class CommitBox extends React.Component<
           minRows={5}
           placeholder={this.props.trans.__('Description (optional)')}
           title={this.props.trans.__('Enter a commit message description')}
-          value={this.state.description}
-          onChange={this._onDescriptionChange}
+          value={this.props.description}
+          onChange={this.props.onDescriptionChange}
         />
         <input
           className={commitButtonClass}
@@ -134,7 +133,7 @@ export class CommitBox extends React.Component<
           title={title}
           value={this.props.label}
           disabled={disabled}
-          onClick={this._onCommitSubmit}
+          onClick={this.props.onCommitSubmit}
         />
       </form>
     );
@@ -144,7 +143,7 @@ export class CommitBox extends React.Component<
    * Whether a commit can be performed (files are staged and summary is not empty).
    */
   private _canCommit(): boolean {
-    return !!(this.props.hasFiles && this.state.summary);
+    return !!(this.props.hasFiles && this.props.summary);
   }
 
   /**
@@ -155,39 +154,6 @@ export class CommitBox extends React.Component<
       binding => binding.command === CommandIDs.gitSubmitCommand
     );
     return binding.keys.join(' ');
-  };
-
-  /**
-   * Callback invoked upon clicking a commit message submit button or otherwise submitting the form.
-   */
-  private _onCommitSubmit = (): void => {
-    const msg = this.state.summary + '\n\n' + this.state.description + '\n';
-    this.props.onCommit(msg);
-
-    // NOTE: we assume here that committing changes always works and we can safely clear component state
-    this._reset();
-  };
-
-  /**
-   * Callback invoked upon updating a commit message description.
-   *
-   * @param event - event object
-   */
-  private _onDescriptionChange = (event: any): void => {
-    this.setState({
-      description: event.target.value
-    });
-  };
-
-  /**
-   * Callback invoked upon updating a commit message summary.
-   *
-   * @param event - event object
-   */
-  private _onSummaryChange = (event: any): void => {
-    this.setState({
-      summary: event.target.value
-    });
   };
 
   /**
@@ -218,17 +184,7 @@ export class CommitBox extends React.Component<
     commandArgs: CommandRegistry.ICommandExecutedArgs
   ): void => {
     if (commandArgs.id === CommandIDs.gitSubmitCommand && this._canCommit()) {
-      this._onCommitSubmit();
+      this.props.onCommitSubmit();
     }
   };
-
-  /**
-   * Resets component state (e.g., in order to re-initialize the commit message input box).
-   */
-  private _reset(): void {
-    this.setState({
-      summary: '',
-      description: ''
-    });
-  }
 }

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -105,6 +105,16 @@ export interface IGitPanelState {
    * Panel tab identifier.
    */
   tab: number;
+
+  /**
+   * Commit message summary.
+   */
+  summary: string;
+
+  /**
+   * Commit message description.
+   */
+  description: string;
 }
 
 /**
@@ -129,7 +139,9 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       nCommitsBehind: 0,
       pastCommits: [],
       repository: pathRepository,
-      tab: 0
+      tab: 0,
+      summary: '',
+      description: ''
     };
   }
 
@@ -391,23 +403,21 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           settings={this.props.settings}
           trans={this.props.trans}
         />
-        {this.props.settings.composite['simpleStaging'] ? (
-          <CommitBox
-            commands={this.props.commands}
-            hasFiles={this._markedFiles.length > 0}
-            trans={this.props.trans}
-            label={buttonLabel}
-            onCommit={this.commitMarkedFiles}
-          />
-        ) : (
-          <CommitBox
-            commands={this.props.commands}
-            hasFiles={this._hasStagedFile()}
-            trans={this.props.trans}
-            label={buttonLabel}
-            onCommit={this.commitStagedFiles}
-          />
-        )}
+        <CommitBox
+          commands={this.props.commands}
+          hasFiles={
+            this.props.settings.composite['simpleStaging']
+              ? this._markedFiles.length > 0
+              : this._hasStagedFile()
+          }
+          trans={this.props.trans}
+          label={buttonLabel}
+          summary={this.state.summary}
+          description={this.state.description}
+          onSummaryChange={this._onSummaryChange}
+          onDescriptionChange={this._onDescriptionChange}
+          onCommitSubmit={this._onCommitSubmit}
+        />
       </React.Fragment>
     );
   }
@@ -491,6 +501,42 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
     this.setState({
       tab: tab
     });
+  };
+
+  /**
+   * Callback invoked upon updating a commit message description.
+   *
+   * @param event - event object
+   */
+  private _onDescriptionChange = (event: any): void => {
+    this.setState({
+      description: event.target.value
+    });
+  };
+
+  /**
+   * Callback invoked upon updating a commit message summary.
+   *
+   * @param event - event object
+   */
+  private _onSummaryChange = (event: any): void => {
+    this.setState({
+      summary: event.target.value
+    });
+  };
+
+  /**
+   * Callback invoked upon clicking a commit message submit button or otherwise submitting the form.
+   */
+  private _onCommitSubmit = (): void => {
+    const msg = this.state.summary + '\n\n' + this.state.description + '\n';
+    this.props.settings.composite['simpleStaging'] ? this.commitMarkedFiles(msg) : this.commitStagedFiles(msg);
+
+    // NOTE: we assume here that committing changes always works
+    this.setState({
+      summary: '',
+      description: ''
+    })
   };
 
   /**

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -109,12 +109,12 @@ export interface IGitPanelState {
   /**
    * Commit message summary.
    */
-  summary: string;
+  commitSummary: string;
 
   /**
    * Commit message description.
    */
-  description: string;
+  commitDescription: string;
 }
 
 /**
@@ -140,8 +140,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       pastCommits: [],
       repository: pathRepository,
       tab: 0,
-      summary: '',
-      description: ''
+      commitSummary: '',
+      commitDescription: ''
     };
   }
 
@@ -414,8 +414,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           }
           trans={this.props.trans}
           label={buttonLabel}
-          summary={this.state.summary}
-          description={this.state.description}
+          summary={this.state.commitSummary}
+          description={this.state.commitDescription}
           onSummaryChange={this._onSummaryChange}
           onDescriptionChange={this._onDescriptionChange}
           onCommitSubmit={this._onCommitSubmit}
@@ -512,7 +512,7 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
    */
   private _onDescriptionChange = (event: any): void => {
     this.setState({
-      description: event.target.value
+      commitDescription: event.target.value
     });
   };
 
@@ -523,7 +523,7 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
    */
   private _onSummaryChange = (event: any): void => {
     this.setState({
-      summary: event.target.value
+      commitSummary: event.target.value
     });
   };
 
@@ -531,7 +531,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
    * Callback invoked upon clicking a commit message submit button or otherwise submitting the form.
    */
   private _onCommitSubmit = async (): Promise<void> => {
-    const msg = this.state.summary + '\n\n' + this.state.description + '\n';
+    const msg =
+      this.state.commitSummary + '\n\n' + this.state.commitDescription + '\n';
     const onCommit = this.props.settings.composite['simpleStaging']
       ? this.commitMarkedFiles
       : this.commitStagedFiles;
@@ -541,8 +542,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
 
       // Only erase commit message upon success
       this.setState({
-        summary: '',
-        description: ''
+        commitSummary: '',
+        commitDescription: ''
       });
     } catch (error) {
       console.error(error);

--- a/tests/test-components/CommitBox.spec.tsx
+++ b/tests/test-components/CommitBox.spec.tsx
@@ -17,9 +17,9 @@ describe('CommitBox', () => {
   const trans = nullTranslator.load('jupyterlab-git');
 
   const defaultProps: ICommitBoxProps = {
-    onCommitSubmit: async () => {},
-    onSummaryChange: () => {},
-    onDescriptionChange: () => {},
+    onCommit: async () => {},
+    setSummary: () => {},
+    setDescription: () => {},
     summary: '',
     description: '',
     hasFiles: false,

--- a/tests/test-components/CommitBox.spec.tsx
+++ b/tests/test-components/CommitBox.spec.tsx
@@ -3,7 +3,7 @@ import { CommandRegistry } from '@lumino/commands';
 import { shallow } from 'enzyme';
 import 'jest';
 import * as React from 'react';
-import { CommitBox } from '../../src/components/CommitBox';
+import { CommitBox, ICommitBoxProps } from '../../src/components/CommitBox';
 import { CommandIDs } from '../../src/tokens';
 
 describe('CommitBox', () => {
@@ -16,50 +16,28 @@ describe('CommitBox', () => {
 
   const trans = nullTranslator.load('jupyterlab-git');
 
+  const defaultProps: ICommitBoxProps = {
+    onCommitSubmit: async () => {},
+    onSummaryChange: () => {},
+    onDescriptionChange: () => {},
+    summary: '',
+    description: '',
+    hasFiles: false,
+    commands: defaultCommands,
+    trans: trans,
+    label: 'Commit'
+  };
+
   describe('#constructor()', () => {
     it('should return a new instance', () => {
-      const box = new CommitBox({
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      });
+      const box = new CommitBox(defaultProps);
       expect(box).toBeInstanceOf(CommitBox);
-    });
-
-    it('should set the default commit message summary to an empty string', () => {
-      const box = new CommitBox({
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      });
-      expect(box.state.summary).toEqual('');
-    });
-
-    it('should set the default commit message description to an empty string', () => {
-      const box = new CommitBox({
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      });
-      expect(box.state.description).toEqual('');
     });
   });
 
   describe('#render()', () => {
     it('should display placeholder text for the commit message summary', () => {
-      const props = {
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      };
+      const props = defaultProps;
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="text"]').first();
       expect(node.prop('placeholder')).toEqual(
@@ -75,11 +53,8 @@ describe('CommitBox', () => {
         selector: '.jp-git-CommitBox'
       });
       const props = {
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: adjustedCommands,
-        trans: trans,
-        label: 'Commit'
+        ...defaultProps,
+        commands: adjustedCommands
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="text"]').first();
@@ -89,78 +64,42 @@ describe('CommitBox', () => {
     });
 
     it('should set a `title` attribute on the input element to provide a commit message summary', () => {
-      const props = {
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      };
+      const props = defaultProps;
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="text"]').first();
       expect(node.prop('title').length > 0).toEqual(true);
     });
 
     it('should display placeholder text for the commit message description', () => {
-      const props = {
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      };
+      const props = defaultProps;
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('TextareaAutosize').first();
       expect(node.prop('placeholder')).toEqual('Description (optional)');
     });
 
     it('should set a `title` attribute on the input element to provide a commit message description', () => {
-      const props = {
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      };
+      const props = defaultProps;
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('TextareaAutosize').first();
       expect(node.prop('title').length > 0).toEqual(true);
     });
 
     it('should display a button to commit changes', () => {
-      const props = {
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      };
+      const props = defaultProps;
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="button"]').first();
       expect(node.prop('value')).toEqual('Commit');
     });
 
     it('should set a `title` attribute on the button to commit changes', () => {
-      const props = {
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      };
+      const props = defaultProps;
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="button"]').first();
       expect(node.prop('title').length > 0).toEqual(true);
     });
 
     it('should apply a class to disable the commit button when no files have changes to commit', () => {
-      const props = {
-        onCommit: async () => {},
-        hasFiles: false,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
-      };
+      const props = defaultProps;
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="button"]').first();
       const prop = node.prop('disabled');
@@ -169,11 +108,8 @@ describe('CommitBox', () => {
 
     it('should apply a class to disable the commit button when files have changes to commit, but the user has not entered a commit message summary', () => {
       const props = {
-        onCommit: async () => {},
-        hasFiles: true,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
+        ...defaultProps,
+        hasFiles: true
       };
       const component = shallow(<CommitBox {...props} />);
       const node = component.find('input[type="button"]').first();
@@ -183,17 +119,11 @@ describe('CommitBox', () => {
 
     it('should not apply a class to disable the commit button when files have changes to commit and the user has entered a commit message summary', () => {
       const props = {
-        onCommit: async () => {},
-        hasFiles: true,
-        commands: defaultCommands,
-        trans: trans,
-        label: 'Commit'
+        ...defaultProps,
+        summary: 'beep boop',
+        hasFiles: true
       };
       const component = shallow(<CommitBox {...props} />);
-      component.setState({
-        summary: 'beep boop'
-      });
-
       const node = component.find('input[type="button"]').first();
       const prop = node.prop('disabled');
       expect(prop).toEqual(false);

--- a/tests/test-components/GitPanel.spec.tsx
+++ b/tests/test-components/GitPanel.spec.tsx
@@ -78,10 +78,31 @@ describe('GitPanel', () => {
     await props.model.ready;
   });
 
-  describe('#commitStagedFiles()', () => {
-    it('should commit when commit message is provided', async () => {
-      const spy = jest.spyOn(GitModel.prototype, 'commit');
+  describe('#constructor()', () => {
+    it('should return a new instance', () => {
+      const panel = new GitPanel(props);
+      expect(panel).toBeInstanceOf(GitPanel);
+    });
 
+    it('should set the default commit message summary to an empty string', () => {
+      const panel = new GitPanel(props);
+      expect(panel.state.summary).toEqual('');
+    });
+
+    it('should set the default commit message description to an empty string', () => {
+      const panel = new GitPanel(props);
+      expect(panel.state.summary).toEqual('');
+    });
+  });
+
+  describe('#commitStagedFiles()', () => {
+    let spy: jest.SpyInstance<Promise<void>>;
+
+    beforeEach(() => {
+      spy = jest.spyOn(GitModel.prototype, 'commit').mockResolvedValue();
+    });
+
+    it('should commit when commit message is provided', async () => {
       // Mock identity look up
       const identity = jest
         .spyOn(GitModel.prototype, 'config')
@@ -100,16 +121,12 @@ describe('GitPanel', () => {
     });
 
     it('should not commit without a commit message', async () => {
-      const spy = jest.spyOn(GitModel.prototype, 'commit');
       const panel = new GitPanel(props);
       await panel.commitStagedFiles('');
       expect(spy).not.toHaveBeenCalled();
-      spy.mockRestore();
     });
 
     it('should prompt for user identity if user.name is not set', async () => {
-      const spy = jest.spyOn(GitModel.prototype, 'commit');
-
       // Mock identity look up
       const identity = jest
         .spyOn(GitModel.prototype, 'config')
@@ -157,8 +174,6 @@ describe('GitPanel', () => {
     });
 
     it('should prompt for user identity if user.email is not set', async () => {
-      const spy = jest.spyOn(GitModel.prototype, 'commit');
-
       // Mock identity look up
       const identity = jest
         .spyOn(GitModel.prototype, 'config')
@@ -206,8 +221,6 @@ describe('GitPanel', () => {
     });
 
     it('should not commit if no user identity is set and the user rejects the dialog', async () => {
-      const spy = jest.spyOn(GitModel.prototype, 'commit');
-
       // Mock identity look up
       const identity = jest
         .spyOn(GitModel.prototype, 'config')

--- a/tests/test-components/GitPanel.spec.tsx
+++ b/tests/test-components/GitPanel.spec.tsx
@@ -86,12 +86,12 @@ describe('GitPanel', () => {
 
     it('should set the default commit message summary to an empty string', () => {
       const panel = new GitPanel(props);
-      expect(panel.state.summary).toEqual('');
+      expect(panel.state.commitSummary).toEqual('');
     });
 
     it('should set the default commit message description to an empty string', () => {
       const panel = new GitPanel(props);
-      expect(panel.state.summary).toEqual('');
+      expect(panel.state.commitDescription).toEqual('');
     });
   });
 

--- a/tests/test-components/GitPanel.spec.tsx
+++ b/tests/test-components/GitPanel.spec.tsx
@@ -249,7 +249,13 @@ describe('GitPanel', () => {
       });
 
       const panel = new GitPanel(props);
-      await panel.commitStagedFiles('Initial commit');
+      try {
+        await panel.commitStagedFiles('Initial commit');
+      } catch (error) {
+        expect(error.message).toEqual(
+          'Failed to set your identity. User refused to set identity.'
+        );
+      }
       expect(identity).toHaveBeenCalledTimes(1);
       expect(identity).toHaveBeenCalledWith();
       expect(spy).not.toHaveBeenCalled();

--- a/tests/test-components/GitPanel.spec.tsx
+++ b/tests/test-components/GitPanel.spec.tsx
@@ -95,170 +95,134 @@ describe('GitPanel', () => {
     });
   });
 
-  describe('#commitStagedFiles()', () => {
-    let spy: jest.SpyInstance<Promise<void>>;
+  describe('#commitFiles()', () => {
+    let panel: GitPanel;
+    let commitSpy: jest.SpyInstance<Promise<void>>;
+    let configSpy: jest.SpyInstance<Promise<void | JSONObject>>;
+
+    const commitSummary = 'Fix really stupid bug';
+    const commitDescription = 'This will probably break everything :)';
+    const commitUser = {
+      'user.name': 'John Snow',
+      'user.email': 'john.snow@winteris.com'
+    };
+
+    const mockUtils = apputils as jest.Mocked<typeof apputils>;
+    const dialogValue: apputils.Dialog.IResult<any> = {
+      button: {
+        accept: true,
+        actions: [],
+        caption: '',
+        className: '',
+        displayType: 'default',
+        iconClass: '',
+        iconLabel: '',
+        label: ''
+      },
+      value: {
+        name: commitUser['user.name'],
+        email: commitUser['user.email']
+      }
+    };
+
+    /**
+     * Mock identity look up (GitModel.config)
+     */
+    const mockConfigImplementation = (key: 'user.email' | 'user.name') => {
+      return (options?: JSONObject): Promise<JSONObject> => {
+        const response = {
+          options: {
+            [key]: commitUser[key]
+          }
+        };
+        return Promise.resolve<JSONObject>(
+          options === undefined
+            ? response // When getting config options
+            : null // When setting config options
+        );
+      };
+    };
 
     beforeEach(() => {
-      spy = jest.spyOn(GitModel.prototype, 'commit').mockResolvedValue();
+      commitSpy = jest.spyOn(GitModel.prototype, 'commit').mockResolvedValue();
+      configSpy = jest.spyOn(GitModel.prototype, 'config');
+
+      const panelWrapper = shallow<GitPanel>(<GitPanel {...props} />);
+      panel = panelWrapper.instance();
     });
 
     it('should commit when commit message is provided', async () => {
-      // Mock identity look up
-      const identity = jest
-        .spyOn(GitModel.prototype, 'config')
-        .mockResolvedValue({
-          options: {
-            'user.name': 'John Snow',
-            'user.email': 'john.snow@winteris.com'
-          }
-        });
+      configSpy.mockResolvedValue({ options: commitUser });
+      panel.setState({ commitSummary, commitDescription });
+      await panel.commitFiles();
+      expect(configSpy).toHaveBeenCalledTimes(1);
+      expect(commitSpy).toHaveBeenCalledTimes(1);
+      expect(commitSpy).toHaveBeenCalledWith(
+        commitSummary + '\n\n' + commitDescription + '\n'
+      );
 
-      const panel = new GitPanel(props);
-      await panel.commitStagedFiles('Initial commit');
-      expect(identity).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith('Initial commit');
+      // Only erase commit message upon success
+      expect(panel.state.commitSummary).toEqual('');
+      expect(panel.state.commitDescription).toEqual('');
     });
 
     it('should not commit without a commit message', async () => {
-      const panel = new GitPanel(props);
-      await panel.commitStagedFiles('');
-      expect(spy).not.toHaveBeenCalled();
+      await panel.commitFiles();
+      expect(configSpy).not.toHaveBeenCalled();
+      expect(commitSpy).not.toHaveBeenCalled();
     });
 
     it('should prompt for user identity if user.name is not set', async () => {
-      // Mock identity look up
-      const identity = jest
-        .spyOn(GitModel.prototype, 'config')
-        .mockImplementation(options => {
-          let response: JSONObject = null;
-          if (options === undefined) {
-            response = {
-              options: {
-                'user.email': 'john.snow@winteris.com'
-              }
-            };
-          }
-          return Promise.resolve(response);
-        });
-      const mock = apputils as jest.Mocked<typeof apputils>;
-      mock.showDialog.mockResolvedValue({
-        button: {
-          accept: true,
-          actions: [],
-          caption: '',
-          className: '',
-          displayType: 'default',
-          iconClass: '',
-          iconLabel: '',
-          label: ''
-        },
-        value: {
-          name: 'John Snow',
-          email: 'john.snow@winteris.com'
-        }
-      });
+      configSpy.mockImplementation(mockConfigImplementation('user.email'));
+      mockUtils.showDialog.mockResolvedValue(dialogValue);
 
-      const panel = new GitPanel(props);
-      await panel.commitStagedFiles('Initial commit');
-      expect(identity).toHaveBeenCalledTimes(2);
-      expect(identity.mock.calls[0]).toHaveLength(0);
-      expect(identity.mock.calls[1]).toEqual([
-        {
-          'user.name': 'John Snow',
-          'user.email': 'john.snow@winteris.com'
-        }
-      ]);
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith('Initial commit');
+      panel.setState({ commitSummary });
+      await panel.commitFiles();
+      expect(configSpy).toHaveBeenCalledTimes(2);
+      expect(configSpy.mock.calls[0]).toHaveLength(0);
+      expect(configSpy.mock.calls[1]).toEqual([commitUser]);
+      expect(commitSpy).toHaveBeenCalledTimes(1);
+      expect(commitSpy).toHaveBeenCalledWith(commitSummary);
     });
 
     it('should prompt for user identity if user.email is not set', async () => {
-      // Mock identity look up
-      const identity = jest
-        .spyOn(GitModel.prototype, 'config')
-        .mockImplementation(options => {
-          let response: JSONObject = null;
-          if (options === undefined) {
-            response = {
-              options: {
-                'user.name': 'John Snow'
-              }
-            };
-          }
-          return Promise.resolve(response);
-        });
-      const mock = apputils as jest.Mocked<typeof apputils>;
-      mock.showDialog.mockResolvedValue({
-        button: {
-          accept: true,
-          actions: [],
-          caption: '',
-          className: '',
-          displayType: 'default',
-          iconClass: '',
-          iconLabel: '',
-          label: ''
-        },
-        value: {
-          name: 'John Snow',
-          email: 'john.snow@winteris.com'
-        }
-      });
+      configSpy.mockImplementation(mockConfigImplementation('user.name'));
+      mockUtils.showDialog.mockResolvedValue(dialogValue);
 
-      const panel = new GitPanel(props);
-      await panel.commitStagedFiles('Initial commit');
-      expect(identity).toHaveBeenCalledTimes(2);
-      expect(identity.mock.calls[0]).toHaveLength(0);
-      expect(identity.mock.calls[1]).toEqual([
-        {
-          'user.name': 'John Snow',
-          'user.email': 'john.snow@winteris.com'
-        }
-      ]);
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith('Initial commit');
+      panel.setState({ commitSummary });
+      await panel.commitFiles();
+      expect(configSpy).toHaveBeenCalledTimes(2);
+      expect(configSpy.mock.calls[0]).toHaveLength(0);
+      expect(configSpy.mock.calls[1]).toEqual([commitUser]);
+      expect(commitSpy).toHaveBeenCalledTimes(1);
+      expect(commitSpy).toHaveBeenCalledWith(commitSummary);
     });
 
     it('should not commit if no user identity is set and the user rejects the dialog', async () => {
-      // Mock identity look up
-      const identity = jest
-        .spyOn(GitModel.prototype, 'config')
-        .mockImplementation(options => {
-          let response: JSONObject = null;
-          if (options === undefined) {
-            response = {
-              options: {}
-            };
-          }
-          return Promise.resolve(response);
-        });
-      const mock = apputils as jest.Mocked<typeof apputils>;
-      mock.showDialog.mockResolvedValue({
+      configSpy.mockResolvedValue({ options: {} });
+      mockUtils.showDialog.mockResolvedValue({
         button: {
-          accept: false,
-          actions: [],
-          caption: '',
-          className: '',
-          displayType: 'default',
-          iconClass: '',
-          iconLabel: '',
-          label: ''
+          ...dialogValue.button,
+          accept: false
         },
         value: null
       });
 
-      const panel = new GitPanel(props);
+      panel.setState({ commitSummary, commitDescription });
       try {
-        await panel.commitStagedFiles('Initial commit');
+        await panel.commitFiles();
       } catch (error) {
         expect(error.message).toEqual(
           'Failed to set your identity. User refused to set identity.'
         );
       }
-      expect(identity).toHaveBeenCalledTimes(1);
-      expect(identity).toHaveBeenCalledWith();
-      expect(spy).not.toHaveBeenCalled();
+      expect(configSpy).toHaveBeenCalledTimes(1);
+      expect(configSpy).toHaveBeenCalledWith();
+      expect(commitSpy).not.toHaveBeenCalled();
+
+      // Should not erase commit message
+      expect(panel.state.commitSummary).toEqual(commitSummary);
+      expect(panel.state.commitDescription).toEqual(commitDescription);
     });
   });
 


### PR DESCRIPTION
When switching to the history tab, the commit description and summary are not erased.
When the commit fails (ex: pre-commit checks), the commit description and summary are not erased.

Fixes #931 
Fixes #836