### PR TITLE
Refresh open file on pull

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -840,6 +840,11 @@ export class GitExtension implements IGitExtension {
         );
       }
     );
+    const changes = await this._changedFiles(
+      this._currentBranch.top_commit,
+      'HEAD'
+    );
+    changes?.files?.forEach(file => this._revertFile(file));
     this.refreshBranch(); // Will emit headChanged if required
     return data;
   }

--- a/src/model.ts
+++ b/src/model.ts
@@ -824,7 +824,8 @@ export class GitExtension implements IGitExtension {
    */
   async pull(auth?: Git.IAuth): Promise<Git.IResultWithMessage> {
     const path = await this._getPathRepository();
-    const data = this._taskHandler.execute<Git.IResultWithMessage>(
+    const previousHead = this._currentBranch?.top_commit;
+    const data = await this._taskHandler.execute<Git.IResultWithMessage>(
       'git:pull',
       async () => {
         return await requestAPI<Git.IResultWithMessage>(
@@ -840,12 +841,9 @@ export class GitExtension implements IGitExtension {
         );
       }
     );
-    const changes = await this._changedFiles(
-      this._currentBranch.top_commit,
-      'HEAD'
-    );
+    const changes = await this._changedFiles(previousHead, 'HEAD');
     changes?.files?.forEach(file => this._revertFile(file));
-    this.refreshBranch(); // Will emit headChanged if required
+    await this.refreshBranch(); // Will emit headChanged if required
     return data;
   }
 


### PR DESCRIPTION
Currently doing a pull does not update the contents of open files
like switching branches does.

This runs the same function to update files as switching branches but instead of diffing the branches it diffs the previous top commit to the new HEAD. 

Fixes #1086