### PR TITLE
Change the label to Refreshing... on click

### DIFF
--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -465,10 +465,12 @@ export function addCommands(
             const widget = await buildDiffWidget(model, diffWidget.toolbar);
 
             diffWidget.toolbar.addItem('spacer', Toolbar.createSpacerItem());
+            const refreshLabel = trans.__('Refresh');
 
             const refreshButton = new ToolbarButton({
-              label: trans.__('Refresh'),
+              label: refreshLabel,
               onClick: async () => {
+                refreshButton.title.label = trans.__('Refreshing...');
                 await widget.refresh();
                 refreshButton.hide();
               },
@@ -479,6 +481,7 @@ export function addCommands(
             diffWidget.toolbar.addItem('refresh', refreshButton);
 
             model.changed.connect(() => {
+              refreshButton.title.label = refreshLabel;
               refreshButton.show();
             });
 


### PR DESCRIPTION
Some exploration to address #932:
- maybe we won't need to change the colour as JupyterLab 3.1 changed the colour definitions
- I would like to add `:active` pseudo-class but maybe this is something that needs to be done in the lab
- Maybe the button should disappear and non-clickable text show up, or maybe the button should become inactive, but I think it might be better to keep the solution simple.