### PR TITLE
Add "Reset to Remote" feature

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -110,6 +110,9 @@
             "args": { "force": true }
           },
           {
+            "command": "git:reset-to-remote"
+          },
+          {
             "command": "git:add-remote"
           },
           {

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -426,7 +426,7 @@ export function addCommands(
             and some changes being permanently discarded. Are you sure you want to proceed? \
             This action cannot be undone.'
           ),
-          trans.__('Also close all opened files to avoid conflicts')
+          trans.__('Close all opened files to avoid conflicts')
         ),
         buttons: [
           Dialog.cancelButton({ label: trans.__('Cancel') }),

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -410,6 +410,56 @@ export function addCommands(
     }
   });
 
+  /** Add git reset --hard <remote-tracking-branch> command */
+  commands.addCommand(CommandIDs.gitResetToRemote, {
+    label: trans.__('Reset to Remote'),
+    caption: trans.__('Reset Current Branch to Remote State'),
+    isEnabled: () => gitModel.pathRepository !== null,
+    execute: async _ => {
+      const result = await showDialog({
+        title: trans.__('Reset to Remote'),
+        body: (
+          <span>
+            {trans.__(
+              'To bring the current branch to the state of its corresponding remote tracking branch, \
+              a hard reset will be performed, which may result in some files being permanently deleted \
+              and some changes being permanently discarded. Are you sure you want to proceed? \
+              This action cannot be undone.'
+            )}
+          </span>
+        ),
+        buttons: [
+          Dialog.cancelButton({ label: trans.__('Cancel') }),
+          Dialog.warnButton({ label: trans.__('Proceed') })
+        ]
+      });
+      if (result.button.accept) {
+        try {
+          logger.log({
+            message: trans.__('Resetting...'),
+            level: Level.RUNNING
+          });
+          await gitModel.resetToCommit(gitModel.status.remote);
+          logger.log({
+            message: trans.__('Successfully reset'),
+            level: Level.SUCCESS,
+            details: trans.__('Successfully reset the current branch to its remote state')
+          })
+        } catch (error) {
+          console.error(
+            'Encountered an error when resetting the current branch to its remote state. Error: ',
+            error
+          );
+          logger.log({
+            message: trans.__('Reset failed'),
+            level: Level.ERROR,
+            error
+          });
+        }
+      }
+    }
+  });
+
   /**
    * Git display diff command - internal command
    *

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -443,8 +443,10 @@ export function addCommands(
           logger.log({
             message: trans.__('Successfully reset'),
             level: Level.SUCCESS,
-            details: trans.__('Successfully reset the current branch to its remote state')
-          })
+            details: trans.__(
+              'Successfully reset the current branch to its remote state'
+            )
+          });
         } catch (error) {
           console.error(
             'Encountered an error when resetting the current branch to its remote state. Error: ',

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -47,7 +47,7 @@ import {
 } from './tokens';
 import { GitCredentialsForm } from './widgets/CredentialsBox';
 import { discardAllChanges } from './widgets/discardAllChanges';
-import { GitResetToRemoteForm } from './widgets/GitResetToRemoteForm';
+import { CheckboxForm } from './widgets/GitResetToRemoteForm';
 
 export interface IGitCloneArgs {
   /**
@@ -419,7 +419,15 @@ export function addCommands(
     execute: async () => {
       const result = await showDialog({
         title: trans.__('Reset to Remote'),
-        body: new GitResetToRemoteForm(trans),
+        body: new CheckboxForm(
+          trans.__(
+            'To bring the current branch to the state of its corresponding remote tracking branch, \
+            a hard reset will be performed, which may result in some files being permanently deleted \
+            and some changes being permanently discarded. Are you sure you want to proceed? \
+            This action cannot be undone.'
+          ),
+          trans.__('Also close all opened files to avoid conflicts')
+        ),
         buttons: [
           Dialog.cancelButton({ label: trans.__('Cancel') }),
           Dialog.warnButton({ label: trans.__('Proceed') })
@@ -427,7 +435,7 @@ export function addCommands(
       });
       if (result.button.accept) {
         try {
-          if (result.value.doCloseAllOpenedFiles) {
+          if (result.value.checked) {
             logger.log({
               message: trans.__('Closing all opened files...'),
               level: Level.RUNNING

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -415,7 +415,7 @@ export function addCommands(
     label: trans.__('Reset to Remote'),
     caption: trans.__('Reset Current Branch to Remote State'),
     isEnabled: () => gitModel.pathRepository !== null,
-    execute: async _ => {
+    execute: async () => {
       const result = await showDialog({
         title: trans.__('Reset to Remote'),
         body: (

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -47,6 +47,7 @@ import {
 } from './tokens';
 import { GitCredentialsForm } from './widgets/CredentialsBox';
 import { discardAllChanges } from './widgets/discardAllChanges';
+import { GitResetToRemoteForm } from './widgets/GitResetToRemoteForm';
 
 export interface IGitCloneArgs {
   /**
@@ -418,16 +419,7 @@ export function addCommands(
     execute: async () => {
       const result = await showDialog({
         title: trans.__('Reset to Remote'),
-        body: (
-          <span>
-            {trans.__(
-              'To bring the current branch to the state of its corresponding remote tracking branch, \
-              a hard reset will be performed, which may result in some files being permanently deleted \
-              and some changes being permanently discarded. Are you sure you want to proceed? \
-              This action cannot be undone.'
-            )}
-          </span>
-        ),
+        body: new GitResetToRemoteForm(trans),
         buttons: [
           Dialog.cancelButton({ label: trans.__('Cancel') }),
           Dialog.warnButton({ label: trans.__('Proceed') })
@@ -435,6 +427,13 @@ export function addCommands(
       });
       if (result.button.accept) {
         try {
+          if (result.value.doCloseAllOpenedFiles) {
+            logger.log({
+              message: trans.__('Closing all opened files...'),
+              level: Level.RUNNING
+            });
+            await fileBrowserModel.manager.closeAll();
+          }
           logger.log({
             message: trans.__('Resetting...'),
             level: Level.RUNNING

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1141,6 +1141,7 @@ export function createGitMenu(
     CommandIDs.gitMerge,
     CommandIDs.gitPush,
     CommandIDs.gitPull,
+    CommandIDs.gitResetToRemote,
     CommandIDs.gitAddRemote,
     CommandIDs.gitTerminalCommand
   ].forEach(command => {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1025,7 +1025,13 @@ export namespace Git {
     }
   }
 
+  /**
+   * Interface for dialog with one checkbox.
+   */
   export interface ICheckboxFormValue {
+    /**
+     * Checkbox value
+     */
     checked: boolean;
   }
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1024,6 +1024,10 @@ export namespace Git {
       super('Not in a Git Repository');
     }
   }
+
+  export interface IGitResetToRemoteFormValue {
+    doCloseAllOpenedFiles: boolean;
+  }
 }
 
 /**

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1025,8 +1025,8 @@ export namespace Git {
     }
   }
 
-  export interface IGitResetToRemoteFormValue {
-    doCloseAllOpenedFiles: boolean;
+  export interface ICheckboxFormValue {
+    checked: boolean;
   }
 }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1097,6 +1097,7 @@ export enum CommandIDs {
   gitOpenGitignore = 'git:open-gitignore',
   gitPush = 'git:push',
   gitPull = 'git:pull',
+  gitResetToRemote = 'git:reset-to-remote',
   gitSubmitCommand = 'git:submit-commit',
   gitShowDiff = 'git:show-diff'
 }

--- a/src/widgets/GitResetToRemoteForm.tsx
+++ b/src/widgets/GitResetToRemoteForm.tsx
@@ -1,68 +1,49 @@
 import { Dialog } from '@jupyterlab/apputils';
-import { TranslationBundle } from '@jupyterlab/translation';
 import { Widget } from '@lumino/widgets';
 import { Git } from '../tokens';
 
 /**
- * The UI used for the Reset to Remote Form,
- * used as the body for Reset to Remote Dialog.
+ * A widget form containing a text block and a checkbox,
+ * can be used as a Dialog body.
  */
-export class GitResetToRemoteForm
+export class CheckboxForm
   extends Widget
-  implements Dialog.IBodyWidget<Git.IGitResetToRemoteFormValue>
+  implements Dialog.IBodyWidget<Git.ICheckboxFormValue>
 {
-  constructor(
-    trans: TranslationBundle,
-    promptContent = trans.__(
-      'To bring the current branch to the state of its corresponding remote tracking branch, \
-      a hard reset will be performed, which may result in some files being permanently deleted \
-      and some changes being permanently discarded. Are you sure you want to proceed? \
-      This action cannot be undone.'
-    ),
-    warningCloseAllOpenedFilesContent = trans.__(
-      'Also close all opened files to avoid conflicts'
-    )
-  ) {
+  constructor(textBody: string, checkboxLabel: string) {
     super();
-    this._trans = trans;
-    this.node.appendChild(
-      this.createBody(promptContent, warningCloseAllOpenedFilesContent)
-    );
+    this.node.appendChild(this.createBody(textBody, checkboxLabel));
   }
 
-  private createBody(
-    promptContent: string,
-    warningCloseAllOpenedFilesContent: string
-  ): HTMLElement {
+  private createBody(textBody: string, checkboxLabel: string): HTMLElement {
     const mainNode = document.createElement('div');
 
-    const warning = document.createElement('div');
-    warning.textContent = promptContent;
+    const text = document.createElement('div');
+    text.textContent = textBody;
 
-    const labelWarnCloseAllOpenedFiles = document.createElement('label');
+    const checkboxContainer = document.createElement('label');
 
-    this._chkCloseAllOpenedFiles = document.createElement('input');
-    this._chkCloseAllOpenedFiles.type = 'checkbox';
-    this._chkCloseAllOpenedFiles.checked = true;
+    this._checkbox = document.createElement('input');
+    this._checkbox.type = 'checkbox';
+    this._checkbox.checked = true;
 
-    const textWarnCloseAllOpenedFiles = document.createElement('span');
-    textWarnCloseAllOpenedFiles.textContent = warningCloseAllOpenedFilesContent;
+    const label = document.createElement('span');
+    label.textContent = checkboxLabel;
 
-    labelWarnCloseAllOpenedFiles.appendChild(this._chkCloseAllOpenedFiles);
-    labelWarnCloseAllOpenedFiles.appendChild(textWarnCloseAllOpenedFiles);
+    checkboxContainer.appendChild(this._checkbox);
+    checkboxContainer.appendChild(label);
 
-    mainNode.appendChild(warning);
-    mainNode.appendChild(labelWarnCloseAllOpenedFiles);
+    mainNode.appendChild(text);
+    mainNode.appendChild(checkboxContainer);
 
     return mainNode;
   }
 
-  getValue(): Git.IGitResetToRemoteFormValue {
+  getValue(): Git.ICheckboxFormValue {
     return {
-      doCloseAllOpenedFiles: this._chkCloseAllOpenedFiles.checked
+      checked: this._checkbox.checked
     };
   }
 
-  protected _trans: TranslationBundle;
-  private _chkCloseAllOpenedFiles: HTMLInputElement;
+  private _checkbox: HTMLInputElement;
 }

--- a/src/widgets/GitResetToRemoteForm.tsx
+++ b/src/widgets/GitResetToRemoteForm.tsx
@@ -1,0 +1,69 @@
+import { Dialog } from '@jupyterlab/apputils';
+import { TranslationBundle } from '@jupyterlab/translation';
+import { Widget } from '@lumino/widgets';
+import { Git } from '../tokens';
+
+/**
+ * The UI used for the Reset to Remote Form,
+ * used as the body for Reset to Remote Dialog.
+ */
+export class GitResetToRemoteForm
+  extends Widget
+  implements Dialog.IBodyWidget<Git.IGitResetToRemoteFormValue>
+{
+  constructor(
+    trans: TranslationBundle,
+    promptContent = trans.__(
+      'To bring the current branch to the state of its corresponding remote tracking branch, \
+      a hard reset will be performed, which may result in some files being permanently deleted \
+      and some changes being permanently discarded. Are you sure you want to proceed? \
+      This action cannot be undone.'
+    ),
+    warningCloseAllOpenedFilesContent = trans.__(
+      'Also close all opened files to avoid conflicts'
+    )
+  ) {
+    super();
+    this._trans = trans;
+    this.node.appendChild(
+      this.createBody(promptContent, warningCloseAllOpenedFilesContent)
+    );
+  }
+
+  private createBody(
+    promptContent: string,
+    warningCloseAllOpenedFilesContent: string
+  ): HTMLElement {
+    const mainNode = document.createElement('div');
+
+    const warning = document.createElement('div');
+    warning.textContent = promptContent;
+
+    const labelWarnCloseAllOpenedFiles = document.createElement('label');
+
+    this._chkCloseAllOpenedFiles = document.createElement('input');
+    this._chkCloseAllOpenedFiles.type = 'checkbox';
+    this._chkCloseAllOpenedFiles.checked = true;
+    
+    const textWarnCloseAllOpenedFiles = document.createElement('span');
+    textWarnCloseAllOpenedFiles.textContent =
+      warningCloseAllOpenedFilesContent;
+
+    labelWarnCloseAllOpenedFiles.appendChild(this._chkCloseAllOpenedFiles);
+    labelWarnCloseAllOpenedFiles.appendChild(textWarnCloseAllOpenedFiles);
+
+    mainNode.appendChild(warning);
+    mainNode.appendChild(labelWarnCloseAllOpenedFiles);
+
+    return mainNode;
+  }
+
+  getValue(): Git.IGitResetToRemoteFormValue {
+    return {
+      doCloseAllOpenedFiles: this._chkCloseAllOpenedFiles.checked
+    };
+  }
+
+  protected _trans: TranslationBundle;
+  private _chkCloseAllOpenedFiles: HTMLInputElement;
+}

--- a/src/widgets/GitResetToRemoteForm.tsx
+++ b/src/widgets/GitResetToRemoteForm.tsx
@@ -44,10 +44,9 @@ export class GitResetToRemoteForm
     this._chkCloseAllOpenedFiles = document.createElement('input');
     this._chkCloseAllOpenedFiles.type = 'checkbox';
     this._chkCloseAllOpenedFiles.checked = true;
-    
+
     const textWarnCloseAllOpenedFiles = document.createElement('span');
-    textWarnCloseAllOpenedFiles.textContent =
-      warningCloseAllOpenedFilesContent;
+    textWarnCloseAllOpenedFiles.textContent = warningCloseAllOpenedFilesContent;
 
     labelWarnCloseAllOpenedFiles.appendChild(this._chkCloseAllOpenedFiles);
     labelWarnCloseAllOpenedFiles.appendChild(textWarnCloseAllOpenedFiles);

--- a/tests/commands.spec.tsx
+++ b/tests/commands.spec.tsx
@@ -198,8 +198,8 @@ describe('git-commands', () => {
               label: ''
             },
             value: {
-              doCloseAllOpenedFiles: checked
-            } as Git.IGitResetToRemoteFormValue
+              checked
+            } as Git.ICheckboxFormValue
           });
 
           const spyCloseAll = jest.spyOn(
@@ -207,8 +207,6 @@ describe('git-commands', () => {
             'closeAll'
           );
           spyCloseAll.mockResolvedValueOnce(undefined);
-
-          const path = DEFAULT_REPOSITORY_PATH;
 
           mockGit.requestAPI.mockImplementation(
             mockedRequestAPI({
@@ -221,6 +219,7 @@ describe('git-commands', () => {
             })
           );
 
+          const path = DEFAULT_REPOSITORY_PATH;
           model.pathRepository = path;
           await model.ready;
 

--- a/tests/commands.spec.tsx
+++ b/tests/commands.spec.tsx
@@ -27,7 +27,9 @@ describe('git-commands', () => {
 
   const mockedFileBrowserModel = {
     manager: {
-      closeAll: jest.fn<Promise<void>, any[]>().mockImplementation(() => Promise.resolve()),
+      closeAll: jest
+        .fn<Promise<void>, any[]>()
+        .mockImplementation(() => Promise.resolve())
     }
   } as any as FileBrowserModel;
 


### PR DESCRIPTION
## Summary

Add `Reset to Remote` feature to the (Git) extension's main menu, which can be executed when working with a Git repository. This lets the user reset the current branch to its remote tracking branch by performing a **hard** reset. This PR should resolve #1074, or should _help_ resolve #998.

## Details

1. A new command entry `git:reset-to-remote` is added in `src/commandsAndMenu.tsx`, `src/tokens.ts` and `schema/plugin.json`.
2. The logic for this command is overall similar to other destructive commands (e.g., forced `git:pull`). The user will be prompted for confirmation, and when it is confirmed, `GitExtension.resetToCommit(remote_tracking_branch_name)` will be invoked, which ultimately triggers a `git reset --hard <remote_tracking_branch_name>` and brings (the state of) the current branch to (the state of) its remote tracking branch.

## Demos

Main menu:
![image](https://cdn.discordapp.com/attachments/938497071546253352/951472457682927647/unknown.png)

Confirmation prompt:
![image](https://cdn.discordapp.com/attachments/938497071546253352/951472457863270470/unknown.png)
_**Note:**_ The grammatical error _"may results"_ has already been fixed in the source code.

On successful reset:
![image](https://cdn.discordapp.com/attachments/938497071546253352/951631949439586344/unknown.png)

CLI branch view:
![image](https://cdn.discordapp.com/attachments/938497071546253352/951631949728972840/unknown.png)
The first output of `git logpretty` shows how the repository looks prior to executing `Reset to Remote` on branch `main`.
The second output of `git logpretty` shows how the repository looks after executing `Reset to Remote` on branch `main`.

_**Note:**_ `logpretty` is an alias. This is how it looks in `git config --list`:
`alias.logpretty=log --graph --abbrev-commit --decorate --format=format:'%C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(reset) %C(bold green)(%ar)%C(reset)%C(bold yellow)%d%C(reset)%n''          %C(white)%s%C(reset) %C(dim white)- %an%C(reset)' --all`

## Linked issues
#1074: Should there be local commits, we can use this `Reset to Remote` feature to bring the branch to the state of its remote tracking branch.