### PR TITLE
Bumping to 0.39.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/git",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "A JupyterLab extension for version control using git",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
We are breaking semver from this version on because I want to keep the previous convention of JupyterLab v3 -> git extension 0.30.0 <= x < 0.40.0.

For JupyterLab v4, we should move to 1.0.0