### PR TITLE
Frontend Cache Credentials for Issue #659

### DIFF
--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1405,12 +1405,12 @@ export async function showGitOperationDialog<T>(
         title: trans.__('Git credentials required'),
         body: new GitCredentialsForm(
           trans,
-          trans.__('Hello my name is Zeshan'),
+          trans.__('March 11th 11:45AM'),
           retry ? trans.__('Incorrect username or password.') : ''
-        ),
-      buttons: [
-        Dialog.cacheCredentials({label: trans.__('Cache Credentials?')})
-      ]
+        )//,
+      //buttons: [
+      //  Dialog.cacheCredentials({label: trans.__('Cache Credentials?')})
+      //]
       });
 
       if (credentials.button.accept) {

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1368,7 +1368,8 @@ export async function showGitOperationDialog<T>(
   trans: TranslationBundle,
   args?: T,
   authentication?: Git.IAuth,
-  retry = false
+  retry = false,
+  cache = false
 ): Promise<string> {
   try {
     let result: Git.IResultWithMessage;
@@ -1405,7 +1406,7 @@ export async function showGitOperationDialog<T>(
         title: trans.__('Git credentials required'),
         body: new GitCredentialsForm(
           trans,
-          trans.__('March 11th 11:45AM'),
+          trans.__('Enter credentials for remote repository'),
           retry ? trans.__('Incorrect username or password.') : ''
         )//,
       //buttons: [
@@ -1421,6 +1422,7 @@ export async function showGitOperationDialog<T>(
           trans,
           args,
           credentials.value,
+          true,
           true
         );
       }

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1405,7 +1405,7 @@ export async function showGitOperationDialog<T>(
         title: trans.__('Git credentials required'),
         body: new GitCredentialsForm(
           trans,
-          trans.__('Enter credentials for remote repository'),
+          trans.__('Hello my name is Zeshan'),
           retry ? trans.__('Incorrect username or password.') : ''
         )
       });

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1367,27 +1367,35 @@ export async function showGitOperationDialog<T>(
   operation: Operation,
   trans: TranslationBundle,
   args?: T,
-  authentication?: Git.IAuth,
+  authentication?: Git.IAuthWithCacheCredentials,
   retry = false,
   cache = false
 ): Promise<string> {
   try {
+    const auth = authentication ? {
+      username: authentication.username,
+      password: authentication.password
+    } as Git.IAuth : undefined;
     let result: Git.IResultWithMessage;
     // the Git action
     switch (operation) {
       case Operation.Clone:
         // eslint-disable-next-line no-case-declarations
         const { path, url } = args as any as IGitCloneArgs;
-        result = await model.clone(path, url, authentication);
+        result = await model.clone(path, 
+          url, 
+          auth,
+          authentication ? authentication.cacheCredentials : false
+          );
         break;
       case Operation.Pull:
         result = await model.pull(authentication);
         break;
       case Operation.Push:
-        result = await model.push(authentication);
+        result = await model.push(authentication, false, authentication.cacheCredentials);
         break;
       case Operation.ForcePush:
-        result = await model.push(authentication, true);
+        result = await model.push(authentication, true, authentication.cacheCredentials);
         break;
       default:
         result = { code: -1, message: 'Unknown git command' };
@@ -1422,7 +1430,6 @@ export async function showGitOperationDialog<T>(
           trans,
           args,
           credentials.value,
-          true,
           true
         );
       }

--- a/src/model.ts
+++ b/src/model.ts
@@ -577,7 +577,8 @@ export class GitExtension implements IGitExtension {
   async clone(
     path: string,
     url: string,
-    auth?: Git.IAuth, cacheCredentials = true
+    auth?: Git.IAuth,
+    cacheCredentials = false
   ): Promise<Git.IResultWithMessage> {
     return await this._taskHandler.execute<Git.IResultWithMessage>(
       'git:clone',
@@ -587,7 +588,8 @@ export class GitExtension implements IGitExtension {
           'POST',
           {
             clone_url: url,
-            auth: auth as any
+            auth: auth as any,
+            cache_credentials: cacheCredentials
           }
         );
       }
@@ -822,7 +824,7 @@ export class GitExtension implements IGitExtension {
    * @throws {Git.GitResponseError} If the server response is not ok
    * @throws {ServerConnection.NetworkError} If the request cannot be made
    */
-  async pull(auth?: Git.IAuth, cacheCredentials = true): Promise<Git.IResultWithMessage> {
+  async pull(auth?: Git.IAuth, cache_credentials: true): Promise<Git.IResultWithMessage> {
     const path = await this._getPathRepository();
     const data = this._taskHandler.execute<Git.IResultWithMessage>(
       'git:pull',
@@ -855,7 +857,7 @@ export class GitExtension implements IGitExtension {
    * @throws {Git.GitResponseError} If the server response is not ok
    * @throws {ServerConnection.NetworkError} If the request cannot be made
    */
-  async push(auth?: Git.IAuth, cacheCredentials = true, force = false): Promise<Git.IResultWithMessage> {
+  async push(auth?: Git.IAuth, cache_credentials: true, force = false, cacheCredentials = false): Promise<Git.IResultWithMessage> {
     const path = await this._getPathRepository();
     const data = this._taskHandler.execute<Git.IResultWithMessage>(
       'git:push',
@@ -865,7 +867,8 @@ export class GitExtension implements IGitExtension {
           'POST',
           {
             auth: auth as any,
-            force: force
+            force: force,
+            cache_credentials: cacheCredentials
           }
         );
       }
@@ -1508,7 +1511,7 @@ export class GitExtension implements IGitExtension {
       });
 
       await requestAPI(URLExt.join(path, 'remote', 'fetch'), 'POST', {
-        auth?: Git.IAuth, cacheCredentials = true
+        auth?: Git.IAuth, cache_credentials: true
       });
     } catch (error) {
       console.error('Failed to fetch remotes', error);

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -926,6 +926,13 @@ export namespace Git {
     password: string;
   }
 
+    /**
+   * Interface for the Git Auth request with credentials caching option
+   */
+  export interface IAuthWithCacheCredentials extends IAuth {
+    cacheCredentials: boolean;
+  }
+
   /**
    * Structure for the request to the Git Clone API.
    */

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -24,7 +24,7 @@ export class GitCredentialsForm
     const node = document.createElement('div');
     const label = document.createElement('label');
     const checkBoxLabel = document.createElement('label');
-    const checkBox = document.createElement('input');
+    this._checkboxCacheCredentials = document.createElement('input');
     this._user = document.createElement('input');
     this._password = document.createElement('input');
     //this._cacheCredentials = document.createElement('input');
@@ -39,7 +39,8 @@ export class GitCredentialsForm
     text.textContent = textContent;
     warning.textContent = warningContent;
     this._user.placeholder = this._trans.__('username');
-    checkBox.type = 'checkbox';
+    this._checkboxCacheCredentials.type = 'checkbox';
+    this._checkboxCacheCredentials.textContent = this._trans.__("Save my login temporarily");
     //this._cacheCredentials.placeholder = this._trans.__('Cache credentials?');
     this._password.placeholder = this._trans.__(
       'password / personal access token'
@@ -49,7 +50,7 @@ export class GitCredentialsForm
     label.appendChild(text);
     label.appendChild(this._user);
     label.appendChild(this._password);
-    checkBoxLabel.appendChild(checkbox);
+    checkBoxLabel.appendChild(this._checkboxCacheCredentials);
     node.appendChild(checkBoxLabel);
     //label.appendChild(this._cacheCredentials);
     node.appendChild(label);
@@ -60,15 +61,17 @@ export class GitCredentialsForm
   /**
    * Returns the input value.
    */
-  getValue(): Git.IAuth {
+  getValue(): Git.IAuthWithCacheCredentials {
     return {
       username: this._user.value,
-      password: this._password.value
+      password: this._password.value,
+      cacheCredentials: this._checkboxCacheCredentials.checked
     };
   //  return this._cacheCredentials;
   }
   protected _trans: TranslationBundle;
   private _user: HTMLInputElement;
   private _password: HTMLInputElement;
+  private _checkboxCacheCredentials: HTMLInputElement;
   //private _cacheCredentials: HTMLInputElement;
 }

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -25,7 +25,7 @@ export class GitCredentialsForm
     const label = document.createElement('label');
     this._user = document.createElement('input');
     this._password = document.createElement('input');
-    //this.cacheCredentials = document.createElement('input');
+    this.cacheCredentials = document.createElement('input');
     this._password.type = 'password';
 
     const text = document.createElement('span');
@@ -36,7 +36,7 @@ export class GitCredentialsForm
     text.textContent = textContent;
     warning.textContent = warningContent;
     this._user.placeholder = this._trans.__('username');
-    //this.cacheCredentials.placeholder = this._trans.__('Cache credentials?');
+    this.cacheCredentials.placeholder = this._trans.__('Cache credentials?');
     this._password.placeholder = this._trans.__(
       'password / personal access token'
       
@@ -45,7 +45,7 @@ export class GitCredentialsForm
     label.appendChild(text);
     label.appendChild(this._user);
     label.appendChild(this._password);
-    //label.appendChild(this._cacheCredentials);
+    label.appendChild(this._cacheCredentials);
     node.appendChild(label);
     node.appendChild(warning);
     return node;
@@ -59,10 +59,10 @@ export class GitCredentialsForm
       username: this._user.value,
       password: this._password.value
     };
-    //return this._cacheCredentials;
+    return this._cacheCredentials;
   }
   protected _trans: TranslationBundle;
   private _user: HTMLInputElement;
   private _password: HTMLInputElement;
-  //private _cacheCredentials: HTMLInputElement;
+  private _cacheCredentials: HTMLInputElement;
 }

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -36,7 +36,7 @@ export class GitCredentialsForm
     text.textContent = textContent;
     warning.textContent = warningContent;
     this._user.placeholder = this._trans.__('username');
-    this.cacheCredentials.placeholder = this._trans.__('Cache credentials?');
+    this._cacheCredentials.placeholder = this._trans.__('Cache credentials?');
     this._password.placeholder = this._trans.__(
       'password / personal access token'
       

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -25,7 +25,7 @@ export class GitCredentialsForm
     const label = document.createElement('label');
     this._user = document.createElement('input');
     this._password = document.createElement('input');
-    this.cacheCredentials = document.createElement('input');
+    this._cacheCredentials = document.createElement('input');
     this._password.type = 'password';
 
     const text = document.createElement('span');

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -23,10 +23,13 @@ export class GitCredentialsForm
   private createBody(textContent: string, warningContent: string): HTMLElement {
     const node = document.createElement('div');
     const label = document.createElement('label');
+    const checkBoxLabel = document.createElement('label');
+    const checkBox = document.createElement('input');
     this._user = document.createElement('input');
     this._password = document.createElement('input');
-    this._cacheCredentials = document.createElement('input');
+    //this._cacheCredentials = document.createElement('input');
     this._password.type = 'password';
+
 
     const text = document.createElement('span');
     const warning = document.createElement('div');
@@ -36,7 +39,8 @@ export class GitCredentialsForm
     text.textContent = textContent;
     warning.textContent = warningContent;
     this._user.placeholder = this._trans.__('username');
-    this._cacheCredentials.placeholder = this._trans.__('Cache credentials?');
+    checkBox.type = 'checkbox';
+    //this._cacheCredentials.placeholder = this._trans.__('Cache credentials?');
     this._password.placeholder = this._trans.__(
       'password / personal access token'
       
@@ -45,7 +49,9 @@ export class GitCredentialsForm
     label.appendChild(text);
     label.appendChild(this._user);
     label.appendChild(this._password);
-    label.appendChild(this._cacheCredentials);
+    checkBoxLabel.appendChild(checkbox);
+    node.appendChild(checkBoxLabel);
+    //label.appendChild(this._cacheCredentials);
     node.appendChild(label);
     node.appendChild(warning);
     return node;
@@ -64,5 +70,5 @@ export class GitCredentialsForm
   protected _trans: TranslationBundle;
   private _user: HTMLInputElement;
   private _password: HTMLInputElement;
-  private _cacheCredentials: HTMLInputElement;
+  //private _cacheCredentials: HTMLInputElement;
 }

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -59,7 +59,7 @@ export class GitCredentialsForm
       username: this._user.value,
       password: this._password.value
     };
-    return this._cacheCredentials;
+  //  return this._cacheCredentials;
   }
   protected _trans: TranslationBundle;
   private _user: HTMLInputElement;


### PR DESCRIPTION
Some frontend exploration on #659

Added new interface `IAuthWithCacheCredentials` that extends `IAuth` that includes a new boolean that is implemented as a checkbox in `CredentialsBox.tsx.` and is used in `commandsAndMenu.tsx` as an additional argument.

When we push and clone we are expecting `authentication.cacheCredentials` (default False). 