### PR TITLE
Add the ability to save `Git` login temporarily

### DIFF
--- a/jupyterlab_git/__init__.py
+++ b/jupyterlab_git/__init__.py
@@ -40,7 +40,7 @@ class JupyterLabGit(Configurable):
     credential_helper = Unicode(
         help="""
             The value of Git credential helper will be set to this value when the Git credential caching mechanism is activated by this extension.
-            By default it is a in-memory cache of 3600 seconds (1 hour); `cache --timeout=3600`.
+            By default it is an in-memory cache of 3600 seconds (1 hour); `cache --timeout=3600`.
         """,
         config=True,
     )

--- a/jupyterlab_git/__init__.py
+++ b/jupyterlab_git/__init__.py
@@ -40,7 +40,7 @@ class JupyterLabGit(Configurable):
     credential_helper = Unicode(
         help="""
             The value of Git credential helper will be set to this value when the Git credential caching mechanism is activated by this extension.
-            By default it is 3600 seconds (1 hour).
+            By default it is a in-memory cache of 3600 seconds (1 hour); `cache --timeout=3600`.
         """,
         config=True,
     )

--- a/jupyterlab_git/__init__.py
+++ b/jupyterlab_git/__init__.py
@@ -4,7 +4,7 @@
 import json
 from pathlib import Path
 
-from traitlets import List, Dict, Unicode
+from traitlets import List, Dict, Unicode, default
 from traitlets.config import Configurable
 
 from ._version import __version__
@@ -36,6 +36,18 @@ class JupyterLabGit(Configurable):
         )
         # TODO Validate
     )
+
+    credential_helper = Unicode(
+        help="""
+            The value of Git credential helper will be set to this value when the Git credential caching mechanism is activated by this extension.
+            By default it is 3600 seconds (1 hour).
+        """,
+        config=True,
+    )
+
+    @default("credential_helper")
+    def _credential_helper_default(self):
+        return "cache --timeout=3600"
 
 
 def _jupyter_server_extension_points():

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -280,7 +280,12 @@ class Git:
         env = os.environ.copy()
         if auth:
             if cache_credentials:
-                await self.ensure_credential_helper(path)
+                ensured_response = await self.ensure_credential_helper(path)
+                if ensured_response["code"] != 0:
+                    return {
+                        "code": ensured_response["code"],
+                        "message": ensured_response.get("error", "Unknown error!"),
+                    }
             env["GIT_TERMINAL_PROMPT"] = "1"
             code, output, error = await execute(
                 ["git", "clone", unquote(repo_url), "-q"],
@@ -319,7 +324,12 @@ class Git:
         env = os.environ.copy()
         if auth:
             if cache_credentials:
-                await self.ensure_credential_helper(path)
+                ensured_response = await self.ensure_credential_helper(path)
+                if ensured_response["code"] != 0:
+                    return {
+                        "code": ensured_response["code"],
+                        "message": ensured_response.get("error", "Unknown error!"),
+                    }
             env["GIT_TERMINAL_PROMPT"] = "1"
             code, _, fetch_error = await execute(
                 cmd,
@@ -1029,7 +1039,12 @@ class Git:
         env = os.environ.copy()
         if auth:
             if cache_credentials:
-                await self.ensure_credential_helper(path)
+                ensured_response = await self.ensure_credential_helper(path)
+                if ensured_response["code"] != 0:
+                    return {
+                        "code": ensured_response["code"],
+                        "message": ensured_response.get("error", "Unknown error!"),
+                    }
             env["GIT_TERMINAL_PROMPT"] = "1"
             code, output, error = await execute(
                 ["git", "pull", "--no-commit"],
@@ -1095,7 +1110,12 @@ class Git:
         env = os.environ.copy()
         if auth:
             if cache_credentials:
-                await self.ensure_credential_helper(path)
+                ensured_response = await self.ensure_credential_helper(path)
+                if ensured_response["code"] != 0:
+                    return {
+                        "code": ensured_response["code"],
+                        "message": ensured_response.get("error", "Unknown error!"),
+                    }
             env["GIT_TERMINAL_PROMPT"] = "1"
             code, output, error = await execute(
                 command,

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -348,6 +348,7 @@ class Git:
         if code != 0:
             result["command"] = " ".join(cmd)
             result["error"] = fetch_error
+            result["message"] = fetch_error
 
         return result
 

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -283,7 +283,7 @@ class Git:
         """
         env = os.environ.copy()
         if auth:
-            if auth.get("cache_credentials", None):
+            if auth.get("cache_credentials"):
                 await self.ensure_credential_helper(path)
             env["GIT_TERMINAL_PROMPT"] = "1"
             code, output, error = await execute(
@@ -322,7 +322,7 @@ class Git:
         ]  # Run prune by default to help beginners
         env = os.environ.copy()
         if auth:
-            if auth.get("cache_credentials", None):
+            if auth.get("cache_credentials"):
                 await self.ensure_credential_helper(path)
             env["GIT_TERMINAL_PROMPT"] = "1"
             code, _, fetch_error = await execute(
@@ -1031,7 +1031,7 @@ class Git:
         """
         env = os.environ.copy()
         if auth:
-            if auth.get("cache_credentials", None):
+            if auth.get("cache_credentials"):
                 await self.ensure_credential_helper(path)
             env["GIT_TERMINAL_PROMPT"] = "1"
             code, output, error = await execute(
@@ -1096,7 +1096,7 @@ class Git:
 
         env = os.environ.copy()
         if auth:
-            if auth.get("cache_credentials", None):
+            if auth.get("cache_credentials"):
                 await self.ensure_credential_helper(path)
             env["GIT_TERMINAL_PROMPT"] = "1"
             code, output, error = await execute(
@@ -1631,8 +1631,9 @@ class Git:
 
         cache_daemon_required = has_credential_helper == True
 
-        if not has_credential_helper:
+        if has_credential_helper is None:
             credential_helper: str = self._config.credential_helper
+            await self.config(path, **{"credential.helper": credential_helper})
             if GIT_CREDENTIAL_HELPER_CACHE.match(credential_helper.strip()):
                 cache_daemon_required = True
 

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -68,7 +68,7 @@ class GitCloneHandler(GitHandler):
               'repo_url': 'https://github.com/path/to/myrepo',
               OPTIONAL 'auth': '{ 'username': '<username>',
                                   'password': '<password>',
-                                  'cacheCredentials': true/false
+                                  'cache_credentials': true/false
                                 }'
             }
         """

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -23,7 +23,7 @@ from .git import DEFAULT_REMOTE_NAME, Git
 from .log import get_logger
 
 # Git configuration options exposed through the REST API
-ALLOWED_OPTIONS = ["user.name", "user.email", "credential.helper"]
+ALLOWED_OPTIONS = ["user.name", "user.email"]
 # REST API namespace
 NAMESPACE = "/git"
 
@@ -67,7 +67,8 @@ class GitCloneHandler(GitHandler):
             {
               'repo_url': 'https://github.com/path/to/myrepo',
               OPTIONAL 'auth': '{ 'username': '<username>',
-                                  'password': '<password>'
+                                  'password': '<password>',
+                                  'cacheCredentials': true/false
                                 }'
             }
         """
@@ -76,7 +77,6 @@ class GitCloneHandler(GitHandler):
             self.url2localpath(path),
             data["clone_url"],
             data.get("auth", None),
-            data.get("cache_credentials", False),
         )
 
         if response["code"] != 0:
@@ -177,7 +177,6 @@ class GitFetchHandler(GitHandler):
         result = await self.git.fetch(
             self.url2localpath(path),
             data.get("auth", None),
-            data.get("cache_credentials", False),
         )
 
         if result["code"] != 0:
@@ -541,7 +540,6 @@ class GitPullHandler(GitHandler):
             self.url2localpath(path),
             data.get("auth", None),
             data.get("cancel_on_conflict", False),
-            data.get("cache_credentials", False),
         )
 
         if response["code"] != 0:
@@ -572,7 +570,6 @@ class GitPushHandler(GitHandler):
         data = self.get_json_body()
         known_remote = data.get("remote")
         force = data.get("force", False)
-        cache_credentials = data.get("cache_credentials", False)
 
         current_local_branch = await self.git.get_current_branch(local_path)
 
@@ -601,7 +598,6 @@ class GitPushHandler(GitHandler):
                 data.get("auth", None),
                 set_upstream,
                 force,
-                cache_credentials,
             )
 
         else:
@@ -628,7 +624,6 @@ class GitPushHandler(GitHandler):
                     data.get("auth", None),
                     set_upstream=True,
                     force=force,
-                    cache_credentials=cache_credentials,
                 )
             else:
                 response = {

--- a/jupyterlab_git/tests/test_clone.py
+++ b/jupyterlab_git/tests/test_clone.py
@@ -176,7 +176,7 @@ async def test_git_clone_with_cache_credentials():
         )
 
         # Then
-        mock_execute.assert_awaited_once_with(
+        mock_execute.assert_called_once_with(
             ["git", "clone", "ghjkhjkl"],
             cwd=test_path,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
@@ -212,8 +212,8 @@ async def test_git_clone_with_auth_and_cache_credentials():
                 )
 
                 # Then
-                assert mock_execute.await_count == 3
-                mock_execute.assert_has_awaits(
+                assert mock_execute.call_count == 3
+                mock_execute.assert_has_calls(
                     [
                         call(["git", "config", "--list"], cwd=test_path),
                         call(
@@ -256,8 +256,8 @@ async def test_git_clone_with_auth_and_cache_credentials_and_existing_credential
         )
 
         # Then
-        assert mock_execute.await_count == 2
-        mock_execute.assert_has_awaits(
+        assert mock_execute.call_count == 2
+        mock_execute.assert_has_calls(
             [
                 call(["git", "config", "--list"], cwd=test_path),
                 call(

--- a/jupyterlab_git/tests/test_clone.py
+++ b/jupyterlab_git/tests/test_clone.py
@@ -161,30 +161,6 @@ async def test_git_clone_with_auth_auth_failure_from_git():
 
 
 @pytest.mark.asyncio
-async def test_git_clone_with_cache_credentials():
-    with patch("jupyterlab_git.git.execute") as mock_execute:
-        # Given
-        test_path = str(Path("/bin") / "test_curr_path")
-        mock_execute.side_effect = [
-            maybe_future((0, "", "")),
-            maybe_future((0, "", "")),
-        ]
-
-        # When
-        actual_response = await Git().clone(
-            path=test_path, repo_url="ghjkhjkl", cache_credentials=True
-        )
-
-        # Then
-        mock_execute.assert_called_once_with(
-            ["git", "clone", "ghjkhjkl"],
-            cwd=test_path,
-            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
-        )
-        assert {"code": 0, "message": ""} == actual_response
-
-
-@pytest.mark.asyncio
 async def test_git_clone_with_auth_and_cache_credentials():
     with patch("sys.platform", "linux"):
         with patch(
@@ -203,12 +179,15 @@ async def test_git_clone_with_auth_and_cache_credentials():
                     maybe_future((0, "", "")),
                 ]
                 # When
-                auth = {"username": "asdf", "password": "qwerty"}
+                auth = {
+                    "username": "asdf",
+                    "password": "qwerty",
+                    "cache_credentials": True,
+                }
                 actual_response = await Git(config=default_config).clone(
                     path=test_path,
                     repo_url="ghjkhjkl",
                     auth=auth,
-                    cache_credentials=True,
                 )
 
                 # Then
@@ -250,9 +229,9 @@ async def test_git_clone_with_auth_and_cache_credentials_and_existing_credential
             maybe_future((0, "", "")),
         ]
         # When
-        auth = {"username": "asdf", "password": "qwerty"}
+        auth = {"username": "asdf", "password": "qwerty", "cache_credentials": True}
         actual_response = await Git(config=default_config).clone(
-            path=test_path, repo_url="ghjkhjkl", auth=auth, cache_credentials=True
+            path=test_path, repo_url="ghjkhjkl", auth=auth
         )
 
         # Then

--- a/jupyterlab_git/tests/test_clone.py
+++ b/jupyterlab_git/tests/test_clone.py
@@ -162,60 +162,59 @@ async def test_git_clone_with_auth_auth_failure_from_git():
 
 @pytest.mark.asyncio
 async def test_git_clone_with_auth_and_cache_credentials():
-    with patch("sys.platform", "linux"):
-        with patch(
-            "jupyterlab_git.git.Git.ensure_git_credential_cache_daemon"
-        ) as mock_ensure_daemon:
-            mock_ensure_daemon.return_value = 0
-            with patch("jupyterlab_git.git.execute") as mock_execute:
-                # Given
-                default_config = JupyterLabGit()
-                default_config.credential_helper = "cache"
-                credential_helper = default_config.credential_helper
-                test_path = "test_curr_path"
-                mock_execute.side_effect = [
-                    maybe_future((0, "", "")),
-                    maybe_future((0, "", "")),
-                    maybe_future((0, "", "")),
-                ]
-                # When
-                auth = {
-                    "username": "asdf",
-                    "password": "qwerty",
-                    "cache_credentials": True,
-                }
-                actual_response = await Git(config=default_config).clone(
-                    path=test_path,
-                    repo_url="ghjkhjkl",
-                    auth=auth,
-                )
+    with patch(
+        "jupyterlab_git.git.Git.ensure_git_credential_cache_daemon"
+    ) as mock_ensure_daemon:
+        mock_ensure_daemon.return_value = 0
+        with patch("jupyterlab_git.git.execute") as mock_execute:
+            # Given
+            default_config = JupyterLabGit()
+            default_config.credential_helper = "cache"
+            credential_helper = default_config.credential_helper
+            test_path = "test_curr_path"
+            mock_execute.side_effect = [
+                maybe_future((0, "", "")),
+                maybe_future((0, "", "")),
+                maybe_future((0, "", "")),
+            ]
+            # When
+            auth = {
+                "username": "asdf",
+                "password": "qwerty",
+                "cache_credentials": True,
+            }
+            actual_response = await Git(config=default_config).clone(
+                path=test_path,
+                repo_url="ghjkhjkl",
+                auth=auth,
+            )
 
-                # Then
-                assert mock_execute.call_count == 3
-                mock_execute.assert_has_calls(
-                    [
-                        call(["git", "config", "--list"], cwd=test_path),
-                        call(
-                            [
-                                "git",
-                                "config",
-                                "--add",
-                                "credential.helper",
-                                credential_helper,
-                            ],
-                            cwd=test_path,
-                        ),
-                        call(
-                            ["git", "clone", "ghjkhjkl", "-q"],
-                            username="asdf",
-                            password="qwerty",
-                            cwd=test_path,
-                            env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
-                        ),
-                    ]
-                )
-                mock_ensure_daemon.assert_called_once_with(cwd=test_path, env=None)
-                assert {"code": 0, "message": ""} == actual_response
+            # Then
+            assert mock_execute.call_count == 3
+            mock_execute.assert_has_calls(
+                [
+                    call(["git", "config", "--list"], cwd=test_path),
+                    call(
+                        [
+                            "git",
+                            "config",
+                            "--add",
+                            "credential.helper",
+                            credential_helper,
+                        ],
+                        cwd=test_path,
+                    ),
+                    call(
+                        ["git", "clone", "ghjkhjkl", "-q"],
+                        username="asdf",
+                        password="qwerty",
+                        cwd=test_path,
+                        env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
+                    ),
+                ]
+            )
+            mock_ensure_daemon.assert_called_once_with(cwd=test_path, env=None)
+            assert {"code": 0, "message": ""} == actual_response
 
 
 @pytest.mark.asyncio

--- a/jupyterlab_git/tests/test_fetch.py
+++ b/jupyterlab_git/tests/test_fetch.py
@@ -1,0 +1,195 @@
+import os
+from unittest.mock import call, patch
+
+import pytest
+
+from jupyterlab_git import JupyterLabGit
+from jupyterlab_git.git import Git
+
+from .testutils import maybe_future
+
+
+@pytest.mark.asyncio
+async def test_git_fetch_success():
+    with patch("jupyterlab_git.git.execute") as mock_execute:
+        # Given
+        mock_execute.return_value = maybe_future((0, "", ""))
+
+        # When
+        actual_response = await Git().fetch(path="test_path")
+
+        # Then
+        mock_execute.assert_called_once_with(
+            ["git", "fetch", "--all", "--prune"],
+            cwd="test_path",
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+        assert {"code": 0} == actual_response
+
+
+@pytest.mark.asyncio
+async def test_git_fetch_fail():
+    with patch("jupyterlab_git.git.execute") as mock_execute:
+        # Given
+        mock_execute.return_value = maybe_future((1, "", "error"))
+
+        # When
+        actual_response = await Git().fetch(path="test_path")
+
+        # Then
+        mock_execute.assert_called_once_with(
+            ["git", "fetch", "--all", "--prune"],
+            cwd="test_path",
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+        assert {
+            "code": 1,
+            "command": "git fetch --all --prune",
+            "error": "error",
+        } == actual_response
+
+
+@pytest.mark.asyncio
+async def test_git_fetch_with_auth_success():
+    with patch("jupyterlab_git.git.execute") as mock_execute:
+        # Given
+        mock_execute.return_value = maybe_future((0, "", ""))
+
+        # When
+        actual_response = await Git().fetch(
+            path="test_path", auth={"username": "test_user", "password": "test_pass"}
+        )
+
+        # Then
+        mock_execute.assert_called_once_with(
+            ["git", "fetch", "--all", "--prune"],
+            username="test_user",
+            password="test_pass",
+            cwd="test_path",
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
+        )
+        assert {"code": 0} == actual_response
+
+
+@pytest.mark.asyncio
+async def test_git_fetch_with_auth_fail():
+    with patch("jupyterlab_git.git.execute") as mock_execute:
+        # Given
+        mock_execute.return_value = maybe_future(
+            (
+                128,
+                "",
+                "remote: Invalid username or password.\r\nfatal: Authentication failed for 'test_repo'",
+            )
+        )
+
+        # When
+        actual_response = await Git().fetch(
+            path="test_path", auth={"username": "test_user", "password": "test_pass"}
+        )
+
+        # Then
+        mock_execute.assert_called_once_with(
+            ["git", "fetch", "--all", "--prune"],
+            username="test_user",
+            password="test_pass",
+            cwd="test_path",
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
+        )
+        assert {
+            "code": 128,
+            "command": "git fetch --all --prune",
+            "error": "remote: Invalid username or password.\r\nfatal: Authentication failed for 'test_repo'",
+        } == actual_response
+
+
+@pytest.mark.asyncio
+async def test_git_fetch_with_cache_credentials():
+    with patch("jupyterlab_git.git.execute") as mock_execute:
+        # Given
+        mock_execute.return_value = maybe_future((0, "", ""))
+
+        # When
+        actual_response = await Git().fetch(path="test_path", cache_credentials=True)
+
+        # Then
+        mock_execute.assert_called_once_with(
+            ["git", "fetch", "--all", "--prune"],
+            cwd="test_path",
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+        assert {"code": 0} == actual_response
+
+
+@pytest.mark.asyncio
+async def test_git_fetch_with_auth_and_cache_credentials():
+    with patch("jupyterlab_git.git.execute") as mock_authentication:
+        # Given
+        default_config = JupyterLabGit()
+        credential_helper = default_config.credential_helper
+        test_path = "test_path"
+        mock_authentication.side_effect = [
+            maybe_future((0, "", "")),
+            maybe_future((0, "", "")),
+            maybe_future((0, "", "")),
+        ]
+        # When
+        actual_response = await Git(config=default_config).fetch(
+            path=test_path,
+            auth={"username": "test_user", "password": "test_pass"},
+            cache_credentials=True,
+        )
+
+        # Then
+        assert mock_authentication.call_count == 3
+        mock_authentication.assert_has_calls(
+            [
+                call(["git", "config", "--list"], cwd=test_path),
+                call(
+                    ["git", "config", "--add", "credential.helper", credential_helper],
+                    cwd=test_path,
+                ),
+                call(
+                    ["git", "fetch", "--all", "--prune"],
+                    username="test_user",
+                    password="test_pass",
+                    cwd=test_path,
+                    env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
+                ),
+            ]
+        )
+        assert {"code": 0} == actual_response
+
+
+@pytest.mark.asyncio
+async def test_git_fetch_with_auth_and_cache_credentials_and_existing_credential_helper():
+    with patch("jupyterlab_git.git.execute") as mock_authentication:
+        # Given
+        default_config = JupyterLabGit()
+        test_path = "test_path"
+        mock_authentication.side_effect = [
+            maybe_future((0, "credential.helper=something", "")),
+            maybe_future((0, "", "")),
+        ]
+        # When
+        actual_response = await Git(config=default_config).fetch(
+            path="test_path",
+            auth={"username": "test_user", "password": "test_pass"},
+            cache_credentials=True,
+        )
+
+        # Then
+        assert mock_authentication.call_count == 2
+        mock_authentication.assert_has_calls(
+            [
+                call(["git", "config", "--list"], cwd=test_path),
+                call(
+                    ["git", "fetch", "--all", "--prune"],
+                    username="test_user",
+                    password="test_pass",
+                    cwd=test_path,
+                    env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
+                ),
+            ]
+        )
+        assert {"code": 0} == actual_response

--- a/jupyterlab_git/tests/test_fetch.py
+++ b/jupyterlab_git/tests/test_fetch.py
@@ -19,7 +19,7 @@ async def test_git_fetch_success():
         actual_response = await Git().fetch(path="test_path")
 
         # Then
-        mock_execute.assert_awaited_once_with(
+        mock_execute.assert_called_once_with(
             ["git", "fetch", "--all", "--prune"],
             cwd="test_path",
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
@@ -37,7 +37,7 @@ async def test_git_fetch_fail():
         actual_response = await Git().fetch(path="test_path")
 
         # Then
-        mock_execute.assert_awaited_once_with(
+        mock_execute.assert_called_once_with(
             ["git", "fetch", "--all", "--prune"],
             cwd="test_path",
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
@@ -62,7 +62,7 @@ async def test_git_fetch_with_auth_success():
         )
 
         # Then
-        mock_execute.assert_awaited_once_with(
+        mock_execute.assert_called_once_with(
             ["git", "fetch", "--all", "--prune"],
             username="test_user",
             password="test_pass",
@@ -91,7 +91,7 @@ async def test_git_fetch_with_auth_fail():
         )
 
         # Then
-        mock_execute.assert_awaited_once_with(
+        mock_execute.assert_called_once_with(
             ["git", "fetch", "--all", "--prune"],
             username="test_user",
             password="test_pass",
@@ -116,7 +116,7 @@ async def test_git_fetch_with_cache_credentials():
         actual_response = await Git().fetch(path="test_path", cache_credentials=True)
 
         # Then
-        mock_execute.assert_awaited_once_with(
+        mock_execute.assert_called_once_with(
             ["git", "fetch", "--all", "--prune"],
             cwd="test_path",
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
@@ -149,8 +149,8 @@ async def test_git_fetch_with_auth_and_cache_credentials():
                 )
 
                 # Then
-                assert mock_execute.await_count == 3
-                mock_execute.assert_has_awaits(
+                assert mock_execute.call_count == 3
+                mock_execute.assert_has_calls(
                     [
                         call(["git", "config", "--list"], cwd=test_path),
                         call(
@@ -194,8 +194,8 @@ async def test_git_fetch_with_auth_and_cache_credentials_and_existing_credential
         )
 
         # Then
-        assert mock_execute.await_count == 2
-        mock_execute.assert_has_awaits(
+        assert mock_execute.call_count == 2
+        mock_execute.assert_has_calls(
             [
                 call(["git", "config", "--list"], cwd=test_path),
                 call(

--- a/jupyterlab_git/tests/test_fetch.py
+++ b/jupyterlab_git/tests/test_fetch.py
@@ -19,7 +19,7 @@ async def test_git_fetch_success():
         actual_response = await Git().fetch(path="test_path")
 
         # Then
-        mock_execute.assert_called_once_with(
+        mock_execute.assert_awaited_once_with(
             ["git", "fetch", "--all", "--prune"],
             cwd="test_path",
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
@@ -37,7 +37,7 @@ async def test_git_fetch_fail():
         actual_response = await Git().fetch(path="test_path")
 
         # Then
-        mock_execute.assert_called_once_with(
+        mock_execute.assert_awaited_once_with(
             ["git", "fetch", "--all", "--prune"],
             cwd="test_path",
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
@@ -61,7 +61,7 @@ async def test_git_fetch_with_auth_success():
         )
 
         # Then
-        mock_execute.assert_called_once_with(
+        mock_execute.assert_awaited_once_with(
             ["git", "fetch", "--all", "--prune"],
             username="test_user",
             password="test_pass",
@@ -75,11 +75,12 @@ async def test_git_fetch_with_auth_success():
 async def test_git_fetch_with_auth_fail():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
+        error_message = "remote: Invalid username or password.\r\nfatal: Authentication failed for 'test_repo'"
         mock_execute.return_value = maybe_future(
             (
                 128,
                 "",
-                "remote: Invalid username or password.\r\nfatal: Authentication failed for 'test_repo'",
+                error_message,
             )
         )
 
@@ -89,7 +90,7 @@ async def test_git_fetch_with_auth_fail():
         )
 
         # Then
-        mock_execute.assert_called_once_with(
+        mock_execute.assert_awaited_once_with(
             ["git", "fetch", "--all", "--prune"],
             username="test_user",
             password="test_pass",
@@ -99,7 +100,7 @@ async def test_git_fetch_with_auth_fail():
         assert {
             "code": 128,
             "command": "git fetch --all --prune",
-            "error": "remote: Invalid username or password.\r\nfatal: Authentication failed for 'test_repo'",
+            "error": error_message,
         } == actual_response
 
 
@@ -113,7 +114,7 @@ async def test_git_fetch_with_cache_credentials():
         actual_response = await Git().fetch(path="test_path", cache_credentials=True)
 
         # Then
-        mock_execute.assert_called_once_with(
+        mock_execute.assert_awaited_once_with(
             ["git", "fetch", "--all", "--prune"],
             cwd="test_path",
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
@@ -123,51 +124,63 @@ async def test_git_fetch_with_cache_credentials():
 
 @pytest.mark.asyncio
 async def test_git_fetch_with_auth_and_cache_credentials():
-    with patch("jupyterlab_git.git.execute") as mock_authentication:
-        # Given
-        default_config = JupyterLabGit()
-        credential_helper = default_config.credential_helper
-        test_path = "test_path"
-        mock_authentication.side_effect = [
-            maybe_future((0, "", "")),
-            maybe_future((0, "", "")),
-            maybe_future((0, "", "")),
-        ]
-        # When
-        actual_response = await Git(config=default_config).fetch(
-            path=test_path,
-            auth={"username": "test_user", "password": "test_pass"},
-            cache_credentials=True,
-        )
+    with patch("sys.platform", "linux"):
+        with patch(
+            "jupyterlab_git.git.Git.ensure_git_credential_cache_daemon"
+        ) as mock_ensure_daemon:
+            mock_ensure_daemon.return_value = 0
+            with patch("jupyterlab_git.git.execute") as mock_execute:
+                # Given
+                default_config = JupyterLabGit()
+                credential_helper = default_config.credential_helper
+                test_path = "test_path"
+                mock_execute.side_effect = [
+                    maybe_future((0, "", "")),
+                    maybe_future((0, "", "")),
+                    maybe_future((0, "", "")),
+                ]
+                # When
+                actual_response = await Git(config=default_config).fetch(
+                    path=test_path,
+                    auth={"username": "test_user", "password": "test_pass"},
+                    cache_credentials=True,
+                )
 
-        # Then
-        assert mock_authentication.call_count == 3
-        mock_authentication.assert_has_calls(
-            [
-                call(["git", "config", "--list"], cwd=test_path),
-                call(
-                    ["git", "config", "--add", "credential.helper", credential_helper],
-                    cwd=test_path,
-                ),
-                call(
-                    ["git", "fetch", "--all", "--prune"],
-                    username="test_user",
-                    password="test_pass",
-                    cwd=test_path,
-                    env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
-                ),
-            ]
-        )
-        assert {"code": 0} == actual_response
+                # Then
+                assert mock_execute.await_count == 3
+                mock_execute.assert_has_awaits(
+                    [
+                        call(["git", "config", "--list"], cwd=test_path),
+                        call(
+                            [
+                                "git",
+                                "config",
+                                "--add",
+                                "credential.helper",
+                                credential_helper,
+                            ],
+                            cwd=test_path,
+                        ),
+                        call(
+                            ["git", "fetch", "--all", "--prune"],
+                            username="test_user",
+                            password="test_pass",
+                            cwd=test_path,
+                            env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
+                        ),
+                    ]
+                )
+                mock_ensure_daemon.assert_called_once_with(cwd=test_path, env=None)
+                assert {"code": 0} == actual_response
 
 
 @pytest.mark.asyncio
 async def test_git_fetch_with_auth_and_cache_credentials_and_existing_credential_helper():
-    with patch("jupyterlab_git.git.execute") as mock_authentication:
+    with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         default_config = JupyterLabGit()
         test_path = "test_path"
-        mock_authentication.side_effect = [
+        mock_execute.side_effect = [
             maybe_future((0, "credential.helper=something", "")),
             maybe_future((0, "", "")),
         ]
@@ -179,8 +192,8 @@ async def test_git_fetch_with_auth_and_cache_credentials_and_existing_credential
         )
 
         # Then
-        assert mock_authentication.call_count == 2
-        mock_authentication.assert_has_calls(
+        assert mock_execute.await_count == 2
+        mock_execute.assert_has_awaits(
             [
                 call(["git", "config", "--list"], cwd=test_path),
                 call(

--- a/jupyterlab_git/tests/test_fetch.py
+++ b/jupyterlab_git/tests/test_fetch.py
@@ -107,24 +107,6 @@ async def test_git_fetch_with_auth_fail():
 
 
 @pytest.mark.asyncio
-async def test_git_fetch_with_cache_credentials():
-    with patch("jupyterlab_git.git.execute") as mock_execute:
-        # Given
-        mock_execute.return_value = maybe_future((0, "", ""))
-
-        # When
-        actual_response = await Git().fetch(path="test_path", cache_credentials=True)
-
-        # Then
-        mock_execute.assert_called_once_with(
-            ["git", "fetch", "--all", "--prune"],
-            cwd="test_path",
-            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
-        )
-        assert {"code": 0} == actual_response
-
-
-@pytest.mark.asyncio
 async def test_git_fetch_with_auth_and_cache_credentials():
     with patch("sys.platform", "linux"):
         with patch(
@@ -144,8 +126,11 @@ async def test_git_fetch_with_auth_and_cache_credentials():
                 # When
                 actual_response = await Git(config=default_config).fetch(
                     path=test_path,
-                    auth={"username": "test_user", "password": "test_pass"},
-                    cache_credentials=True,
+                    auth={
+                        "username": "test_user",
+                        "password": "test_pass",
+                        "cache_credentials": True,
+                    },
                 )
 
                 # Then

--- a/jupyterlab_git/tests/test_fetch.py
+++ b/jupyterlab_git/tests/test_fetch.py
@@ -46,6 +46,7 @@ async def test_git_fetch_fail():
             "code": 1,
             "command": "git fetch --all --prune",
             "error": "error",
+            "message": "error",
         } == actual_response
 
 
@@ -101,6 +102,7 @@ async def test_git_fetch_with_auth_fail():
             "code": 128,
             "command": "git fetch --all --prune",
             "error": error_message,
+            "message": error_message,
         } == actual_response
 
 

--- a/jupyterlab_git/tests/test_fetch.py
+++ b/jupyterlab_git/tests/test_fetch.py
@@ -108,57 +108,56 @@ async def test_git_fetch_with_auth_fail():
 
 @pytest.mark.asyncio
 async def test_git_fetch_with_auth_and_cache_credentials():
-    with patch("sys.platform", "linux"):
-        with patch(
-            "jupyterlab_git.git.Git.ensure_git_credential_cache_daemon"
-        ) as mock_ensure_daemon:
-            mock_ensure_daemon.return_value = 0
-            with patch("jupyterlab_git.git.execute") as mock_execute:
-                # Given
-                default_config = JupyterLabGit()
-                credential_helper = default_config.credential_helper
-                test_path = "test_path"
-                mock_execute.side_effect = [
-                    maybe_future((0, "", "")),
-                    maybe_future((0, "", "")),
-                    maybe_future((0, "", "")),
-                ]
-                # When
-                actual_response = await Git(config=default_config).fetch(
-                    path=test_path,
-                    auth={
-                        "username": "test_user",
-                        "password": "test_pass",
-                        "cache_credentials": True,
-                    },
-                )
+    with patch(
+        "jupyterlab_git.git.Git.ensure_git_credential_cache_daemon"
+    ) as mock_ensure_daemon:
+        mock_ensure_daemon.return_value = 0
+        with patch("jupyterlab_git.git.execute") as mock_execute:
+            # Given
+            default_config = JupyterLabGit()
+            credential_helper = default_config.credential_helper
+            test_path = "test_path"
+            mock_execute.side_effect = [
+                maybe_future((0, "", "")),
+                maybe_future((0, "", "")),
+                maybe_future((0, "", "")),
+            ]
+            # When
+            actual_response = await Git(config=default_config).fetch(
+                path=test_path,
+                auth={
+                    "username": "test_user",
+                    "password": "test_pass",
+                    "cache_credentials": True,
+                },
+            )
 
-                # Then
-                assert mock_execute.call_count == 3
-                mock_execute.assert_has_calls(
-                    [
-                        call(["git", "config", "--list"], cwd=test_path),
-                        call(
-                            [
-                                "git",
-                                "config",
-                                "--add",
-                                "credential.helper",
-                                credential_helper,
-                            ],
-                            cwd=test_path,
-                        ),
-                        call(
-                            ["git", "fetch", "--all", "--prune"],
-                            username="test_user",
-                            password="test_pass",
-                            cwd=test_path,
-                            env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
-                        ),
-                    ]
-                )
-                mock_ensure_daemon.assert_called_once_with(cwd=test_path, env=None)
-                assert {"code": 0} == actual_response
+            # Then
+            assert mock_execute.call_count == 3
+            mock_execute.assert_has_calls(
+                [
+                    call(["git", "config", "--list"], cwd=test_path),
+                    call(
+                        [
+                            "git",
+                            "config",
+                            "--add",
+                            "credential.helper",
+                            credential_helper,
+                        ],
+                        cwd=test_path,
+                    ),
+                    call(
+                        ["git", "fetch", "--all", "--prune"],
+                        username="test_user",
+                        password="test_pass",
+                        cwd=test_path,
+                        env={**os.environ, "GIT_TERMINAL_PROMPT": "1"},
+                    ),
+                ]
+            )
+            mock_ensure_daemon.assert_called_once_with(cwd=test_path, env=None)
+            assert {"code": 0} == actual_response
 
 
 @pytest.mark.asyncio
@@ -174,8 +173,11 @@ async def test_git_fetch_with_auth_and_cache_credentials_and_existing_credential
         # When
         actual_response = await Git(config=default_config).fetch(
             path="test_path",
-            auth={"username": "test_user", "password": "test_pass"},
-            cache_credentials=True,
+            auth={
+                "username": "test_user",
+                "password": "test_pass",
+                "cache_credentials": True,
+            },
         )
 
         # Then

--- a/jupyterlab_git/tests/test_handlers.py
+++ b/jupyterlab_git/tests/test_handlers.py
@@ -327,7 +327,7 @@ async def test_push_handler_localbranch(mock_git, jp_fetch, jp_root_dir):
     mock_git.get_current_branch.assert_called_with(str(local_path))
     mock_git.get_upstream_branch.assert_called_with(str(local_path), "localbranch")
     mock_git.push.assert_called_with(
-        ".", "HEAD:localbranch", str(local_path), None, False, False
+        ".", "HEAD:localbranch", str(local_path), None, False, False, False
     )
 
     assert response.code == 200
@@ -361,6 +361,7 @@ async def test_push_handler_remotebranch(mock_git, jp_fetch, jp_root_dir):
         "HEAD:remote-branch-name",
         str(local_path),
         None,
+        False,
         False,
         False,
     )
@@ -463,7 +464,13 @@ async def test_push_handler_noupstream_unique_remote(mock_git, jp_fetch, jp_root
     mock_git.config.assert_called_with(str(local_path))
     mock_git.remote_show.assert_called_with(str(local_path))
     mock_git.push.assert_called_with(
-        remote, "foo", str(local_path), None, set_upstream=True, force=False
+        remote,
+        "foo",
+        str(local_path),
+        None,
+        set_upstream=True,
+        force=False,
+        cache_credentials=False,
     )
 
     assert response.code == 200
@@ -496,7 +503,13 @@ async def test_push_handler_noupstream_pushdefault(mock_git, jp_fetch, jp_root_d
     mock_git.config.assert_called_with(str(local_path))
     mock_git.remote_show.assert_called_with(str(local_path))
     mock_git.push.assert_called_with(
-        remote, "foo", str(local_path), None, set_upstream=True, force=False
+        remote,
+        "foo",
+        str(local_path),
+        None,
+        set_upstream=True,
+        force=False,
+        cache_credentials=False,
     )
 
     assert response.code == 200
@@ -531,7 +544,7 @@ async def test_push_handler_noupstream_pass_remote_nobranch(
     mock_git.config.assert_not_called()
     mock_git.remote_show.assert_not_called()
     mock_git.push.assert_called_with(
-        remote, "HEAD:foo", str(local_path), None, True, False
+        remote, "HEAD:foo", str(local_path), None, True, False, False
     )
 
     assert response.code == 200
@@ -567,7 +580,7 @@ async def test_push_handler_noupstream_pass_remote_branch(
     mock_git.config.assert_not_called()
     mock_git.remote_show.assert_not_called()
     mock_git.push.assert_called_with(
-        remote, "HEAD:" + remote_branch, str(local_path), None, True, False
+        remote, "HEAD:" + remote_branch, str(local_path), None, True, False, False
     )
 
     assert response.code == 200

--- a/jupyterlab_git/tests/test_handlers.py
+++ b/jupyterlab_git/tests/test_handlers.py
@@ -327,7 +327,7 @@ async def test_push_handler_localbranch(mock_git, jp_fetch, jp_root_dir):
     mock_git.get_current_branch.assert_called_with(str(local_path))
     mock_git.get_upstream_branch.assert_called_with(str(local_path), "localbranch")
     mock_git.push.assert_called_with(
-        ".", "HEAD:localbranch", str(local_path), None, False, False, False
+        ".", "HEAD:localbranch", str(local_path), None, False, False
     )
 
     assert response.code == 200
@@ -361,7 +361,6 @@ async def test_push_handler_remotebranch(mock_git, jp_fetch, jp_root_dir):
         "HEAD:remote-branch-name",
         str(local_path),
         None,
-        False,
         False,
         False,
     )
@@ -470,7 +469,6 @@ async def test_push_handler_noupstream_unique_remote(mock_git, jp_fetch, jp_root
         None,
         set_upstream=True,
         force=False,
-        cache_credentials=False,
     )
 
     assert response.code == 200
@@ -509,7 +507,6 @@ async def test_push_handler_noupstream_pushdefault(mock_git, jp_fetch, jp_root_d
         None,
         set_upstream=True,
         force=False,
-        cache_credentials=False,
     )
 
     assert response.code == 200
@@ -544,7 +541,7 @@ async def test_push_handler_noupstream_pass_remote_nobranch(
     mock_git.config.assert_not_called()
     mock_git.remote_show.assert_not_called()
     mock_git.push.assert_called_with(
-        remote, "HEAD:foo", str(local_path), None, True, False, False
+        remote, "HEAD:foo", str(local_path), None, True, False
     )
 
     assert response.code == 200
@@ -580,7 +577,7 @@ async def test_push_handler_noupstream_pass_remote_branch(
     mock_git.config.assert_not_called()
     mock_git.remote_show.assert_not_called()
     mock_git.push.assert_called_with(
-        remote, "HEAD:" + remote_branch, str(local_path), None, True, False, False
+        remote, "HEAD:" + remote_branch, str(local_path), None, True, False
     )
 
     assert response.code == 200

--- a/jupyterlab_git/tests/test_pushpull.py
+++ b/jupyterlab_git/tests/test_pushpull.py
@@ -186,7 +186,7 @@ async def test_git_pull_with_cache_credentials():
         actual_response = await Git().pull(test_path, cache_credentials=True)
 
         # Then
-        mock_execute.assert_awaited_once_with(
+        mock_execute.assert_called_once_with(
             ["git", "pull", "--no-commit"],
             cwd=test_path,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
@@ -219,8 +219,8 @@ async def test_git_pull_with_auth_and_cache_credentials():
                 )
 
                 # Then
-                assert mock_execute.await_count == 3
-                mock_execute.assert_has_awaits(
+                assert mock_execute.call_count == 3
+                mock_execute.assert_has_calls(
                     [
                         call(
                             ["git", "config", "--list"],
@@ -267,8 +267,8 @@ async def test_git_pull_with_auth_and_cache_credentials_and_existing_credential_
         )
 
         # Then
-        assert mock_execute.await_count == 2
-        mock_execute.assert_has_awaits(
+        assert mock_execute.call_count == 2
+        mock_execute.assert_has_calls(
             [
                 call(
                     ["git", "config", "--list"],
@@ -407,7 +407,7 @@ async def test_git_push_with_cache_credentials():
         )
 
         # Then
-        mock_execute.assert_awaited_once_with(
+        mock_execute.assert_called_once_with(
             ["git", "push", ".", "HEAD:test_master"],
             cwd=test_path,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
@@ -440,8 +440,8 @@ async def test_git_push_with_auth_and_cache_credentials():
                 )
 
                 # Then
-                assert mock_execute.await_count == 3
-                mock_execute.assert_has_awaits(
+                assert mock_execute.call_count == 3
+                mock_execute.assert_has_calls(
                     [
                         call(
                             ["git", "config", "--list"],
@@ -488,8 +488,8 @@ async def test_git_push_with_auth_and_cache_credentials_and_existing_credential_
         )
 
         # Then
-        assert mock_execute.await_count == 2
-        mock_execute.assert_has_awaits(
+        assert mock_execute.call_count == 2
+        mock_execute.assert_has_calls(
             [
                 call(
                     ["git", "config", "--list"],

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1364,7 +1364,7 @@ export function addFileBrowserContextMenu(
  * @returns Promise for displaying a dialog
  */
 export async function showGitOperationDialog<T>(
-  model: GitExtension,
+  model: IGitExtension,
   operation: Operation,
   trans: TranslationBundle,
   args?: T,

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -66,7 +66,8 @@ export enum Operation {
   Clone = 'Clone',
   Pull = 'Pull',
   Push = 'Push',
-  ForcePush = 'ForcePush'
+  ForcePush = 'ForcePush',
+  Fetch = 'Fetch'
 }
 
 interface IFileDiffArgument {
@@ -1387,6 +1388,10 @@ export async function showGitOperationDialog<T>(
         break;
       case Operation.ForcePush:
         result = await model.push(authentication, true);
+        break;
+      case Operation.Fetch:
+        result = await model.fetch(authentication);
+        model.credentialsRequired = false;
         break;
       default:
         result = { code: -1, message: 'Unknown git command' };

--- a/src/components/StatusWidget.tsx
+++ b/src/components/StatusWidget.tsx
@@ -3,6 +3,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStatusBar } from '@jupyterlab/statusbar';
 import { TranslationBundle } from '@jupyterlab/translation';
 import React from 'react';
+import { Operation, showGitOperationDialog } from '../commandsAndMenu';
 import { gitIcon } from '../style/icons';
 import {
   statusAnimatedIconClass,
@@ -17,8 +18,9 @@ export class StatusWidget extends ReactWidget {
    * @param trans - The language translator
    * @returns widget
    */
-  constructor(trans: TranslationBundle) {
+  constructor(model: IGitExtension, trans: TranslationBundle) {
     super();
+    this._model = model;
     this._trans = trans;
   }
 
@@ -61,6 +63,14 @@ export class StatusWidget extends ReactWidget {
     );
   }
 
+  async _showGitOperationDialog(): Promise<void> {
+    try {
+      await showGitOperationDialog(this._model, Operation.Fetch, this._trans);
+    } catch (error) {
+      console.error('Encountered an error when fetching. Error:', error);
+    }
+  }
+
   /**
    * Locks the status widget to prevent updates.
    *
@@ -91,6 +101,7 @@ export class StatusWidget extends ReactWidget {
    */
   private _waitingForCredentials: boolean;
 
+  private _model: IGitExtension;
   private _trans: TranslationBundle;
 }
 
@@ -101,7 +112,7 @@ export function addStatusBarWidget(
   trans: TranslationBundle
 ): void {
   // Add a status bar widget to provide Git status updates:
-  const statusWidget = new StatusWidget(trans);
+  const statusWidget = new StatusWidget(model, trans);
   statusBar.registerStatusItem('git-status', {
     align: 'left',
     item: statusWidget,

--- a/src/components/StatusWidget.tsx
+++ b/src/components/StatusWidget.tsx
@@ -2,15 +2,20 @@ import { ReactWidget } from '@jupyterlab/apputils';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStatusBar } from '@jupyterlab/statusbar';
 import { TranslationBundle } from '@jupyterlab/translation';
+import { Badge } from '@material-ui/core';
 import React from 'react';
+import { classes } from 'typestyle';
 import { Operation, showGitOperationDialog } from '../commandsAndMenu';
 import { gitIcon } from '../style/icons';
 import {
+  badgeClass,
   statusAnimatedIconClass,
   statusIconClass
 } from '../style/StatusWidget';
+import { toolbarButtonClass } from '../style/Toolbar';
 import { IGitExtension } from '../tokens';
 import { sleep } from '../utils';
+import { ActionButton } from './ActionButton';
 
 export class StatusWidget extends ReactWidget {
   /**
@@ -50,16 +55,30 @@ export class StatusWidget extends ReactWidget {
 
   render(): JSX.Element {
     return (
-      <div title={`Git: ${this._trans.__(this._status)}`}>
-        <gitIcon.react
-          className={
+      <Badge
+        className={badgeClass}
+        variant="dot"
+        invisible={!this._waitingForCredentials}
+        data-test-id="git-credential-badge"
+      >
+        <ActionButton
+          className={classes(
+            toolbarButtonClass,
             this._status !== 'idle' ? statusAnimatedIconClass : statusIconClass
+          )}
+          icon={gitIcon}
+          onClick={
+            this._waitingForCredentials
+              ? async () => this._showGitOperationDialog()
+              : undefined
           }
-          left={'1px'}
-          top={'3px'}
-          stylesheet={'statusBar'}
+          title={
+            this._waitingForCredentials
+              ? `Git: ${this._trans.__('credentials required')}`
+              : `Git: ${this._trans.__(this._status)}`
+          }
         />
-      </div>
+      </Badge>
     );
   }
 

--- a/src/components/StatusWidget.tsx
+++ b/src/components/StatusWidget.tsx
@@ -32,6 +32,20 @@ export class StatusWidget extends ReactWidget {
     }
   }
 
+  /**
+   * Boolean indicating whether credentials are required.
+   */
+  get waitingForCredentials(): boolean {
+    return this._waitingForCredentials;
+  }
+
+  /**
+   * Sets the boolean indicating whether credentials are required.
+   */
+  set waitingForCredentials(value: boolean) {
+    this._waitingForCredentials = value;
+  }
+
   render(): JSX.Element {
     return (
       <div title={`Git: ${this._trans.__(this._status)}`}>
@@ -72,6 +86,11 @@ export class StatusWidget extends ReactWidget {
    */
   private _status = '';
 
+  /**
+   * Boolean indicating whether credentials are required.
+   */
+  private _waitingForCredentials: boolean;
+
   private _trans: TranslationBundle;
 }
 
@@ -92,8 +111,14 @@ export function addStatusBarWidget(
 
   const callback = Private.createEventCallback(statusWidget);
   model.taskChanged.connect(callback);
+
+  const credentialsRequiredCallback =
+    Private.createCredentialsRequiredCallback(statusWidget);
+  model.credentialsRequiredSignal.connect(credentialsRequiredCallback);
+
   statusWidget.disposed.connect(() => {
     model.taskChanged.disconnect(callback);
+    model.credentialsRequiredSignal.disconnect(credentialsRequiredCallback);
   });
 }
 /* eslint-disable no-inner-declarations */
@@ -199,6 +224,33 @@ namespace Private {
     function isActive(): boolean {
       return settings.composite.displayStatus as boolean;
     }
+  }
+
+  /**
+   * Returns a callback invoked when credentials are required.
+   *
+   * @private
+   * @param widget - status widget
+   * @returns callback
+   */
+  export function createCredentialsRequiredCallback(
+    widget: StatusWidget
+  ): (model: IGitExtension, value: boolean) => void {
+    /**
+     * Callback invoked when credentials are required.
+     *
+     * @private
+     * @param model - extension model
+     * @param value - boolean indicating whether credentials are required
+     * @returns void
+     */
+    function callbackCredentialsRequired(
+      model: IGitExtension,
+      value: boolean
+    ): void {
+      widget.waitingForCredentials = value;
+    }
+    return callbackCredentialsRequired;
   }
 }
 /* eslint-enable no-inner-declarations */

--- a/src/model.ts
+++ b/src/model.ts
@@ -587,7 +587,8 @@ export class GitExtension implements IGitExtension {
           'POST',
           {
             clone_url: url,
-            auth: auth as any
+            auth: auth as any,
+            cache_credentials: auth?.cacheCredentials
           }
         );
       }
@@ -835,7 +836,8 @@ export class GitExtension implements IGitExtension {
             cancel_on_conflict:
               (this._settings?.composite[
                 'cancelPullMergeConflict'
-              ] as boolean) || false
+              ] as boolean) || false,
+            cache_credentials: auth?.cacheCredentials
           }
         );
       }
@@ -865,7 +867,8 @@ export class GitExtension implements IGitExtension {
           'POST',
           {
             auth: auth as any,
-            force: force
+            force: force,
+            cache_credentials: auth?.cacheCredentials
           }
         );
       }

--- a/src/model.ts
+++ b/src/model.ts
@@ -313,17 +313,6 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
-   * Boolean indicating whether the fetch poll is blocked.
-   */
-  get fetchBlocked(): boolean {
-    return this._fetchBlocked;
-  }
-
-  set fetchBlocked(value: boolean) {
-    this._fetchBlocked = value;
-  }
-
-  /**
    * Get the current markers
    *
    * Note: This makes sure it always returns non null value
@@ -1678,7 +1667,6 @@ export class GitExtension implements IGitExtension {
   private _selectedHistoryFile: Git.IStatusFile | null = null;
   private _hasDirtyStagedFiles = false;
   private _credentialsRequired = false;
-  private _fetchBlocked = false;
 
   private _headChanged = new Signal<IGitExtension, void>(this);
   private _markChanged = new Signal<IGitExtension, void>(this);

--- a/src/model.ts
+++ b/src/model.ts
@@ -1545,7 +1545,9 @@ export class GitExtension implements IGitExtension {
    * This is blocked if Git credentials are required.
    */
   private _fetchRemotes = async (): Promise<void> => {
-    if (this.credentialsRequired) return;
+    if (this.credentialsRequired) {
+      return;
+    }
     try {
       await this.fetch();
     } catch (error) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -292,6 +292,38 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
+   * Boolean indicating whether credentials are required from the user.
+   */
+  get credentialsRequired(): boolean {
+    return this._credentialsRequired;
+  }
+
+  set credentialsRequired(value: boolean) {
+    if (this._credentialsRequired !== value) {
+      this._credentialsRequired = value;
+      this._credentialsRequiredSignal.emit(value);
+    }
+  }
+
+  /**
+   * A signal emitted whenever credentials are required, or are not required anymore.
+   */
+  get credentialsRequiredSignal(): ISignal<IGitExtension, boolean> {
+    return this._credentialsRequiredSignal;
+  }
+
+  /**
+   * Boolean indicating whether the fetch poll is blocked.
+   */
+  get fetchBlocked(): boolean {
+    return this._fetchBlocked;
+  }
+
+  set fetchBlocked(value: boolean) {
+    this._fetchBlocked = value;
+  }
+
+  /**
    * Get the current markers
    *
    * Note: This makes sure it always returns non null value
@@ -1609,6 +1641,8 @@ export class GitExtension implements IGitExtension {
   private _changeUpstreamNotified: Git.IStatusFile[] = [];
   private _selectedHistoryFile: Git.IStatusFile | null = null;
   private _hasDirtyStagedFiles = false;
+  private _credentialsRequired = false;
+  private _fetchBlocked = false;
 
   private _headChanged = new Signal<IGitExtension, void>(this);
   private _markChanged = new Signal<IGitExtension, void>(this);
@@ -1628,6 +1662,7 @@ export class GitExtension implements IGitExtension {
   private _dirtyStagedFilesStatusChanged = new Signal<IGitExtension, boolean>(
     this
   );
+  private _credentialsRequiredSignal = new Signal<IGitExtension, boolean>(this);
 }
 
 export class BranchMarker implements Git.IBranchMarker {

--- a/src/model.ts
+++ b/src/model.ts
@@ -608,7 +608,7 @@ export class GitExtension implements IGitExtension {
           'POST',
           {
             clone_url: url,
-            auth: auth as any,
+            auth: auth as any
           }
         );
       }
@@ -770,7 +770,7 @@ export class GitExtension implements IGitExtension {
           URLExt.join(path, 'remote', 'fetch'),
           'POST',
           {
-            auth: auth as any,
+            auth: auth as any
           }
         );
       }
@@ -883,7 +883,7 @@ export class GitExtension implements IGitExtension {
             cancel_on_conflict:
               (this._settings?.composite[
                 'cancelPullMergeConflict'
-              ] as boolean) || false,
+              ] as boolean) || false
           }
         );
       }
@@ -913,7 +913,7 @@ export class GitExtension implements IGitExtension {
           'POST',
           {
             auth: auth as any,
-            force: force,
+            force: force
           }
         );
       }
@@ -1684,7 +1684,9 @@ export class GitExtension implements IGitExtension {
   private _dirtyStagedFilesStatusChanged = new Signal<IGitExtension, boolean>(
     this
   );
-  private _credentialsRequiredChanged = new Signal<IGitExtension, boolean>(this);
+  private _credentialsRequiredChanged = new Signal<IGitExtension, boolean>(
+    this
+  );
 }
 
 export class BranchMarker implements Git.IBranchMarker {

--- a/src/model.ts
+++ b/src/model.ts
@@ -301,15 +301,15 @@ export class GitExtension implements IGitExtension {
   set credentialsRequired(value: boolean) {
     if (this._credentialsRequired !== value) {
       this._credentialsRequired = value;
-      this._credentialsRequiredSignal.emit(value);
+      this._credentialsRequiredChanged.emit(value);
     }
   }
 
   /**
    * A signal emitted whenever credentials are required, or are not required anymore.
    */
-  get credentialsRequiredSignal(): ISignal<IGitExtension, boolean> {
-    return this._credentialsRequiredSignal;
+  get credentialsRequiredChanged(): ISignal<IGitExtension, boolean> {
+    return this._credentialsRequiredChanged;
   }
 
   /**
@@ -609,7 +609,6 @@ export class GitExtension implements IGitExtension {
           {
             clone_url: url,
             auth: auth as any,
-            cache_credentials: auth?.cacheCredentials
           }
         );
       }
@@ -772,7 +771,6 @@ export class GitExtension implements IGitExtension {
           'POST',
           {
             auth: auth as any,
-            cache_credentials: auth?.cacheCredentials
           }
         );
       }
@@ -886,7 +884,6 @@ export class GitExtension implements IGitExtension {
               (this._settings?.composite[
                 'cancelPullMergeConflict'
               ] as boolean) || false,
-            cache_credentials: auth?.cacheCredentials
           }
         );
       }
@@ -917,7 +914,6 @@ export class GitExtension implements IGitExtension {
           {
             auth: auth as any,
             force: force,
-            cache_credentials: auth?.cacheCredentials
           }
         );
       }
@@ -1688,7 +1684,7 @@ export class GitExtension implements IGitExtension {
   private _dirtyStagedFilesStatusChanged = new Signal<IGitExtension, boolean>(
     this
   );
-  private _credentialsRequiredSignal = new Signal<IGitExtension, boolean>(this);
+  private _credentialsRequiredChanged = new Signal<IGitExtension, boolean>(this);
 }
 
 export class BranchMarker implements Git.IBranchMarker {

--- a/src/style/StatusWidget.ts
+++ b/src/style/StatusWidget.ts
@@ -28,3 +28,13 @@ export const statusAnimatedIconClass = style({
     }
   }
 });
+
+export const badgeClass = style({
+  $nest: {
+    '& > .MuiBadge-badge': {
+      top: 6,
+      right: 15,
+      backgroundColor: 'var(--jp-warn-color1)'
+    }
+  }
+});

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -398,13 +398,14 @@ export interface IGitExtension extends IDisposable {
    * Push local changes to a remote repository.
    *
    * @param auth - remote authentication information
+   * @param force - whether or not to force the push
    * @returns promise which resolves upon pushing changes
    *
    * @throws {Git.NotInRepository} If the current path is not a Git repository
    * @throws {Git.GitResponseError} If the server response is not ok
    * @throws {ServerConnection.NetworkError} If the request cannot be made
    */
-  push(auth?: Git.IAuth): Promise<Git.IResultWithMessage>;
+  push(auth?: Git.IAuth, force?: boolean): Promise<Git.IResultWithMessage>;
 
   /**
    * General Git refresh

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -68,6 +68,21 @@ export interface IGitExtension extends IDisposable {
   hasDirtyStagedFiles: boolean;
 
   /**
+   * Boolean indicating whether credentials are required from the user.
+   */
+  credentialsRequired: boolean;
+
+  /**
+   * A signal emitted whenever credentials are required, or are not required anymore.
+   */
+  readonly credentialsRequiredSignal: ISignal<IGitExtension, boolean>;
+
+  /**
+   * Boolean indicating whether the fetch poll is blocked.
+   */
+  fetchBlocked: boolean;
+
+  /**
    * Git repository status.
    */
   readonly status: Git.IStatus;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -301,6 +301,18 @@ export interface IGitExtension extends IDisposable {
   ensureGitignore(): Promise<void>;
 
   /**
+   * Fetch to get ahead/behind status
+   *
+   * @param auth - remote authentication information
+   * @returns promise which resolves upon fetching
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  fetch(auth?: Git.IAuth): Promise<Git.IResultWithMessage>;
+
+  /**
    * Match files status information based on a provided file path.
    *
    * If the file is tracked and has no changes, a StatusFile of unmodified will be returned

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -919,11 +919,12 @@ export namespace Git {
   }
 
   /**
-   * Interface for the Git Auth request.
+   * Interface for the Git Auth request with credentials caching option.
    */
   export interface IAuth {
     username: string;
     password: string;
+    cacheCredentials?: boolean;
   }
 
   /**

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -75,7 +75,7 @@ export interface IGitExtension extends IDisposable {
   /**
    * A signal emitted whenever credentials are required, or are not required anymore.
    */
-  readonly credentialsRequiredSignal: ISignal<IGitExtension, boolean>;
+  readonly credentialsRequiredChanged: ISignal<IGitExtension, boolean>;
 
   /**
    * Git repository status.
@@ -947,7 +947,7 @@ export namespace Git {
   export interface IAuth {
     username: string;
     password: string;
-    cacheCredentials?: boolean;
+    cache_credentials?: boolean;
   }
 
   /**

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -78,11 +78,6 @@ export interface IGitExtension extends IDisposable {
   readonly credentialsRequiredSignal: ISignal<IGitExtension, boolean>;
 
   /**
-   * Boolean indicating whether the fetch poll is blocked.
-   */
-  fetchBlocked: boolean;
-
-  /**
    * Git repository status.
    */
   readonly status: Git.IStatus;

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -23,15 +23,21 @@ export class GitCredentialsForm
   private createBody(textContent: string, warningContent: string): HTMLElement {
     const node = document.createElement('div');
     const label = document.createElement('label');
+
+    const checkboxLabel = document.createElement('label');
+    this._checkboxCacheCredentials = document.createElement('input');
+    const checkboxText = document.createElement('span');
+
     this._user = document.createElement('input');
+    this._user.type = 'text';
     this._password = document.createElement('input');
     this._password.type = 'password';
 
     const text = document.createElement('span');
     const warning = document.createElement('div');
 
-    node.className = 'jp-RedirectForm';
-    warning.className = 'jp-RedirectForm-warning';
+    node.className = 'jp-CredentialsBox';
+    warning.className = 'jp-CredentialsBox-warning';
     text.textContent = textContent;
     warning.textContent = warningContent;
     this._user.placeholder = this._trans.__('username');
@@ -39,11 +45,20 @@ export class GitCredentialsForm
       'password / personal access token'
     );
 
+    checkboxLabel.className = 'jp-CredentialsBox-label-checkbox';
+    this._checkboxCacheCredentials.type = 'checkbox';
+    checkboxText.textContent = this._trans.__('Save my login temporarily');
+
     label.appendChild(text);
     label.appendChild(this._user);
     label.appendChild(this._password);
     node.appendChild(label);
     node.appendChild(warning);
+
+    checkboxLabel.appendChild(this._checkboxCacheCredentials);
+    checkboxLabel.appendChild(checkboxText);
+    node.appendChild(checkboxLabel);
+
     return node;
   }
 
@@ -53,10 +68,12 @@ export class GitCredentialsForm
   getValue(): Git.IAuth {
     return {
       username: this._user.value,
-      password: this._password.value
+      password: this._password.value,
+      cacheCredentials: this._checkboxCacheCredentials.checked
     };
   }
   protected _trans: TranslationBundle;
   private _user: HTMLInputElement;
   private _password: HTMLInputElement;
+  private _checkboxCacheCredentials: HTMLInputElement;
 }

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -69,7 +69,7 @@ export class GitCredentialsForm
     return {
       username: this._user.value,
       password: this._password.value,
-      cacheCredentials: this._checkboxCacheCredentials.checked
+      cache_credentials: this._checkboxCacheCredentials.checked
     };
   }
   protected _trans: TranslationBundle;

--- a/style/base.css
+++ b/style/base.css
@@ -3,6 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+@import url('credentials-box.css');
 @import url('diff-common.css');
 @import url('diff-nb.css');
 @import url('diff-text.css');

--- a/style/credentials-box.css
+++ b/style/credentials-box.css
@@ -1,0 +1,20 @@
+.jp-CredentialsBox input[type='text'],
+.jp-CredentialsBox input[type='password'] {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.jp-CredentialsBox input[type='checkbox'] {
+  display: inline-block;
+}
+
+.jp-CredentialsBox-warning {
+  color: var(--jp-warn-color0);
+}
+
+.jp-CredentialsBox-label-checkbox {
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary

This PR fixes #659 by implementing the ability that lets JupyterLab-Git users *cache* their login credentials. By default, the information is saved temporarily for 1 hour, and this can be configured (the unit of time is *seconds*). This feature is readily available for any one of the following Git operations:
- Clone: tick the checkbox when prompted for Git credentials.
- Push: tick the checkbox when prompted for Git credentials.
- Pull: tick the checkbox when prompted for Git credentials.
- Fetch: when credentials/login information is required, a small notification dot will appear on top of the Git icon in the status bar. Users can click it for the prompt to show up, and within that prompt pop-up, tick the checkbox if they wish to have their credentials cached.

Within the cache period, any of the aforementioned Git operations should not ask for the user's credentials again and should be able to work using the cached credentials.

## Details

### Frontend

- The Git credential prompt dialog is extended with a checkbox indicating whether the credentials should be cached or not.
- `Git.IAuth` is extended with an optional `cache_credentials: boolean`.
- The fetch poll will not send requests when Git credentials are required, instead it waits for the credentials to be provided, and gets unblocked when Git credentials are provided and the authentication is successful. A small colored dot appears on top of the Git extension icon in the status bar when this happens.

### Backend

- Endpoints `push`, `pull`, `fetch`, `clone` each accepts a `POST` request that includes `auth` and `auth` includes `cache_credentials` (optional/nullable/`None`-able). These are used to indicate what the user provided from the frontend.
- `git config` is used to make a decision here. If the user wishes to have their credentials temporarily saved, and in `git config`, `credential.helper` is not set, then `credential.helper` will be set to whatever that is configured in the server settings. Otherwise, no action is taken. **After that, in either case, if `credential.helper` is `cache` (i.e., Git's built-in credential caching mechanism), JupyterLab will attempt to spawn a daemon process that takes care of the caching work.**  In a brief amount of time after the daemon has been summoned, credentials given to Git will be picked up by that daemon.
- When the caching mechanism kicks in, a Git credential cache daemon is created in a separated process, and it will go away when the cache period expires. **Right now, the cache mechanism can only work on systems with support for Unix sockets, which means this feature will not work with standard Windows installations**.

## References

https://git-scm.com/docs/git-credential-cache: A `--timeout` argument can be added to specify how long (in seconds) credentials should be cached.

https://git-scm.com/docs/git-credential-cache--daemon

## Demos

![image](https://cdn.discordapp.com/attachments/938497071546253352/956075721346940980/unknown.png)
*An orange dot appears on top of the Git icon in the status bar, indicating that it needs Git credentials.*

![image](https://cdn.discordapp.com/attachments/938497071546253352/956075721606971392/unknown.png)
*Clicking the Git icon in the status bar should make this prompt pop-up show up. This also applies for doing clones, pushes and pulls.*

![image](https://cdn.discordapp.com/attachments/938497071546253352/956075721841836062/unknown.png)
*There should be no colored dot while the cached information is alive and is valid.*

![image](https://cdn.discordapp.com/attachments/938497071546253352/956075861101150248/unknown.png)
*The dot will show up again when the cached information does not exist (anymore) or is no longer valid. Also in this case, doing clones, pushes or pulls would require the user to input their Git credentials again.*

## Notes

This PR might need more tests.

## Linked issues
#659