### PR TITLE
Improve merge widgets

### DIFF
--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -619,8 +619,8 @@ export function addCommands(
         const diffContext: Git.Diff.IContext =
           status === 'unmerged'
             ? {
-                currentRef: 'HEAD',
-                previousRef: 'MERGE_HEAD',
+                currentRef: 'MERGE_HEAD',
+                previousRef: 'HEAD',
                 baseRef: 'ORIG_HEAD'
               }
             : context ?? {

--- a/src/components/diff/PlainTextDiff.ts
+++ b/src/components/diff/PlainTextDiff.ts
@@ -206,9 +206,9 @@ export class PlainTextDiff extends Widget implements Git.Diff.IDiffWidget {
       if (baseContent !== null && baseContent !== undefined) {
         options = {
           ...options,
+          origLeft: referenceContent,
           value: baseContent,
-          origRight: referenceContent,
-          origLeft: challengerContent,
+          origRight: challengerContent,
           readOnly: false,
           revertButtons: true
         };

--- a/style/diff-common.css
+++ b/style/diff-common.css
@@ -111,7 +111,7 @@ button.jp-git-diff-resolve .jp-ToolbarButtonComponent-label {
   display: inline-block;
   white-space: normal;
   vertical-align: top;
-  width: 100%;
+  /* width: 100%; */
 }
 
 .jp-git-diff-root .CodeMirror-merge-pane-rightmost {

--- a/style/diff-text.css
+++ b/style/diff-text.css
@@ -58,3 +58,54 @@
   color: #999;
   background-color: var(--jp-git-diff-deleted-color);
 }
+
+/* Styles for horizontal scroll lock */
+.jp-git-PlainText-diff .CodeMirror-merge-scrolllock {
+  /* color: #555; */
+  color: var(--jp--inverse-layout-color2);
+}
+.jp-git-PlainText-diff .CodeMirror-merge-scrolllock:after {
+  content: '\21db\00a0\00a0\21da';
+}
+.jp-git-PlainText-diff
+  .CodeMirror-merge-scrolllock.CodeMirror-merge-scrolllock-enabled:after {
+  content: '\21db\21da';
+}
+
+/* Styles for revert buttons handling */
+
+.jp-git-PlainText-diff .CodeMirror-merge-copybuttons-left,
+.jp-git-PlainText-diff .CodeMirror-merge-copybuttons-right {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  line-height: 1;
+}
+
+.jp-git-PlainText-diff .CodeMirror-merge-copy {
+  position: absolute;
+  cursor: pointer;
+  color: var(--jp-mirror-editor-operator-color);
+  /* color: #44c; */
+  z-index: 3;
+}
+
+.jp-git-PlainText-diff .CodeMirror-merge-copy-reverse {
+  position: absolute;
+  cursor: pointer;
+  color: var(--jp-mirror-editor-operator-color);
+  /* color: #44c; */
+}
+
+.jp-git-PlainText-diff
+  .CodeMirror-merge-copybuttons-left
+  .CodeMirror-merge-copy {
+  left: 2px;
+}
+.jp-git-PlainText-diff
+  .CodeMirror-merge-copybuttons-right
+  .CodeMirror-merge-copy {
+  right: 2px;
+}


### PR DESCRIPTION
Follow-up of merge widgets feature

- Correct position Current / Result / Incoming to be coherent for plain text files and notebooks
- Correct styling for raw plain text
  - Position revert chunk button correctly
  - Display scroll lock button
- [ ] Orange text on blue background for selected conflicted file is hard to read
- [ ] Conflict notebook view in dark mode is hard to read
- [ ] Hidden unchanged cells on conflicted notebook is not working
- [ ] Move _Clear all cell outputs_ and _Clear conflicted cell outputs_ checkboxes in the toolbar
- [ ] nbdime working is local / base / remote => text will be expressed using that wording (like _cell added remotely_ or _cell delete locally_). This breaks consistency with a hard to understand wording.
- [ ] It seems that nbdime merge tool allow to move the cell (hence the anchor in the cell header). What do to with that... This interacting in an unexpected way with drag-and-drop animation of tabs in JupyterLab main area.
- [ ] ORIG_HEAD is not base content (it is actuall HEAD in case of merge). The code needs to be reworked to get the real base (requires a round trip to backend using `git ls-files -u` to get object ref?)
- Dealing with additional and deleted files is done directly by git.