### PR TITLE
add current branch name on status bar

### DIFF
--- a/src/components/StatusWidget.tsx
+++ b/src/components/StatusWidget.tsx
@@ -10,7 +10,8 @@ import { gitIcon } from '../style/icons';
 import {
   badgeClass,
   statusAnimatedIconClass,
-  statusIconClass
+  statusIconClass,
+  currentBranchClass
 } from '../style/StatusWidget';
 import { toolbarButtonClass } from '../style/Toolbar';
 import { IGitExtension } from '../tokens';
@@ -46,32 +47,39 @@ export class StatusWidget extends ReactWidget {
         initialArgs={false}
       >
         {(_, needsCredentials) => (
-          <Badge
-            className={badgeClass}
-            variant="dot"
-            invisible={!needsCredentials}
-            data-test-id="git-credential-badge"
-          >
-            <ActionButton
-              className={classes(
-                toolbarButtonClass,
-                this._status !== 'idle'
-                  ? statusAnimatedIconClass
-                  : statusIconClass
-              )}
-              icon={gitIcon}
-              onClick={
-                needsCredentials
-                  ? async () => this._showGitOperationDialog()
-                  : undefined
-              }
-              title={
-                needsCredentials
-                  ? `Git: ${this._trans.__('credentials required')}`
-                  : `Git: ${this._trans.__(this._status)}`
-              }
-            />
-          </Badge>
+          <>
+            <Badge
+              className={badgeClass}
+              variant="dot"
+              invisible={!needsCredentials}
+              data-test-id="git-credential-badge"
+            >
+              <ActionButton
+                className={classes(
+                  toolbarButtonClass,
+                  this._status !== 'idle'
+                    ? statusAnimatedIconClass
+                    : statusIconClass
+                )}
+                icon={gitIcon}
+                onClick={
+                  needsCredentials
+                    ? async () => this._showGitOperationDialog()
+                    : undefined
+                }
+                title={
+                  needsCredentials
+                    ? `Git: ${this._trans.__('credentials required')}`
+                    : `Git: ${this._trans.__(this._status)}`
+                }
+              />
+            </Badge>
+            {this._model.currentBranch && (
+              <span className={currentBranchClass}>
+                {this._model.currentBranch.name}*
+              </span>
+            )}
+          </>
         )}
       </UseSignal>
     );

--- a/src/components/StatusWidget.tsx
+++ b/src/components/StatusWidget.tsx
@@ -83,7 +83,7 @@ export class StatusWidget extends ReactWidget {
           {() =>
             this._model.currentBranch && (
               <span className={currentBranchNameClass}>
-                {this._model.currentBranch.name}*
+                {this._model.currentBranch.name}
               </span>
             )
           }

--- a/src/components/StatusWidget.tsx
+++ b/src/components/StatusWidget.tsx
@@ -28,6 +28,8 @@ export class StatusWidget extends ReactWidget {
     super();
     this._model = model;
     this._trans = trans;
+
+    this.addClass('jp-git-StatusWidget');
   }
 
   /**

--- a/src/components/StatusWidget.tsx
+++ b/src/components/StatusWidget.tsx
@@ -11,7 +11,7 @@ import {
   badgeClass,
   statusAnimatedIconClass,
   statusIconClass,
-  currentBranchClass
+  currentBranchNameClass
 } from '../style/StatusWidget';
 import { toolbarButtonClass } from '../style/Toolbar';
 import { IGitExtension } from '../tokens';
@@ -42,12 +42,12 @@ export class StatusWidget extends ReactWidget {
 
   render(): JSX.Element {
     return (
-      <UseSignal
-        signal={this._model.credentialsRequiredChanged}
-        initialArgs={false}
-      >
-        {(_, needsCredentials) => (
-          <>
+      <>
+        <UseSignal
+          signal={this._model.credentialsRequiredChanged}
+          initialArgs={false}
+        >
+          {(_, needsCredentials) => (
             <Badge
               className={badgeClass}
               variant="dot"
@@ -74,14 +74,19 @@ export class StatusWidget extends ReactWidget {
                 }
               />
             </Badge>
-            {this._model.currentBranch && (
-              <span className={currentBranchClass}>
+          )}
+        </UseSignal>
+
+        <UseSignal signal={this._model.headChanged}>
+          {() =>
+            this._model.currentBranch && (
+              <span className={currentBranchNameClass}>
                 {this._model.currentBranch.name}*
               </span>
-            )}
-          </>
-        )}
-      </UseSignal>
+            )
+          }
+        </UseSignal>
+      </>
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ async function activate(
     change: IChangedArgs<string>
   ) => {
     gitExtension.pathRepository = change.newValue;
+    gitExtension.refreshBranch();
   };
 
   // Whenever the file browser path changes, sync the Git extension path

--- a/src/style/StatusWidget.ts
+++ b/src/style/StatusWidget.ts
@@ -39,6 +39,7 @@ export const badgeClass = style({
   }
 });
 
-export const currentBranchClass = style({
-  fontSize: 'var(--jp-ui-font-size1)'
+export const currentBranchNameClass = style({
+  fontSize: 'var(--jp-ui-font-size1)',
+  lineHeight: '100%'
 });

--- a/src/style/StatusWidget.ts
+++ b/src/style/StatusWidget.ts
@@ -38,3 +38,7 @@ export const badgeClass = style({
     }
   }
 });
+
+export const currentBranchClass = style({
+  fontSize: 'var(--jp-ui-font-size1)'
+});

--- a/style/base.css
+++ b/style/base.css
@@ -8,3 +8,4 @@
 @import url('diff-nb.css');
 @import url('diff-text.css');
 @import url('variables.css');
+@import url('status-widget.css');

--- a/style/status-widget.css
+++ b/style/status-widget.css
@@ -1,0 +1,4 @@
+.jp-git-StatusWidget {
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab-git/issues/1100

@fcollonval 
Added current branch name on the status bar
I managed to style it but I'm not sure how to center the text vertically.
I should make the parent element a flex box and do align-item: center but I don't know how to select the parent class.
Also I'm not sure how to change the padding of the git icon so that the text could be closer to the icon.

Another issue is when navigate to another repo (change file directory), the branch name stays unless you click on the git extension icon on the left menu bar, which is a bit weird. 

---

Edited to link the related issue.