### PR TITLE
close diff window when changes to file are discarded

### DIFF
--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -607,7 +607,7 @@ export function addCommands(
             modelIsLoading.reject(msg);
           }
 
-          const slotRegistered = gitModel.statusChanged.connect((_, status) => {
+          gitModel.statusChanged.connect((_, status) => {
             const targetFile = status.files.find(
               fileStatus => model.filename === fileStatus.from
             );
@@ -615,7 +615,6 @@ export function addCommands(
               mainAreaItem.dispose();
             }
           });
-          console.log(slotRegistered);
         }
 
         return mainAreaItem;


### PR DESCRIPTION
@fcollonval 
Implemented closing of diff window when the changes to file are discarded, but I copied a lot of codes from the gitFileDiff command

Fixes https://github.com/jupyterlab/jupyterlab-git/issues/911

---

Edited to link the issue