### PR TITLE
bug: modified password placeholder text depending if remote URI is github (Fix #1176)

### DIFF
--- a/src/cloneCommand.ts
+++ b/src/cloneCommand.ts
@@ -79,6 +79,7 @@ export const gitCloneCommandPlugin: JupyterFrontEndPlugin<void> = {
               level: Level.ERROR,
               error: error as Error
             });
+            throw error;
           }
         }
       }

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1713,7 +1713,6 @@ export async function showGitOperationDialog<T>(
           });
           remoteGitProvider = checkUrlGitProvider(remoteList[0]?.url);
           break;
-        // executed if none of the cases were matched
         default:
           break;
       }

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -397,7 +397,6 @@ export function addCommands(
       try {
         // copy how gitPush grabs remote - this needs to be fixed as it creates a Git Push UI
         // is there a better way to grab the remoteName?
-        let remote;
         const result = await showDialog({
           title: trans.__('Please select push options.'),
           body: new AdvancedPushForm(trans, gitModel),
@@ -406,7 +405,7 @@ export function addCommands(
             Dialog.okButton({ label: trans.__('Proceed') })
           ]
         });
-        remote = result.value.remoteName;
+        const remote = result.value.remoteName;
 
         if (args.force) {
           await discardAllChanges(gitModel, trans, args.fallback as boolean);
@@ -1610,7 +1609,7 @@ export async function showGitOperationDialog<T>(
    */
   function checkUrlGitProvider(remoteUrl: string): string {
     // Regex returns the word between "https" and "."
-    const re = /https:\/\/([^\.]+)\./;
+    const re = /https:\/\/([^.]+)\./;
     const result = remoteUrl.match(re) ?? [];
     const gitProvider = result[1];
     return gitProvider;
@@ -1666,7 +1665,7 @@ export async function showGitOperationDialog<T>(
     ) {
       // Change the placeholder message for GitHub
       let gitPasswordPlaceholder = 'password / personal access token';
-      let remoteGitProvider: string;
+      let remoteGitProvider: string = '';
 
       switch (operation) {
         case Operation.Clone:

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1586,7 +1586,6 @@ export async function showGitOperationDialog<T>(
     if (currentRemote) {
       return currentRemote?.url;
     } else {
-      // if the current remote isn't inside, what is best to return? Could maybe throw an error?
       return '';
     }
   }
@@ -1668,8 +1667,8 @@ export async function showGitOperationDialog<T>(
           // If the remote is defined, check it against the remote URI list
           if (model.currentBranch.upstream) {
             // Compare the remote against the URI list
-            const remote = model.currentBranch.upstream.split('/')[0];
-            const currentRemoteUrl = await getCurrentRemote(remote);
+            const remoteName = model.currentBranch.upstream.split('/')[0];
+            const currentRemoteUrl = await getCurrentRemote(remoteName);
             remoteGitProvider = currentRemoteUrl
               ? getGitProviderHost(currentRemoteUrl)
               : '';

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -72,13 +72,6 @@ export interface IGitCloneArgs {
   submodules?: boolean;
 }
 
-// interface IGitPullArgs {
-//   remote?: string;
-//   name?: string;
-// }
-
-// interface IGitCloneOrPullArgs extends IGitCloneArgs, IGitPullArgs {}
-
 /**
  * Git operations requiring authentication
  */
@@ -1684,7 +1677,6 @@ export async function showGitOperationDialog<T>(
         case Operation.Push:
         case Operation.ForcePush:
         case Operation.Pull:
-          // Get the remote from the args
           const remote = (
             args as unknown as {
               remote: string;

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1665,7 +1665,7 @@ export async function showGitOperationDialog<T>(
     ) {
       // Change the placeholder message for GitHub
       let gitPasswordPlaceholder = 'password / personal access token';
-      let remoteGitProvider: string = '';
+      let remoteGitProvider = '';
 
       switch (operation) {
         case Operation.Clone:

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1620,13 +1620,28 @@ export async function showGitOperationDialog<T>(
         errorMessage => (error as Error).message.indexOf(errorMessage) > -1
       )
     ) {
+      const remoteURI = await model.getRemotes().then(remote => {
+        return remote;
+      });
+
+      // Determine the Git Provider
+      const re = /https:\/\/(.+)\.com/;
+      const result = remoteURI[0]?.url.match(re);
+      const gitProvider = result[1];
+
+      // Change the placeholder message for GitHub
+      let message = 'password / personal access token';
+      if (gitProvider === 'github') {
+        message = 'personal access token';
+      }
       // If the error is an authentication error, ask the user credentials
       const credentials = await showDialog({
         title: trans.__('Git credentials required'),
         body: new GitCredentialsForm(
           trans,
           trans.__('Enter credentials for remote repository'),
-          retry ? trans.__('Incorrect username or password.') : ''
+          retry ? trans.__('Incorrect username or password.') : '',
+          trans.__(message)
         )
       });
 

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1669,13 +1669,16 @@ export async function showGitOperationDialog<T>(
 
       switch (operation) {
         case Operation.Clone:
+          // eslint-disable-next-line no-case-declarations
           const { url: encodedArgsUrl } = args as any as IGitCloneArgs;
-          const argsUrl = decodeURIComponent(encodedArgsUrl);
-          remoteGitProvider = checkUrlGitProvider(argsUrl);
+          remoteGitProvider = checkUrlGitProvider(
+            decodeURIComponent(encodedArgsUrl)
+          );
           break;
         case Operation.Push:
         case Operation.ForcePush:
         case Operation.Pull:
+          // eslint-disable-next-line no-case-declarations
           const remote = (
             args as unknown as {
               remote: string;
@@ -1699,10 +1702,9 @@ export async function showGitOperationDialog<T>(
           break;
 
         case Operation.Fetch:
-          const remoteList = await model.getRemotes().then(remoteList => {
-            return remoteList;
-          });
-          remoteGitProvider = checkUrlGitProvider(remoteList[0]?.url);
+          remoteGitProvider = await model
+            .getRemotes()
+            .then(remoteList => remoteList[0]?.url);
           break;
         default:
           break;

--- a/src/git.ts
+++ b/src/git.ts
@@ -9,7 +9,8 @@ import { Git } from './tokens';
 export const AUTH_ERROR_MESSAGES = [
   'Invalid username or password',
   'could not read Username',
-  'could not read Password'
+  'could not read Password',
+  'Authentication error'
 ];
 
 /**

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -361,6 +361,12 @@ export interface IGitExtension extends IDisposable {
   getRelativeFilePath(path?: string): string | null;
 
   /**
+   * Show remote repository for the current repository
+   * @returns promise which resolves to a list of remote repositories
+   */
+  getRemotes(): Promise<Git.IGitRemote[]>;
+
+  /**
    * Add an entry in .gitignore file
    *
    * @param filename The name of the entry to ignore

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -10,7 +10,7 @@ export class GitCredentialsForm
   extends Widget
   implements Dialog.IBodyWidget<Git.IAuth>
 {
-  passwordPlaceholder: string;
+  private _passwordPlaceholder: string;
   constructor(
     trans: TranslationBundle,
     textContent = trans.__('Enter credentials for remote repository'),
@@ -19,7 +19,7 @@ export class GitCredentialsForm
   ) {
     super();
     this._trans = trans;
-    this.passwordPlaceholder = passwordPlaceholder;
+    this._passwordPlaceholder = passwordPlaceholder;
     this.node.appendChild(this.createBody(textContent, warningContent));
   }
 
@@ -44,7 +44,7 @@ export class GitCredentialsForm
     text.textContent = textContent;
     warning.textContent = warningContent;
     this._user.placeholder = this._trans.__('username');
-    this._password.placeholder = this._trans.__(this.passwordPlaceholder);
+    this._password.placeholder = this._trans.__(this._passwordPlaceholder);
 
     checkboxLabel.className = 'jp-CredentialsBox-label-checkbox';
     this._checkboxCacheCredentials.type = 'checkbox';

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -15,7 +15,7 @@ export class GitCredentialsForm
     trans: TranslationBundle,
     textContent = trans.__('Enter credentials for remote repository'),
     warningContent = '',
-    passwordPlaceholder = 'password / personal access token'
+    passwordPlaceholder = trans.__('password / personal access token')
   ) {
     super();
     this._trans = trans;
@@ -44,7 +44,7 @@ export class GitCredentialsForm
     text.textContent = textContent;
     warning.textContent = warningContent;
     this._user.placeholder = this._trans.__('username');
-    this._password.placeholder = this._trans.__(this._passwordPlaceholder);
+    this._password.placeholder = this._passwordPlaceholder;
 
     checkboxLabel.className = 'jp-CredentialsBox-label-checkbox';
     this._checkboxCacheCredentials.type = 'checkbox';

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -15,7 +15,7 @@ export class GitCredentialsForm
     trans: TranslationBundle,
     textContent = trans.__('Enter credentials for remote repository'),
     warningContent = '',
-    passwordPlaceholder: string = 'password / personal access token'
+    passwordPlaceholder = 'password / personal access token'
   ) {
     super();
     this._trans = trans;

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -10,13 +10,16 @@ export class GitCredentialsForm
   extends Widget
   implements Dialog.IBodyWidget<Git.IAuth>
 {
+  passwordPlaceholder: string;
   constructor(
     trans: TranslationBundle,
     textContent = trans.__('Enter credentials for remote repository'),
-    warningContent = ''
+    warningContent = '',
+    passwordPlaceholder: string = 'password / personal access token'
   ) {
     super();
     this._trans = trans;
+    this.passwordPlaceholder = passwordPlaceholder;
     this.node.appendChild(this.createBody(textContent, warningContent));
   }
 
@@ -41,7 +44,7 @@ export class GitCredentialsForm
     text.textContent = textContent;
     warning.textContent = warningContent;
     this._user.placeholder = this._trans.__('username');
-    this._password.placeholder = this._trans.__('personal access token');
+    this._password.placeholder = this._trans.__(this.passwordPlaceholder);
 
     checkboxLabel.className = 'jp-CredentialsBox-label-checkbox';
     this._checkboxCacheCredentials.type = 'checkbox';

--- a/src/widgets/CredentialsBox.tsx
+++ b/src/widgets/CredentialsBox.tsx
@@ -41,9 +41,7 @@ export class GitCredentialsForm
     text.textContent = textContent;
     warning.textContent = warningContent;
     this._user.placeholder = this._trans.__('username');
-    this._password.placeholder = this._trans.__(
-      'password / personal access token'
-    );
+    this._password.placeholder = this._trans.__('personal access token');
 
     checkboxLabel.className = 'jp-CredentialsBox-label-checkbox';
     this._checkboxCacheCredentials.type = 'checkbox';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5619,9 +5619,9 @@ htmlparser2@^8.0.1:
     entities "^4.3.0"
 
 http-cache-semantics@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
-  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
 http-errors@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This fixes #1176.

**Description of Changes**
- Check to see if the remote URI matches the GitHub expression
- Change the password placeholder text accordingly

**Git Push**


https://user-images.githubusercontent.com/94336773/219996988-e0dad60f-6e51-4e74-bfd3-6cfa22731d83.mov




**Git Clone**

https://user-images.githubusercontent.com/94336773/219996946-b3ecbd35-16a2-454e-b697-338f463d9555.mov


**Git Pull**

https://user-images.githubusercontent.com/94336773/220784704-a0246d05-3c29-48e2-a32c-a8a61d657980.mov




Collaborated with @basokant on this!