### PR TITLE
Add 'Discard All and Pull' button

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -107,7 +107,7 @@
           },
           {
             "command": "git:pull",
-            "args": { "discard": true }
+            "args": { "force": true }
           },
           {
             "command": "git:add-remote"

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -99,7 +99,15 @@
             "command": "git:push"
           },
           {
+            "command": "git:push",
+            "args": { "force": true }
+          },
+          {
             "command": "git:pull"
+          },
+          {
+            "command": "git:pull",
+            "args": { "discard": true }
           },
           {
             "command": "git:add-remote"

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -391,11 +391,11 @@ export function addCommands(
   /** Add git pull command */
   commands.addCommand(CommandIDs.gitPull, {
     label: args =>
-      args.discard
+      args.force
         ? trans.__('Pull from Remote (Force)')
         : trans.__('Pull from Remote'),
     caption: args =>
-      args.discard
+      args.force
         ? trans.__(
             'Discard all current changes and pull from remote repository'
           )
@@ -403,7 +403,7 @@ export function addCommands(
     isEnabled: () => gitModel.pathRepository !== null,
     execute: async args => {
       try {
-        if (args.discard) {
+        if (args.force) {
           await discardAllChanges(gitModel, trans, args.fallback as boolean);
         }
         logger.log({
@@ -438,7 +438,7 @@ export function addCommands(
             )
         ) {
           await commands.execute(CommandIDs.gitPull, {
-            discard: true,
+            force: true,
             fallback: true
           });
         } else {
@@ -1197,7 +1197,7 @@ export function createGitMenu(
       menu.addItem({ command, args: { force: true } });
     }
     if (command === CommandIDs.gitPull) {
-      menu.addItem({ command, args: { discard: true } });
+      menu.addItem({ command, args: { force: true } });
     }
   });
 

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -443,8 +443,9 @@ export function addCommands(
           });
         } else {
           if ((error as any).cancelled) {
+            // Empty message to hide alert
             logger.log({
-              message: trans.__('Pull cancelled'),
+              message: '',
               level: Level.INFO
             });
           } else {

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -425,11 +425,24 @@ export function addCommands(
           'Encountered an error when pulling changes. Error: ',
           error
         );
-        logger.log({
-          message: trans.__('Failed to pull'),
-          level: Level.ERROR,
-          error: error as Error
-        });
+
+        // Discard changes then retry pull
+        if (
+          (error as string)
+            .toLowerCase()
+            .includes(
+              'your local changes to the following files would be overwritten by merge'
+            )
+        ) {
+          await discardAllChanges(gitModel, trans, true);
+          await commands.execute(CommandIDs.gitPull, {} as any);
+        } else {
+          logger.log({
+            message: trans.__('Failed to pull'),
+            level: Level.ERROR,
+            error
+          });
+        }
       }
     }
   });

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -426,16 +426,18 @@ export function addCommands(
           error
         );
 
+        const errorMsg = typeof error === 'string' ? error : error.message;
+
         // Discard changes then retry pull
         if (
-          (error as string)
+          errorMsg
             .toLowerCase()
             .includes(
               'your local changes to the following files would be overwritten by merge'
             )
         ) {
           await discardAllChanges(gitModel, trans, true);
-          await commands.execute(CommandIDs.gitPull, {} as any);
+          await commands.execute(CommandIDs.gitPull);
         } else {
           logger.log({
             message: trans.__('Failed to pull'),

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -21,6 +21,7 @@ import { ContextCommandIDs, CommandIDs, Git } from '../tokens';
 import { ActionButton } from './ActionButton';
 import { FileItem } from './FileItem';
 import { GitStage } from './GitStage';
+import { discardAllChanges as _discardAllChanges } from '../widgets/discardAllChanges';
 
 export interface IFileListState {
   selectedFile: Git.IStatusFile | null;
@@ -189,7 +190,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     const result = await showDialog({
       title: this.props.trans.__('Discard all changes'),
       body: this.props.trans.__(
-        'Are you sure you want to permanently discard changes to all files? This action cannot be undone.'
+        'Are you sure you want to permanently discard changes to all unstaged files? This action cannot be undone.'
       ),
       buttons: [
         Dialog.cancelButton({ label: this.props.trans.__('Cancel') }),
@@ -211,26 +212,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   /** Discard changes in all unstaged and staged files */
   discardAllChanges = async (event: React.MouseEvent): Promise<void> => {
     event.stopPropagation();
-    const result = await showDialog({
-      title: this.props.trans.__('Discard all changes'),
-      body: this.props.trans.__(
-        'Are you sure you want to permanently discard changes to all files? This action cannot be undone.'
-      ),
-      buttons: [
-        Dialog.cancelButton({ label: this.props.trans.__('Cancel') }),
-        Dialog.warnButton({ label: this.props.trans.__('Discard') })
-      ]
-    });
-    if (result.button.accept) {
-      try {
-        await this.props.model.resetToCommit();
-      } catch (reason) {
-        showErrorMessage(
-          this.props.trans.__('Discard all changes failed.'),
-          reason
-        );
-      }
-    }
+    await _discardAllChanges(this.props.model, this.props.trans);
   };
 
   /** Add a specific unstaged file */

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -21,7 +21,7 @@ import { ContextCommandIDs, CommandIDs, Git } from '../tokens';
 import { ActionButton } from './ActionButton';
 import { FileItem } from './FileItem';
 import { GitStage } from './GitStage';
-import { discardAllChanges as _discardAllChanges } from '../widgets/discardAllChanges';
+import { discardAllChanges } from '../widgets/discardAllChanges';
 
 export interface IFileListState {
   selectedFile: Git.IStatusFile | null;
@@ -212,7 +212,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   /** Discard changes in all unstaged and staged files */
   discardAllChanges = async (event: React.MouseEvent): Promise<void> => {
     event.stopPropagation();
-    await _discardAllChanges(this.props.model, this.props.trans);
+    await discardAllChanges(this.props.model, this.props.trans);
   };
 
   /** Add a specific unstaged file */

--- a/src/model.ts
+++ b/src/model.ts
@@ -786,14 +786,23 @@ export class GitExtension implements IGitExtension {
    * Fetch changes from a remote repository.
    *
    * @param auth - remote authentication information
+   * @param discard - whether or not to discard all changes
    * @returns promise which resolves upon fetching changes
    *
    * @throws {Git.NotInRepository} If the current path is not a Git repository
    * @throws {Git.GitResponseError} If the server response is not ok
    * @throws {ServerConnection.NetworkError} If the request cannot be made
    */
-  async pull(auth?: Git.IAuth): Promise<Git.IResultWithMessage> {
+  async pull(
+    auth?: Git.IAuth,
+    discard = false
+  ): Promise<Git.IResultWithMessage> {
     const path = await this._getPathRepository();
+
+    if (discard) {
+      await this.resetToCommit('HEAD');
+    }
+
     const data = this._taskHandler.execute<Git.IResultWithMessage>(
       'git:pull',
       async () => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -786,23 +786,14 @@ export class GitExtension implements IGitExtension {
    * Fetch changes from a remote repository.
    *
    * @param auth - remote authentication information
-   * @param discard - whether or not to discard all changes
    * @returns promise which resolves upon fetching changes
    *
    * @throws {Git.NotInRepository} If the current path is not a Git repository
    * @throws {Git.GitResponseError} If the server response is not ok
    * @throws {ServerConnection.NetworkError} If the request cannot be made
    */
-  async pull(
-    auth?: Git.IAuth,
-    discard = false
-  ): Promise<Git.IResultWithMessage> {
+  async pull(auth?: Git.IAuth): Promise<Git.IResultWithMessage> {
     const path = await this._getPathRepository();
-
-    if (discard) {
-      await this.resetToCommit('HEAD');
-    }
-
     const data = this._taskHandler.execute<Git.IResultWithMessage>(
       'git:pull',
       async () => {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1076,6 +1076,7 @@ export enum CommandIDs {
   gitPush = 'git:push',
   gitForcePush = 'git:force-push',
   gitPull = 'git:pull',
+  gitDiscardPull = 'git:discard-pull',
   gitSubmitCommand = 'git:submit-commit',
   gitShowDiff = 'git:show-diff'
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1074,9 +1074,7 @@ export enum CommandIDs {
   gitMerge = 'git:merge',
   gitOpenGitignore = 'git:open-gitignore',
   gitPush = 'git:push',
-  gitForcePush = 'git:force-push',
   gitPull = 'git:pull',
-  gitDiscardPull = 'git:discard-pull',
   gitSubmitCommand = 'git:submit-commit',
   gitShowDiff = 'git:show-diff'
 }

--- a/src/widgets/discardAllChanges.ts
+++ b/src/widgets/discardAllChanges.ts
@@ -16,7 +16,7 @@ export async function discardAllChanges(
     title: trans.__('Discard all changes'),
     body: isFallback
       ? trans.__(
-          'Do you want to permanently discard changes to all files and pull? This action cannot be undone.'
+          'Your current changes forbid pulling the latest changes. Do you want to permanently discard those changes? This action cannot be undone.'
         )
       : trans.__(
           'Are you sure you want to permanently discard changes to all files? This action cannot be undone.'
@@ -36,5 +36,8 @@ export async function discardAllChanges(
     }
   }
 
-  return Promise.reject('The user refused to discard all changes');
+  return Promise.reject({
+    cancelled: true,
+    message: 'The user refused to discard all changes'
+  });
 }

--- a/src/widgets/discardAllChanges.ts
+++ b/src/widgets/discardAllChanges.ts
@@ -1,0 +1,33 @@
+import { showDialog, Dialog, showErrorMessage } from '@jupyterlab/apputils';
+import { TranslationBundle } from '@jupyterlab/translation';
+import { IGitExtension } from '../tokens';
+
+/**
+ * Discard changes in all unstaged and staged files
+ */
+export async function discardAllChanges(
+  model: IGitExtension,
+  trans: TranslationBundle
+): Promise<void> {
+  const result = await showDialog({
+    title: trans.__('Discard all changes'),
+    body: trans.__(
+      'Are you sure you want to permanently discard changes to all files? This action cannot be undone.'
+    ),
+    buttons: [
+      Dialog.cancelButton({ label: trans.__('Cancel') }),
+      Dialog.warnButton({ label: trans.__('Discard') })
+    ]
+  });
+
+  if (result.button.accept) {
+    try {
+      return model.resetToCommit('HEAD');
+    } catch (reason) {
+      showErrorMessage(trans.__('Discard all changes failed.'), reason);
+      return Promise.reject(reason);
+    }
+  }
+
+  return Promise.reject('The user refused to discard all changes');
+}

--- a/src/widgets/discardAllChanges.ts
+++ b/src/widgets/discardAllChanges.ts
@@ -4,16 +4,23 @@ import { IGitExtension } from '../tokens';
 
 /**
  * Discard changes in all unstaged and staged files
+ *
+ * @param isFallback If dialog is called when the classical pull operation fails
  */
 export async function discardAllChanges(
   model: IGitExtension,
-  trans: TranslationBundle
+  trans: TranslationBundle,
+  isFallback?: boolean
 ): Promise<void> {
   const result = await showDialog({
     title: trans.__('Discard all changes'),
-    body: trans.__(
-      'Are you sure you want to permanently discard changes to all files? This action cannot be undone.'
-    ),
+    body: isFallback
+      ? trans.__(
+          'Do you want to permanently discard changes to all files and pull? This action cannot be undone.'
+        )
+      : trans.__(
+          'Are you sure you want to permanently discard changes to all files? This action cannot be undone.'
+        ),
     buttons: [
       Dialog.cancelButton({ label: trans.__('Cancel') }),
       Dialog.warnButton({ label: trans.__('Discard') })


### PR DESCRIPTION
This changes introduces a `Pull from remote (Discard all)` option to the Git Menu

![image](https://user-images.githubusercontent.com/59669957/131338668-004eeda0-130c-45d1-bf2b-4577e8801b58.png)


Closes #860 

---

This may lead into the enhancement of #998, specifically
> where all pulls completely overwrote (and pruned) local files
