### PR TITLE
Improve HTTP status codes for the some remote git operations

### DIFF
--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -98,7 +98,7 @@ class GitCloneHandler(GitHandler):
         )
 
         if response["code"] != 0:
-            self.set_status(500)
+            self.set_status(401)
         self.finish(json.dumps(response))
 
 

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -683,6 +683,8 @@ class GitPushHandler(GitHandler):
                     set_upstream=True,
                     force=force,
                 )
+                if response["code"] != 0:
+                    self.set_status(401)
             else:
                 response = {
                     "code": 128,
@@ -691,9 +693,8 @@ class GitPushHandler(GitHandler):
                     ),
                     "remotes": remotes,  # Returns the list of known remotes
                 }
-
-        if response["code"] != 0:
-            self.set_status(500)
+                if response["code"] != 0:
+                    self.set_status(404)
 
         self.finish(json.dumps(response))
 

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -198,7 +198,7 @@ class GitFetchHandler(GitHandler):
         )
 
         if result["code"] != 0:
-            self.set_status(500)
+            self.set_status(401)
         self.finish(json.dumps(result))
 
 
@@ -601,7 +601,7 @@ class GitPullHandler(GitHandler):
         )
 
         if response["code"] != 0:
-            self.set_status(500)
+            self.set_status(401)
 
         self.finish(json.dumps(response))
 


### PR DESCRIPTION
Improve HTTP status codes by switch some of the Server Error (5xx) to Client Error codes (4xx), since it is related to client specific actions.
Also this allows to not break some security rules for 5xx codes in NGINX and other reverse proxies, maintaining the feature as is.