### PR TITLE
Warn the user of unsaved changes when working with staged files

### DIFF
--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -192,25 +192,21 @@ export class CommitBox extends React.Component<
       'Summary (%1 to commit)',
       shortcutHint
     );
-    const dirtyStagedFilesWarningTitle = this.props.trans.__(
-      'Warning'
-    )
+    const dirtyStagedFilesWarningTitle = this.props.trans.__('Warning');
     const dirtyStagedFilesWarningContent = this.props.trans.__(
-      'Looks like you still have unsaved staged files. ' +
-      'Remember to save and stage all needed changes before committing!'
-    )
+      'Looks like you still have unsaved staged files. Remember to save and stage all needed changes before committing!'
+    );
     return (
       <div className={classes(commitFormClass, 'jp-git-CommitBox')}>
-        { this.props.warnDirtyStagedFiles ? (
+        {this.props.warnDirtyStagedFiles ? (
           <WarningBox
             headerIcon={<WarningRoundedIcon />}
             title={dirtyStagedFilesWarningTitle}
             content={dirtyStagedFilesWarningContent}
           />
         ) : (
-          <React.Fragment>
-          </React.Fragment>
-        ) }
+          <React.Fragment></React.Fragment>
+        )}
         <CommitMessage
           trans={this.props.trans}
           summary={this.props.summary}

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -28,6 +28,8 @@ import {
 } from '../style/NewBranchDialog';
 import { CommandIDs } from '../tokens';
 import { CommitMessage } from './CommitMessage';
+import { WarningBox } from './WarningBox';
+import { WarningRounded as WarningRoundedIcon } from '@material-ui/icons';
 
 /**
  * Commit action
@@ -81,6 +83,11 @@ export interface ICommitBoxProps {
    * Whether commit is amending the previous one or not
    */
   amend: boolean;
+
+  /**
+   * Whether the warning box for dirty (e.g., unsaved) staged files is shown.
+   */
+  warnDirtyStagedFiles: boolean;
 
   /**
    * Updates the commit message summary.
@@ -185,8 +192,25 @@ export class CommitBox extends React.Component<
       'Summary (%1 to commit)',
       shortcutHint
     );
+    const dirtyStagedFilesWarningTitle = this.props.trans.__(
+      'Warning'
+    )
+    const dirtyStagedFilesWarningContent = this.props.trans.__(
+      'Looks like you still have unsaved staged files. ' +
+      'Remember to save and stage all needed changes before committing!'
+    )
     return (
       <div className={classes(commitFormClass, 'jp-git-CommitBox')}>
+        { this.props.warnDirtyStagedFiles ? (
+          <WarningBox
+            headerIcon={<WarningRoundedIcon />}
+            title={dirtyStagedFilesWarningTitle}
+            content={dirtyStagedFilesWarningContent}
+          />
+        ) : (
+          <React.Fragment>
+          </React.Fragment>
+        ) }
         <CommitMessage
           trans={this.props.trans}
           summary={this.props.summary}

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -198,14 +198,12 @@ export class CommitBox extends React.Component<
     );
     return (
       <div className={classes(commitFormClass, 'jp-git-CommitBox')}>
-        {this.props.warnDirtyStagedFiles ? (
+        {this.props.warnDirtyStagedFiles && (
           <WarningBox
             headerIcon={<WarningRoundedIcon />}
             title={dirtyStagedFilesWarningTitle}
             content={dirtyStagedFilesWarningContent}
           />
-        ) : (
-          <React.Fragment></React.Fragment>
         )}
         <CommitMessage
           trans={this.props.trans}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -144,7 +144,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
    */
   constructor(props: IGitPanelProps) {
     super(props);
-    const { branches, currentBranch, pathRepository } = props.model;
+    const { branches, currentBranch, pathRepository, hasDirtyStagedFiles } =
+      props.model;
 
     this.state = {
       branches: branches,
@@ -159,7 +160,7 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       commitSummary: '',
       commitDescription: '',
       commitAmend: false,
-      hasDirtyStagedFiles: false
+      hasDirtyStagedFiles: hasDirtyStagedFiles
     };
   }
 

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -125,6 +125,11 @@ export interface IGitPanelState {
    * Amend option toggle
    */
   commitAmend: boolean;
+
+  /**
+   * Whether there are dirty (e.g., unsaved) staged files.
+   */
+  hasDirtyStagedFiles: boolean;
 }
 
 /**
@@ -153,7 +158,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       tab: 0,
       commitSummary: '',
       commitDescription: '',
-      commitAmend: false
+      commitAmend: false,
+      hasDirtyStagedFiles: false
     };
   }
 
@@ -195,6 +201,12 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
     }, this);
 
     settings.changed.connect(this.refreshView, this);
+
+    model.dirtyStagedFilesStatusChanged.connect((_, args) => {
+      this.setState({
+        hasDirtyStagedFiles: args
+      });
+    });
   }
 
   componentWillUnmount(): void {
@@ -414,6 +426,7 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           setDescription={this._setCommitDescription}
           setAmend={this._setCommitAmend}
           onCommit={this.commitFiles}
+          warnDirtyStagedFiles={this.state.hasDirtyStagedFiles}
         />
       </React.Fragment>
     );

--- a/src/components/WarningBox.tsx
+++ b/src/components/WarningBox.tsx
@@ -37,7 +37,7 @@ export function WarningBox(props: IWarningBoxProps): JSX.Element {
         root: commitRoot
       }}
       className={dirtyStagedFilesWarningBoxClass}
-      variant='outlined'
+      variant="outlined"
     >
       <CardHeader
         className={dirtyStagedFilesWarningBoxHeaderClass}
@@ -45,9 +45,7 @@ export function WarningBox(props: IWarningBoxProps): JSX.Element {
         title={props.title}
         disableTypography={true}
       />
-      <CardContent
-        className={dirtyStagedFilesWarningBoxContentClass}
-      >
+      <CardContent className={dirtyStagedFilesWarningBoxContentClass}>
         {props.content}
       </CardContent>
     </Card>

--- a/src/components/WarningBox.tsx
+++ b/src/components/WarningBox.tsx
@@ -1,0 +1,55 @@
+import { CardContent } from '@material-ui/core';
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import * as React from 'react';
+import {
+  commitRoot,
+  dirtyStagedFilesWarningBoxClass,
+  dirtyStagedFilesWarningBoxContentClass,
+  dirtyStagedFilesWarningBoxHeaderClass
+} from '../style/CommitBox';
+
+/**
+ * Interface describing the properties of the warning box component.
+ */
+export interface IWarningBoxProps {
+  /**
+   * The warning box's header icon.
+   */
+  headerIcon?: JSX.Element;
+  /**
+   * The warning box's header text.
+   */
+  title: string;
+  /**
+   * The warning box's content text.
+   */
+  content: string;
+}
+
+/**
+ * Warning box component.
+ */
+export function WarningBox(props: IWarningBoxProps): JSX.Element {
+  return (
+    <Card
+      classes={{
+        root: commitRoot
+      }}
+      className={dirtyStagedFilesWarningBoxClass}
+      variant='outlined'
+    >
+      <CardHeader
+        className={dirtyStagedFilesWarningBoxHeaderClass}
+        avatar={props.headerIcon}
+        title={props.title}
+        disableTypography={true}
+      />
+      <CardContent
+        className={dirtyStagedFilesWarningBoxContentClass}
+      >
+        {props.content}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -1069,7 +1069,7 @@ export class GitExtension implements IGitExtension {
    */
   async refreshDirtyStagedStatus(): Promise<void> {
     // staged files
-    const fileNames = (await this._changedFiles('INDEX', 'HEAD')).files
+    const fileNames = (await this._changedFiles('INDEX', 'HEAD')).files;
 
     let result = false;
 
@@ -1609,7 +1609,9 @@ export class GitExtension implements IGitExtension {
     IGitExtension,
     Git.IRemoteChangedNotification | null
   >(this);
-  private _dirtyStagedFilesStatusChanged = new Signal<IGitExtension, boolean>(this);
+  private _dirtyStagedFilesStatusChanged = new Signal<IGitExtension, boolean>(
+    this
+  );
 }
 
 export class BranchMarker implements Git.IBranchMarker {

--- a/src/model.ts
+++ b/src/model.ts
@@ -262,11 +262,19 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
-   * Boolean indicating whether the application is dirty (e.g., due to unsaved files).
+   * Boolean indicating whether there are dirty staged files
+   * (e.g., due to unsaved changes on files that have been previously staged).
    */
   get hasDirtyStagedFiles(): boolean {
     return this._hasDirtyStagedFiles;
   }
+  /**
+   * Updates the value of the boolean indicating whether there are dirty staged files
+   * (e.g., due to unsaved changes on files that have been previously staged).
+   * Emits a signal indicating if necessary.
+   * This signal is emitted when there is a dirty staged file but none previously,
+   * and vice versa, when there are no dirty staged files but there were some previously.
+   */
   set hasDirtyStagedFiles(value: boolean) {
     if (this._hasDirtyStagedFiles !== value) {
       this._hasDirtyStagedFiles = value;
@@ -276,7 +284,8 @@ export class GitExtension implements IGitExtension {
 
   /**
    * A signal emitted indicating whether there are dirty (e.g., unsaved) staged files.
-   * This signal is emitted when there is a dirty staged file, and when there are no dirty staged files.
+   * This signal is emitted when there is a dirty staged file but none previously,
+   * and vice versa, when there are no dirty staged files but there were some previously.
    */
   get dirtyStagedFilesStatusChanged(): ISignal<IGitExtension, boolean> {
     return this._dirtyStagedFilesStatusChanged;
@@ -1067,7 +1076,6 @@ export class GitExtension implements IGitExtension {
    * Determines whether there are unsaved changes on staged files,
    * e.g., the user has made changes to a file that has been staged,
    * but has not saved them.
-   * Emits a signal indicating if there are unsaved changes.
    * @returns promise that resolves upon refreshing the dirty status of staged files
    */
   async refreshDirtyStagedStatus(): Promise<void> {

--- a/src/model.ts
+++ b/src/model.ts
@@ -268,7 +268,10 @@ export class GitExtension implements IGitExtension {
     return this._hasDirtyStagedFiles;
   }
   set hasDirtyStagedFiles(value: boolean) {
-    this._hasDirtyStagedFiles = value;
+    if (this._hasDirtyStagedFiles !== value) {
+      this._hasDirtyStagedFiles = value;
+      this._dirtyStagedFilesStatusChanged.emit(value);
+    }
   }
 
   /**
@@ -1086,10 +1089,7 @@ export class GitExtension implements IGitExtension {
       }
     }
 
-    if (result !== this._hasDirtyStagedFiles) {
-      this._hasDirtyStagedFiles = result;
-      this._dirtyStagedFilesStatusChanged.emit(result);
-    }
+    this.hasDirtyStagedFiles = result;
   }
 
   /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -961,7 +961,6 @@ export class GitExtension implements IGitExtension {
     }
 
     try {
-      await this.refreshDirtyStagedStatus();
       const data = await this._taskHandler.execute<Git.IStatusResult>(
         'git:refresh:status',
         async () => {
@@ -985,6 +984,7 @@ export class GitExtension implements IGitExtension {
         behind: data.behind || 0,
         files
       });
+      await this.refreshDirtyStagedStatus();
     } catch (err) {
       // TODO we should notify the user
       this._clearStatus();
@@ -1079,8 +1079,13 @@ export class GitExtension implements IGitExtension {
    * @returns promise that resolves upon refreshing the dirty status of staged files
    */
   async refreshDirtyStagedStatus(): Promise<void> {
-    // staged files
-    const fileNames = (await this._changedFiles('INDEX', 'HEAD')).files;
+    // we assume the repository status has been refreshed prior to this
+
+    // get staged files
+    const stagedFiles = this.status.files.filter(
+      file => file.status === 'staged' || file.status === 'partially-staged'
+    );
+    const fileNames = stagedFiles.map(file => file.to);
 
     let result = false;
 

--- a/src/style/CommitBox.ts
+++ b/src/style/CommitBox.ts
@@ -14,6 +14,34 @@ export const commitFormClass = style({
   borderTop: 'var(--jp-border-width) solid var(--jp-border-color2)'
 });
 
+export const dirtyStagedFilesWarningBoxClass = style({
+  marginBottom: '1em',
+  padding: 'var(--jp-code-padding)',
+
+  outline: 'none',
+  overflowX: 'auto',
+
+  border: 'var(--jp-border-width) solid var(--jp-border-color2)',
+  borderRadius: '3px'
+});
+
+export const dirtyStagedFilesWarningBoxHeaderClass = style({
+  fontWeight: 'bold',
+  marginBottom: '0.5em',
+  color: 'var(--jp-warn-color1)',
+  padding: 0
+});
+
+export const dirtyStagedFilesWarningBoxContentClass = style({
+  color: 'var(--jp-warn-color1)',
+  padding: 0,
+  $nest: {
+    '&:last-child': {
+      paddingBottom: 0
+    }
+  }
+});
+
 export const commitSummaryClass = style({
   height: '2em',
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -64,7 +64,7 @@ export interface IGitExtension extends IDisposable {
   /**
    * Test whether the application is dirty (e.g., due to unsaved files).
    */
-   hasDirtyStagedFiles: boolean;
+  hasDirtyStagedFiles: boolean;
 
   /**
    * Git repository status.

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -62,6 +62,11 @@ export interface IGitExtension extends IDisposable {
   selectedHistoryFile: Git.IStatusFile | null;
 
   /**
+   * Test whether the application is dirty (e.g., due to unsaved files).
+   */
+   hasDirtyStagedFiles: boolean;
+
+  /**
    * Git repository status.
    */
   readonly status: Git.IStatus;
@@ -91,6 +96,12 @@ export interface IGitExtension extends IDisposable {
     IGitExtension,
     Git.IRemoteChangedNotification | null
   >;
+
+  /**
+   * A signal emitted indicating whether there are dirty (e.g., unsaved) staged files.
+   * This signal is emitted when there is a dirty staged file, and when there are no dirty staged files.
+   */
+  readonly dirtyStagedFilesStatusChanged: ISignal<IGitExtension, boolean>;
 
   /**
    * Add one or more files to the repository staging area.
@@ -380,6 +391,15 @@ export interface IGitExtension extends IDisposable {
    * Make request for a list of all Git branches
    */
   refreshBranch(): Promise<void>;
+
+  /**
+   * Determines whether there are unsaved changes on staged files,
+   * e.g., the user has made changes to a file that has been staged,
+   * but has not saved them.
+   * Emits a signal indicating if there are unsaved changes.
+   * @returns promise that resolves upon refreshing the dirty status of staged files
+   */
+  refreshDirtyStagedStatus(): Promise<void>;
 
   /**
    * Request Git status refresh

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -62,7 +62,8 @@ export interface IGitExtension extends IDisposable {
   selectedHistoryFile: Git.IStatusFile | null;
 
   /**
-   * Test whether the application is dirty (e.g., due to unsaved files).
+   * Boolean indicating whether there are dirty staged files
+   * (e.g., due to unsaved changes on files that have been previously staged).
    */
   hasDirtyStagedFiles: boolean;
 
@@ -99,7 +100,8 @@ export interface IGitExtension extends IDisposable {
 
   /**
    * A signal emitted indicating whether there are dirty (e.g., unsaved) staged files.
-   * This signal is emitted when there is a dirty staged file, and when there are no dirty staged files.
+   * This signal is emitted when there is a dirty staged file but none in prior,
+   * and vice versa, when there are no dirty staged files but there were previously.
    */
   readonly dirtyStagedFilesStatusChanged: ISignal<IGitExtension, boolean>;
 

--- a/tests/test-components/CommitBox.spec.tsx
+++ b/tests/test-components/CommitBox.spec.tsx
@@ -6,6 +6,7 @@ import 'jest';
 import * as React from 'react';
 import { CommitBox, ICommitBoxProps } from '../../src/components/CommitBox';
 import { CommitMessage } from '../../src/components/CommitMessage';
+import { WarningBox } from '../../src/components/WarningBox';
 import { CommandIDs } from '../../src/tokens';
 
 describe('CommitBox', () => {
@@ -135,6 +136,15 @@ describe('CommitBox', () => {
       const node = component.find(Button).first();
       const prop = node.prop('disabled');
       expect(prop).toEqual(false);
+    });
+
+    it('should render a warning box when there are dirty staged files', () => {
+      const props = {
+        ...defaultProps,
+        warnDirtyStagedFiles: true
+      };
+      const component = shallow(<CommitBox {...props} />);
+      expect(component.find(WarningBox).length).toEqual(1);
     });
   });
 });

--- a/tests/test-components/CommitBox.spec.tsx
+++ b/tests/test-components/CommitBox.spec.tsx
@@ -29,7 +29,8 @@ describe('CommitBox', () => {
     hasFiles: false,
     commands: defaultCommands,
     trans: trans,
-    label: 'Commit'
+    label: 'Commit',
+    warnDirtyStagedFiles: false
   };
 
   describe('#constructor()', () => {

--- a/tests/test-components/GitPanel.spec.tsx
+++ b/tests/test-components/GitPanel.spec.tsx
@@ -250,6 +250,9 @@ describe('GitPanel', () => {
         },
         notifyRemoteChanges: {
           connect: jest.fn()
+        },
+        dirtyStagedFilesStatusChanged: {
+          connect: jest.fn()
         }
       } as any;
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -37,7 +37,7 @@ export const defaultMockedResponses: {
       return {
         code: 0,
         files: []
-      }
+      };
     }
   },
   show_prefix: {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -32,6 +32,14 @@ export const defaultMockedResponses: {
       };
     }
   },
+  changed_files: {
+    body: () => {
+      return {
+        code: 0,
+        files: []
+      }
+    }
+  },
   show_prefix: {
     body: () => {
       return {


### PR DESCRIPTION
## Summary

Show a notice box warning the user to pay attention to unsaved changes as he/she/they are working on files that are staged. In other words, this PR makes JupyterLab-Git shows a warning box in the commit box section when it detects unsaved changes on files that have been staged. This will potentially fix #853.

## Details

**Note: We're only checking dirty state of staged files (not other files even if they belong to the repo) and the warning box only shows up when the user is working with unsaved staged files belonging to a repo recognized by JupyterLab-Git.**

In `src/model.ts`, these are added:
- `_hasDirtyStagedFiles: boolean` indicating whether there are dirty files that are also staged files.
- `_dirtyStagedFilesStatusChanged: Signal<IGitExtension, boolean>`  that emits a signal when `_hasDirtyStageFiles` changes, e.g., was `false` before but now `true` (e.g., due to detection of an unsaved file and that file is also in the staged list)
- `async refreshDirtyStagedStatus()` taking care of the above by basically checking with `docmanager` to see the dirty status of each file in the staged list. This is invoked within `GitExtension.refreshStatus()`.

`src/tokens.ts` is also modifed accordingly to adopt the changes above.

In `src/components/GitPanel.tsx`, these are done:
- Add `hasDirtyStagedFiles: boolean` to `IGitPanelState`
- `componentDidMount()` also connects the `_dirtyStagedFilesStatusChanged` with a callback that syncs `((GitPanel)this).state.hasDirtyStagedFiles`

`src/components/WarningBox.tsx` is a new component that is used for displaying warnings. Its styles are defined in `src/style/CommitBox.ts`. This component is used in `src/components/CommitBox.tsx` to show the warning for dirty state of staged files.

## Demos

![image](https://user-images.githubusercontent.com/6735818/153591729-d23772a9-23b2-4f26-91f1-19d239023da2.png)


## Notes

- This PR likely needs more tests.
- `refreshStatus()` is invoked periodically, therefore, as the user makes changes, or discards/saves file changes, the warning box may not show up/disappear immediately.

## Linked issues
#853