### PR TITLE
fix switch from a detached head to a branch not working

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -264,7 +264,7 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
     if (this.props.model.pathRepository === null) {
       return null;
     }
-    if (this.props.model.currentBranch.detached) {
+    if (this.props.model.currentBranch?.detached) {
       branchTitle = 'Detached Head at';
     }
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -260,12 +260,12 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
    * @returns React element
    */
   private _renderBranchMenu(): React.ReactElement | null {
-    let branchTitle = 'Current Branch';
+    let branchTitle = this.props.trans.__('Current Branch');
     if (this.props.model.pathRepository === null) {
       return null;
     }
     if (this.props.model.currentBranch?.detached) {
-      branchTitle = 'Detached Head at';
+      branchTitle = this.props.trans.__('Detached Head at');
     }
 
     return (
@@ -280,9 +280,7 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
         >
           <branchIcon.react className={toolbarMenuButtonIconClass} />
           <div className={toolbarMenuButtonTitleWrapperClass}>
-            <p className={toolbarMenuButtonTitleClass}>
-              {this.props.trans.__(branchTitle)}
-            </p>
+            <p className={toolbarMenuButtonTitleClass}>{branchTitle}</p>
             <p className={toolbarMenuButtonSubtitleClass}>
               {this.props.currentBranch || ''}
             </p>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -260,9 +260,14 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
    * @returns React element
    */
   private _renderBranchMenu(): React.ReactElement | null {
+    let branchTitle = 'Current Branch';
     if (this.props.model.pathRepository === null) {
       return null;
     }
+    if (this.props.model.currentBranch.detached) {
+      branchTitle = 'Detached Head at';
+    }
+
     return (
       <div className={toolbarMenuWrapperClass}>
         <button
@@ -276,7 +281,7 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
           <branchIcon.react className={toolbarMenuButtonIconClass} />
           <div className={toolbarMenuButtonTitleWrapperClass}>
             <p className={toolbarMenuButtonTitleClass}>
-              {this.props.trans.__('Current Branch')}
+              {this.props.trans.__(branchTitle)}
             </p>
             <p className={toolbarMenuButtonSubtitleClass}>
               {this.props.currentBranch || ''}

--- a/src/model.ts
+++ b/src/model.ts
@@ -562,6 +562,13 @@ export class GitExtension implements IGitExtension {
         let changes;
         if (!body.new_check) {
           if (body.checkout_branch && !body.new_check) {
+            const detachedHeadRegex = /\(HEAD detached at (.+)\)/;
+            let result = this._currentBranch.name.match(detachedHeadRegex);
+
+            if (result && result.length > 1) {
+              this._currentBranch.name = result[1];
+            }
+
             changes = await this._changedFiles(
               this._currentBranch.name,
               body.branchname

--- a/src/model.ts
+++ b/src/model.ts
@@ -562,13 +562,6 @@ export class GitExtension implements IGitExtension {
         let changes;
         if (!body.new_check) {
           if (body.checkout_branch && !body.new_check) {
-            const detachedHeadRegex = /\(HEAD detached at (.+)\)/;
-            const result = this._currentBranch.name.match(detachedHeadRegex);
-
-            if (result && result.length > 1) {
-              this._currentBranch.name = result[1];
-            }
-
             changes = await this._changedFiles(
               this._currentBranch.name,
               body.branchname
@@ -1049,6 +1042,15 @@ export class GitExtension implements IGitExtension {
       );
 
       this._branches = data.branches ?? [];
+
+      const detachedHeadRegex = /\(HEAD detached at (.+)\)/;
+      const result = data.current_branch.name.match(detachedHeadRegex);
+
+      if (result && result.length > 1) {
+        data.current_branch.tag = result[1];
+        data.current_branch.name = result[1];
+      }
+      
       this._currentBranch = data.current_branch;
       if (this._currentBranch) {
         // Set up the marker obj for the current (valid) repo/branch combination

--- a/src/model.ts
+++ b/src/model.ts
@@ -1050,7 +1050,7 @@ export class GitExtension implements IGitExtension {
         data.current_branch.tag = result[1];
         data.current_branch.name = result[1];
       }
-      
+
       this._currentBranch = data.current_branch;
       if (this._currentBranch) {
         // Set up the marker obj for the current (valid) repo/branch combination

--- a/src/model.ts
+++ b/src/model.ts
@@ -1048,6 +1048,7 @@ export class GitExtension implements IGitExtension {
 
       if (result && result.length > 1) {
         data.current_branch.name = result[1];
+        data.current_branch.detached = true;
       }
 
       this._currentBranch = data.current_branch;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1047,7 +1047,6 @@ export class GitExtension implements IGitExtension {
       const result = data.current_branch.name.match(detachedHeadRegex);
 
       if (result && result.length > 1) {
-        data.current_branch.tag = result[1];
         data.current_branch.name = result[1];
       }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -563,7 +563,7 @@ export class GitExtension implements IGitExtension {
         if (!body.new_check) {
           if (body.checkout_branch && !body.new_check) {
             const detachedHeadRegex = /\(HEAD detached at (.+)\)/;
-            let result = this._currentBranch.name.match(detachedHeadRegex);
+            const result = this._currentBranch.name.match(detachedHeadRegex);
 
             if (result && result.length > 1) {
               this._currentBranch.name = result[1];

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -820,6 +820,7 @@ export namespace Git {
     upstream: string | null;
     top_commit: string;
     tag: string | null;
+    detached?: boolean;
   }
 
   /** Interface for GitBranch request result,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -28,7 +28,7 @@ export const defaultMockedResponses: {
       return {
         code: 0,
         branches: [],
-        current_branch: null
+        current_branch: { name: "" }
       };
     }
   },


### PR DESCRIPTION
Provides fix for #995 

If the repository is in detached head (for example after switching to a tag), then switching to a branch will no longer fail. Behaviour after changes:

https://user-images.githubusercontent.com/70033855/217340638-7ebe001e-f713-44dc-bcb4-65dc2c3bfced.mov

Transforms the fake branch name (HEAD detached at #####) to ##### using Regex.