### PR TITLE
Fix submodules unhandler

### DIFF
--- a/src/cloneCommand.ts
+++ b/src/cloneCommand.ts
@@ -59,7 +59,8 @@ export const gitCloneCommandPlugin: JupyterFrontEndPlugin<void> = {
               {
                 path: fileBrowserModel.path,
                 url: result.value.url,
-                versioning: result.value.versioning
+                versioning: result.value.versioning,
+                submodules: result.value.submodules
               }
             );
             logger.log({

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -65,6 +65,7 @@ export interface IGitCloneArgs {
    * If false, this will remove the .git folder after cloning.
    */
   versioning?: boolean;
+  submodules?: boolean;
 }
 
 /**
@@ -1544,12 +1545,14 @@ export async function showGitOperationDialog<T>(
     switch (operation) {
       case Operation.Clone:
         // eslint-disable-next-line no-case-declarations
-        const { path, url, versioning } = args as any as IGitCloneArgs;
+        const { path, url, versioning, submodules } =
+          args as any as IGitCloneArgs;
         result = await model.clone(
           path,
           url,
           authentication,
-          versioning ?? true
+          versioning ?? true,
+          submodules ?? true
         );
         break;
       case Operation.Pull:

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -65,6 +65,9 @@ export interface IGitCloneArgs {
    * If false, this will remove the .git folder after cloning.
    */
   versioning?: boolean;
+  /**
+   * Whether to activate git recurse submodules clone or not.
+   */
   submodules?: boolean;
 }
 
@@ -1552,7 +1555,7 @@ export async function showGitOperationDialog<T>(
           url,
           authentication,
           versioning ?? true,
-          submodules ?? true
+          submodules ?? false
         );
         break;
       case Operation.Pull:

--- a/src/model.ts
+++ b/src/model.ts
@@ -620,7 +620,7 @@ export class GitExtension implements IGitExtension {
    * @param url - Git repository URL
    * @param auth - remote repository authentication information
    * @param versioning - boolean flag of Git metadata (default true)
-   * @param submodules - boolean flag of Git submodules (default true)
+   * @param submodules - boolean flag of Git submodules (default false)
    * @returns promise which resolves upon cloning a repository
    *
    * @throws {Git.GitResponseError} If the server response is not ok
@@ -631,7 +631,7 @@ export class GitExtension implements IGitExtension {
     url: string,
     auth?: Git.IAuth,
     versioning = true,
-    submodules = true
+    submodules = false
   ): Promise<Git.IResultWithMessage> {
     return await this._taskHandler.execute<Git.IResultWithMessage>(
       'git:clone',

--- a/src/model.ts
+++ b/src/model.ts
@@ -620,6 +620,7 @@ export class GitExtension implements IGitExtension {
    * @param url - Git repository URL
    * @param auth - remote repository authentication information
    * @param versioning - boolean flag of Git metadata (default true)
+   * @param submodules - boolean flag of Git submodules (default true)
    * @returns promise which resolves upon cloning a repository
    *
    * @throws {Git.GitResponseError} If the server response is not ok
@@ -629,7 +630,8 @@ export class GitExtension implements IGitExtension {
     path: string,
     url: string,
     auth?: Git.IAuth,
-    versioning = true
+    versioning = true,
+    submodules = true
   ): Promise<Git.IResultWithMessage> {
     return await this._taskHandler.execute<Git.IResultWithMessage>(
       'git:clone',
@@ -640,6 +642,7 @@ export class GitExtension implements IGitExtension {
           {
             clone_url: url,
             versioning: versioning,
+            submodules: submodules,
             auth: auth as any
           }
         );

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -233,6 +233,7 @@ export interface IGitExtension extends IDisposable {
    * @param url - Git repository URL
    * @param auth - remote repository authentication information
    * @param versioning - Whether to clone or download the Git repository
+   * @param submodules - Whether to clone recursively the Git submodules
    * @returns promise which resolves upon cloning a repository
    *
    * @throws {Git.GitResponseError} If the server response is not ok
@@ -242,7 +243,8 @@ export interface IGitExtension extends IDisposable {
     path: string,
     url: string,
     auth?: Git.IAuth,
-    versioning?: boolean
+    versioning?: boolean,
+    submodules?: boolean
   ): Promise<Git.IResultWithMessage>;
 
   /**


### PR DESCRIPTION
Unfortunately it seems that #1188 introduced a `Unhandled error` 😞

```
Uncaught exception POST /git/clone?1669638844222 (127.0.0.1)
    HTTPServerRequest(protocol='http', host='localhost:8888', method='POST', uri='/git/clone?1669638844222', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File ".../site-packages/tornado/web.py", line 1713, in _execute
        result = await result
      File ".../site-packages/jupyterlab_git/handlers.py", line 92, in post
        data["submodules"],
    KeyError: 'submodules'
```

This PR should implements a hot fix with the correct clone command handler (I have mainly duplicated the `versioning` attribute in the TS command model).

You might also need to write a test for the clone TS component (I don't really know how to do it).

Feel free to double check and edit this PR if needed. My apologies for not spotting this earlier.