### PR TITLE
Bump to 0.40.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/git",
-  "version": "0.39.3",
+  "version": "0.40.0",
   "description": "A JupyterLab extension for version control using git",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
:warning: This is changing the previous rules

JLab 2 <-> git extension 0.2#.#
JLab 3 <-> git extension 0.3#.#

But it was not a great idea and I prefer to follow semver.

So 0.40.0 will be compatible with JupyterLab 3 (and only 3 as some changes will be required for JLab 4).
