### PR TITLE
Moved clone command to plugin for extensibility

### DIFF
--- a/src/cloneCommand.ts
+++ b/src/cloneCommand.ts
@@ -1,0 +1,88 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
+import { CommandIDs, IGitExtension, Level } from './tokens';
+import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { GitCloneForm } from './widgets/GitCloneForm';
+import { logger } from './logger';
+import {
+  addFileBrowserContextMenu,
+  IGitCloneArgs,
+  Operation,
+  showGitOperationDialog
+} from './commandsAndMenu';
+import { GitExtension } from './model';
+import { addCloneButton } from './widgets/gitClone';
+
+export const gitCloneCommandPlugin: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/git:command-clone:plugin',
+  requires: [ITranslator, IGitExtension, IFileBrowserFactory],
+  activate: (
+    app: JupyterFrontEnd,
+    translator: ITranslator,
+    gitModel: IGitExtension,
+    fileBrowserFactory: IFileBrowserFactory
+  ) => {
+    translator = translator || nullTranslator;
+    const trans = translator.load('jupyterlab_git');
+    const fileBrowser = fileBrowserFactory.defaultBrowser;
+    const fileBrowserModel = fileBrowser.model;
+    /** Add git clone command */
+    app.commands.addCommand(CommandIDs.gitClone, {
+      label: trans.__('Clone a Repository'),
+      caption: trans.__('Clone a repository from a URL'),
+      isEnabled: () => gitModel.pathRepository === null,
+      execute: async () => {
+        const result = await showDialog({
+          title: trans.__('Clone a repo'),
+          body: new GitCloneForm(trans),
+          focusNodeSelector: 'input',
+          buttons: [
+            Dialog.cancelButton({ label: trans.__('Cancel') }),
+            Dialog.okButton({ label: trans.__('Clone') })
+          ]
+        });
+
+        if (result.button.accept && result.value) {
+          logger.log({
+            level: Level.RUNNING,
+            message: trans.__('Cloning…')
+          });
+          try {
+            const details = await showGitOperationDialog<IGitCloneArgs>(
+              gitModel as GitExtension,
+              Operation.Clone,
+              trans,
+              { path: fileBrowserModel.path, url: result.value }
+            );
+            logger.log({
+              message: trans.__('Successfully cloned'),
+              level: Level.SUCCESS,
+              details
+            });
+            await fileBrowserModel.refresh();
+          } catch (error) {
+            console.error(
+              'Encountered an error when cloning the repository. Error: ',
+              error
+            );
+            logger.log({
+              message: trans.__('Failed to clone'),
+              level: Level.ERROR,
+              error: error as Error
+            });
+          }
+        }
+      }
+    });
+    // Add a clone button to the file browser extension toolbar
+    addCloneButton(gitModel, fileBrowser, app.commands);
+
+    // Add the context menu items for the default file browser
+    addFileBrowserContextMenu(gitModel, fileBrowser, app.contextMenu);
+  },
+  autoStart: true
+};

--- a/src/cloneCommand.ts
+++ b/src/cloneCommand.ts
@@ -18,7 +18,7 @@ import { GitExtension } from './model';
 import { addCloneButton } from './widgets/gitClone';
 
 export const gitCloneCommandPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/git:command-clone:plugin',
+  id: '@jupyterlab/git:clone',
   requires: [ITranslator, IGitExtension, IFileBrowserFactory],
   activate: (
     app: JupyterFrontEnd,

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -472,15 +472,17 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
         >
           {this.props.trans.__('Initialize a Repository')}
         </button>
-        <button
-          className={repoButtonClass}
-          onClick={async () => {
-            await commands.execute(CommandIDs.gitClone);
-            await commands.execute('filebrowser:toggle-main');
-          }}
-        >
-          {this.props.trans.__('Clone a Repository')}
-        </button>
+        {commands.hasCommand(CommandIDs.gitClone) && (
+          <button
+            className={repoButtonClass}
+            onClick={async () => {
+              await commands.execute(CommandIDs.gitClone);
+              await commands.execute('filebrowser:toggle-main');
+            }}
+          >
+            {this.props.trans.__('Clone a Repository')}
+          </button>
+        )}
       </React.Fragment>
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { gitIcon } from './style/icons';
 import { Git, IGitExtension } from './tokens';
 import { addCloneButton } from './widgets/gitClone';
 import { GitWidget } from './widgets/GitWidget';
+import { gitCloneCommandPlugin } from './cloneCommand';
 
 export { DiffModel } from './components/diff/model';
 export { NotebookDiff } from './components/diff/NotebookDiff';
@@ -54,7 +55,7 @@ const plugin: JupyterFrontEndPlugin<IGitExtension> = {
 /**
  * Export the plugin as default.
  */
-export default plugin;
+export default [plugin, gitCloneCommandPlugin];
 
 /**
  * Activate the running plugin.

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,6 +1,6 @@
 import 'jest';
 import * as git from '../src/git';
-import plugin from '../src/index';
+import plugins from '../src/index';
 import { version } from '../src/version';
 import { ISettingRegistry, SettingRegistry } from '@jupyterlab/settingregistry';
 import { JupyterLab } from '@jupyterlab/application';
@@ -16,6 +16,8 @@ jest.mock('../src/git');
 jest.mock('@jupyterlab/application');
 jest.mock('@jupyterlab/apputils');
 jest.mock('@jupyterlab/settingregistry');
+
+const plugin = plugins[0];
 
 describe('plugin', () => {
   const mockGit = git as jest.Mocked<typeof git>;


### PR DESCRIPTION
### Problem
The current clone dialog has a simplified interface which does not allow useful features e.g., specifying a directory where to clone the repo, post-clone actions e.g., option for opening README of the repo when it is cloned etc.

### Solution
A short term solution is to isolate the clone command and expose it in a separate plugin. This will allow other extension developers to replace the command with their own implementation by disabling the command plugin and registering a new plugin with the same command id. 