### PR TITLE
Switch back to using the Jupyter Releaser actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Populate Release
         id: populate-release
-        uses: fcollonval/jupyter_releaser/.github/actions/populate-release@ft/trusted-publish
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           branch: ${{ github.event.inputs.branch }}
@@ -33,7 +33,7 @@ jobs:
         id: finalize-release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        uses: fcollonval/jupyter_releaser/.github/actions/finalize-release@ft/trusted-publish
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           release_url: ${{ steps.populate-release.outputs.release_url }}


### PR DESCRIPTION
Using the trusted publisher workflow for PyPI and npm are now available in the releaser: https://github.com/jupyter-server/jupyter_releaser/pull/511