### PR TITLE
Re-encode cwd if path does not exist

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -11,7 +11,7 @@ import subprocess
 import traceback
 from typing import Dict, List, Optional
 from unittest.mock import NonCallableMock
-from urllib.parse import unquote
+from urllib.parse import quote, unquote
 
 import nbformat
 import pexpect
@@ -73,6 +73,9 @@ async def execute(
         env: "Optional[Dict[str, str]]" = None,
     ) -> "Tuple[int, str, str]":
         try:
+            if not os.path.exists(cwd):
+                cwd = quote(cwd, safe=":/\\")
+
             p = pexpect.spawn(
                 cmdline[0],
                 cmdline[1:],
@@ -112,6 +115,9 @@ async def execute(
         cwd: "Optional[str]" = None,
         env: "Optional[Dict[str, str]]" = None,
     ) -> "Tuple[int, str, str]":
+        if not os.path.exists(cwd):
+            cwd = quote(cwd, safe=":/\\")
+
         process = subprocess.Popen(
             cmdline, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, env=env
         )


### PR DESCRIPTION
Fixes the case where a folder name is cloned with url-encoded spaces.

Closes #1211