### PR TITLE
Update commandsAndMenu.tsx to replace "`" in file path for Open Git Repository since it leads to Command Injection Vulnerability

### DIFF
--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -160,7 +160,11 @@ export function addCommands(
           terminal.session.send({
             type: 'stdin',
             content: [
-              `cd "${gitModel.pathRepository.split('"').join('\\"')}"\n`
+              `cd "${gitModel.pathRepository
+                .split('"')
+                .join('\\"')
+                .split('`')
+                .join('\\`')}"\n`
             ]
           });
         }


### PR DESCRIPTION


When a repo is created with the backtick character around it and Initialized as a repo and then opened in Terminal, the linux command is resolved or executed on a running instance. For example if a folder with the name "whoami" is created, initialized as a repo and then opened in terminal using 'Open Git repository in Terminal' you will see that whoami is resolved to the current user which is a vector of command injection.