### PR TITLE
Add support for rebase

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -572,14 +572,14 @@ class Git:
         state = State.DEFAULT
         for state_, head in states.items():
             if isinstance(head, str):
-                code, _, _ = await execute(["git", "show", "--quiet", head], cwd=path)
+                code, _, _ = await self.__execute(["git", "show", "--quiet", head], cwd=path)
                 if code == 0:
                     state = state_
                     break
             else:
                 found = False
                 for directory in head:
-                    code, output, _ = await execute(["git", "rev-parse", "--git-path", directory], cwd=path)
+                    code, output, _ = await self.__execute(["git", "rev-parse", "--git-path", directory], cwd=path)
                     filepath = output.strip("\n\t ")
                     if code == 0 and (Path(path) / filepath).exists():
                         found = True

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -909,11 +909,12 @@ class GitRebaseHandler(GitHandler):
             body = await self.git.rebase(branch, self.url2localpath(path))
         else:
             try:
-                body = await self.git.resolve_rebase(self.url2localpath(path), RebaseAction[action.upper()])
+                body = await self.git.resolve_rebase(
+                    self.url2localpath(path), RebaseAction[action.upper()]
+                )
             except KeyError:
                 raise tornado.web.HTTPError(
-                    status_code=404,
-                    reason=f"Unknown action '{action}'"
+                    status_code=404, reason=f"Unknown action '{action}'"
                 )
 
         if body["code"] != 0:

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -892,6 +892,25 @@ class GitTagCheckoutHandler(GitHandler):
         self.finish(json.dumps(result))
 
 
+class GitRebaseHandler(GitHandler):
+    """
+    Handler for git rebase '<rebase_onto>'.
+    """
+
+    @tornado.web.authenticated
+    async def post(self, path: str = ""):
+        """
+        POST request handler, rebase the current branch
+        """
+        data = self.get_json_body()
+        branch = data["branch"]
+        body = await self.git.rebase(branch, self.url2localpath(path))
+
+        if body["code"] != 0:
+            self.set_status(500)
+        self.finish(json.dumps(body))
+
+
 class GitStashHandler(GitHandler):
     """
     Handler for 'git stash'. Stores the changes in the current branch
@@ -1037,6 +1056,7 @@ def setup_handlers(web_app):
         ("/tags", GitTagHandler),
         ("/tag_checkout", GitTagCheckoutHandler),
         ("/add", GitAddHandler),
+        ("/rebase", GitRebaseHandler),
         ("/stash", GitStashHandler),
         ("/stash_pop", GitStashPopHandler),
         ("/stash_apply", GitStashApplyHandler),

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -984,7 +984,7 @@ async def test_branch_success_rebasing():
         # Given
         process_output_heads = [
             "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t ",
-            "feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/feature-foo\t "
+            "feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/feature-foo\t ",
         ]
         process_output_remotes = [
             "origin/feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123"

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -457,7 +457,7 @@ async def test_get_current_branch_detached_failure():
         )
         assert (
             "Error [fatal: Not a git repository (or any of the parent directories): .git] "
-            "occurred while executing [git branch -a] command to get detached HEAD name."
+            "occurred while executing [git branch -a] command to get current state."
             == str(error.value)
         )
 
@@ -891,7 +891,7 @@ async def test_branch_success_detached_head():
                 {
                     "is_current_branch": True,
                     "is_remote_branch": False,
-                    "name": "(HEAD detached at origin/feature-foo)",
+                    "name": "origin/feature-foo",
                     "upstream": None,
                     "top_commit": None,
                     "tag": None,
@@ -983,7 +983,7 @@ async def test_branch_success_rebasing():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         process_output_heads = [
-            "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t "
+            "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t ",
             "feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/feature-foo\t "
         ]
         process_output_remotes = [
@@ -1019,19 +1019,19 @@ async def test_branch_success_rebasing():
                     "tag": None,
                 },
                 {
-                    "is_current_branch": True,
-                    "is_remote_branch": False,
-                    "name": "(no branch, rebasing feature-foo)",
-                    "upstream": None,
-                    "top_commit": None,
-                    "tag": None,
-                },
-                {
                     "is_current_branch": False,
                     "is_remote_branch": False,
                     "name": "feature-foo",
                     "upstream": "origin/feature-foo",
                     "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                    "tag": None,
+                },
+                {
+                    "is_current_branch": True,
+                    "is_remote_branch": False,
+                    "name": "feature-foo",
+                    "upstream": None,
+                    "top_commit": None,
                     "tag": None,
                 },
                 {

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -908,7 +908,145 @@ async def test_branch_success_detached_head():
             "current_branch": {
                 "is_current_branch": True,
                 "is_remote_branch": False,
-                "name": "(HEAD detached at origin/feature-foo)",
+                "name": "origin/feature-foo",
+                "upstream": None,
+                "top_commit": None,
+                "tag": None,
+            },
+        }
+
+        # When
+        actual_response = await Git().branch(path=str(Path("/bin/test_curr_path")))
+
+        # Then
+        mock_execute.assert_has_calls(
+            [
+                # call to get refs/heads
+                call(
+                    [
+                        "git",
+                        "for-each-ref",
+                        "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)",
+                        "refs/heads/",
+                    ],
+                    cwd=str(Path("/bin") / "test_curr_path"),
+                    timeout=20,
+                    env=None,
+                    username=None,
+                    password=None,
+                    is_binary=False,
+                ),
+                # call to get current branch
+                call(
+                    ["git", "symbolic-ref", "--short", "HEAD"],
+                    cwd=str(Path("/bin") / "test_curr_path"),
+                    timeout=20,
+                    env=None,
+                    username=None,
+                    password=None,
+                    is_binary=False,
+                ),
+                # call to get current branch name given a detached head
+                call(
+                    ["git", "branch", "-a"],
+                    cwd=str(Path("/bin") / "test_curr_path"),
+                    timeout=20,
+                    env=None,
+                    username=None,
+                    password=None,
+                    is_binary=False,
+                ),
+                # call to get refs/remotes
+                call(
+                    [
+                        "git",
+                        "for-each-ref",
+                        "--format=%(refname:short)%09%(objectname)",
+                        "refs/remotes/",
+                    ],
+                    cwd=str(Path("/bin") / "test_curr_path"),
+                    timeout=20,
+                    env=None,
+                    username=None,
+                    password=None,
+                    is_binary=False,
+                ),
+            ],
+            any_order=False,
+        )
+
+        assert expected_response == actual_response
+
+
+@pytest.mark.asyncio
+async def test_branch_success_rebasing():
+    with patch("jupyterlab_git.git.execute") as mock_execute:
+        # Given
+        process_output_heads = [
+            "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t "
+            "feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/feature-foo\t "
+        ]
+        process_output_remotes = [
+            "origin/feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123"
+        ]
+        detached_head_output = [
+            "* (no branch, rebasing feature-foo)",
+            "  main",
+            "  feature-foo",
+            "  remotes/origin/feature-foo",
+        ]
+
+        mock_execute.side_effect = [
+            # Response for get all refs/heads
+            maybe_future((0, "\n".join(process_output_heads), "")),
+            # Response for get current branch
+            maybe_future((128, "", "fatal: ref HEAD is not a symbolic ref")),
+            # Response for get current branch detached
+            maybe_future((0, "\n".join(detached_head_output), "")),
+            # Response for get all refs/remotes
+            maybe_future((0, "\n".join(process_output_remotes), "")),
+        ]
+
+        expected_response = {
+            "code": 0,
+            "branches": [
+                {
+                    "is_current_branch": False,
+                    "is_remote_branch": False,
+                    "name": "main",
+                    "upstream": "origin/main",
+                    "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                    "tag": None,
+                },
+                {
+                    "is_current_branch": True,
+                    "is_remote_branch": False,
+                    "name": "(no branch, rebasing feature-foo)",
+                    "upstream": None,
+                    "top_commit": None,
+                    "tag": None,
+                },
+                {
+                    "is_current_branch": False,
+                    "is_remote_branch": False,
+                    "name": "feature-foo",
+                    "upstream": "origin/feature-foo",
+                    "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                    "tag": None,
+                },
+                {
+                    "is_current_branch": False,
+                    "is_remote_branch": True,
+                    "name": "origin/feature-foo",
+                    "upstream": None,
+                    "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                    "tag": None,
+                },
+            ],
+            "current_branch": {
+                "is_current_branch": True,
+                "is_remote_branch": False,
+                "name": "feature-foo",
                 "upstream": None,
                 "top_commit": None,
                 "tag": None,

--- a/jupyterlab_git/tests/test_status.py
+++ b/jupyterlab_git/tests/test_status.py
@@ -33,6 +33,7 @@ from .testutils import maybe_future
                 "remote": None,
                 "ahead": 0,
                 "behind": 0,
+                "state": "DEFAULT",
                 "files": [
                     {
                         "x": "A",
@@ -82,6 +83,7 @@ from .testutils import maybe_future
                 "remote": None,
                 "ahead": 0,
                 "behind": 0,
+                "state": "DEFAULT",
                 "files": [],
             },
         ),
@@ -95,6 +97,7 @@ from .testutils import maybe_future
                 "remote": "origin/main",
                 "ahead": 0,
                 "behind": 0,
+                "state": "DEFAULT",
                 "files": [],
             },
         ),
@@ -108,6 +111,7 @@ from .testutils import maybe_future
                 "remote": "origin/main",
                 "ahead": 15,
                 "behind": 0,
+                "state": "DEFAULT",
                 "files": [],
             },
         ),
@@ -121,6 +125,7 @@ from .testutils import maybe_future
                 "remote": "origin/main",
                 "ahead": 0,
                 "behind": 5,
+                "state": "DEFAULT",
                 "files": [],
             },
         ),
@@ -134,6 +139,7 @@ from .testutils import maybe_future
                 "remote": "origin/main",
                 "ahead": 3,
                 "behind": 5,
+                "state": "DEFAULT",
                 "files": [],
             },
         ),
@@ -147,6 +153,7 @@ from .testutils import maybe_future
                 "remote": None,
                 "ahead": 0,
                 "behind": 0,
+                "state": "DEFAULT",
                 "files": [],
             },
         ),
@@ -160,7 +167,182 @@ from .testutils import maybe_future
                 "remote": None,
                 "ahead": 0,
                 "behind": 0,
+                "state": "DETACHED",
                 "files": [],
+            },
+        ),
+        # Cherry pick
+        (
+            (
+                "## master",
+                "UD another_file.txt",
+                "A  branch_file.py",
+                "UU example.ipynb",
+                "UU file.txt",
+            ),
+            (
+                "1\t0\t.gitignore",
+                "0\t0\tanother_file.txt",
+                "21\t0\tbranch_file.py",
+                "0\t0\texample.ipynb",
+                "0\t0\tfile.txt",
+                "-\t-\tgit_workflow.jpg",
+                "-\t-\tjupyter.png",
+                "16\t0\tmaster_file.ts",
+            ),
+            {
+                "code": 0,
+                "branch": "master",
+                "remote": None,
+                "ahead": 0,
+                "behind": 0,
+                "files": [
+                    {
+                        "x": "U",
+                        "y": "D",
+                        "to": "another_file.txt",
+                        "from": "another_file.txt",
+                        "is_binary": False,
+                    },
+                    {
+                        "x": "A",
+                        "y": " ",
+                        "to": "branch_file.py",
+                        "from": "branch_file.py",
+                        "is_binary": False,
+                    },
+                    {
+                        "x": "U",
+                        "y": "U",
+                        "to": "example.ipynb",
+                        "from": "example.ipynb",
+                        "is_binary": False,
+                    },
+                    {
+                        "x": "U",
+                        "y": "U",
+                        "to": "file.txt",
+                        "from": "file.txt",
+                        "is_binary": False,
+                    },
+                ],
+                "state": "CHERRY_PICKING",
+            },
+        ),
+        # Rebasing
+        (
+            (
+                "## master",
+                "UD another_file.txt",
+                "A  branch_file.py",
+                "UU example.ipynb",
+                "UU file.txt",
+            ),
+            (
+                "1\t0\t.gitignore",
+                "0\t0\tanother_file.txt",
+                "21\t0\tbranch_file.py",
+                "0\t0\texample.ipynb",
+                "0\t0\tfile.txt",
+                "-\t-\tgit_workflow.jpg",
+                "-\t-\tjupyter.png",
+                "16\t0\tmaster_file.ts",
+            ),
+            {
+                "code": 0,
+                "branch": "master",
+                "remote": None,
+                "ahead": 0,
+                "behind": 0,
+                "files": [
+                    {
+                        "x": "U",
+                        "y": "D",
+                        "to": "another_file.txt",
+                        "from": "another_file.txt",
+                        "is_binary": False,
+                    },
+                    {
+                        "x": "A",
+                        "y": " ",
+                        "to": "branch_file.py",
+                        "from": "branch_file.py",
+                        "is_binary": False,
+                    },
+                    {
+                        "x": "U",
+                        "y": "U",
+                        "to": "example.ipynb",
+                        "from": "example.ipynb",
+                        "is_binary": False,
+                    },
+                    {
+                        "x": "U",
+                        "y": "U",
+                        "to": "file.txt",
+                        "from": "file.txt",
+                        "is_binary": False,
+                    },
+                ],
+                "state": "REBASING",
+            },
+        ),
+        # Merging
+        (
+            (
+                "## master",
+                "UD another_file.txt",
+                "A  branch_file.py",
+                "UU example.ipynb",
+                "UU file.txt",
+            ),
+            (
+                "1\t0\t.gitignore",
+                "0\t0\tanother_file.txt",
+                "21\t0\tbranch_file.py",
+                "0\t0\texample.ipynb",
+                "0\t0\tfile.txt",
+                "-\t-\tgit_workflow.jpg",
+                "-\t-\tjupyter.png",
+                "16\t0\tmaster_file.ts",
+            ),
+            {
+                "code": 0,
+                "branch": "master",
+                "remote": None,
+                "ahead": 0,
+                "behind": 0,
+                "files": [
+                    {
+                        "x": "U",
+                        "y": "D",
+                        "to": "another_file.txt",
+                        "from": "another_file.txt",
+                        "is_binary": False,
+                    },
+                    {
+                        "x": "A",
+                        "y": " ",
+                        "to": "branch_file.py",
+                        "from": "branch_file.py",
+                        "is_binary": False,
+                    },
+                    {
+                        "x": "U",
+                        "y": "U",
+                        "to": "example.ipynb",
+                        "from": "example.ipynb",
+                        "is_binary": False,
+                    },
+                    {
+                        "x": "U",
+                        "y": "U",
+                        "to": "file.txt",
+                        "from": "file.txt",
+                        "is_binary": False,
+                    },
+                ],
+                "state": "MERGING",
             },
         ),
     ],
@@ -172,40 +354,77 @@ async def test_status(output, diff_output, expected):
         mock_execute.side_effect = [
             maybe_future((0, "\x00".join(output) + "\x00", "")),
             maybe_future((0, "\x00".join(diff_output) + "\x00", "")),
+            maybe_future(
+                (0 if expected["state"] == "CHERRY_PICKING" else 128, "", "cherry pick")
+            ),
+            maybe_future((0 if expected["state"] == "MERGING" else 128, "", "merge")),
+            maybe_future((0 if expected["state"] == "REBASING" else 128, "", "rebase")),
         ]
 
         # When
         actual_response = await Git().status(path=repository)
 
         # Then
-        mock_execute.assert_has_calls(
-            [
-                call(
-                    ["git", "status", "--porcelain", "-b", "-u", "-z"],
-                    cwd=repository,
-                    timeout=20,
-                    env=None,
-                    username=None,
-                    password=None,
-                    is_binary=False,
-                ),
-                call(
-                    [
-                        "git",
-                        "diff",
-                        "--numstat",
-                        "-z",
-                        "--cached",
-                        "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
-                    ],
-                    cwd=repository,
-                    timeout=20,
-                    env=None,
-                    username=None,
-                    password=None,
-                    is_binary=False,
-                ),
-            ]
-        )
+        expected_calls = [
+            call(
+                ["git", "status", "--porcelain", "-b", "-u", "-z"],
+                cwd=repository,
+                timeout=20,
+                env=None,
+                username=None,
+                password=None,
+                is_binary=False,
+            ),
+            call(
+                [
+                    "git",
+                    "diff",
+                    "--numstat",
+                    "-z",
+                    "--cached",
+                    "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+                ],
+                cwd=repository,
+                timeout=20,
+                env=None,
+                username=None,
+                password=None,
+                is_binary=False,
+            ),
+            call(
+                ["git", "show", "--quiet", "CHERRY_PICK_HEAD"],
+                cwd=repository,
+                timeout=20,
+                env=None,
+                username=None,
+                password=None,
+                is_binary=False,
+            ),
+            call(
+                ["git", "show", "--quiet", "MERGE_HEAD"],
+                cwd=repository,
+                timeout=20,
+                env=None,
+                username=None,
+                password=None,
+                is_binary=False,
+            ),
+            call(
+                ["git", "show", "--quiet", "REBASE_HEAD"],
+                cwd=repository,
+                timeout=20,
+                env=None,
+                username=None,
+                password=None,
+                is_binary=False,
+            ),
+        ]
+
+        if expected["state"] == "CHERRY_PICKING":
+            expected_calls = expected_calls[:-2]
+        elif expected["state"] == "MERGING":
+            expected_calls = expected_calls[:-1]
+
+        mock_execute.assert_has_calls(expected_calls)
 
         assert expected == actual_response

--- a/jupyterlab_git/tests/test_status.py
+++ b/jupyterlab_git/tests/test_status.py
@@ -356,12 +356,14 @@ async def test_status(tmp_path, output, diff_output, expected):
         mock_execute.side_effect = [
             maybe_future((0, "\x00".join(output) + "\x00", "")),
             maybe_future((0, "\x00".join(diff_output) + "\x00", "")),
-            maybe_future(
-                (0 if expected["state"] == 4 else 128, "", "cherry pick")
-            ),
+            maybe_future((0 if expected["state"] == 4 else 128, "", "cherry pick")),
             maybe_future((0 if expected["state"] == 2 else 128, "", "merge")),
-            maybe_future((0 if expected["state"] == 3 else 128, ".git/rebase-merge", "rebase")),
-            maybe_future((0 if expected["state"] == 3 else 128, ".git/rebase-apply", "rebase")),
+            maybe_future(
+                (0 if expected["state"] == 3 else 128, ".git/rebase-merge", "rebase")
+            ),
+            maybe_future(
+                (0 if expected["state"] == 3 else 128, ".git/rebase-apply", "rebase")
+            ),
         ]
 
         # When

--- a/src/__tests__/test-components/GitPanel.spec.tsx
+++ b/src/__tests__/test-components/GitPanel.spec.tsx
@@ -237,6 +237,7 @@ describe('GitPanel', () => {
       } as any;
       props.model = {
         branches: [],
+        status: {},
         stashChanged: {
           connect: jest.fn()
         },

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -940,8 +940,7 @@ export function addCommands(
         });
       }
     },
-    isEnabled: () =>
-      gitModel.status.state === Git.State.REBASING
+    isEnabled: () => gitModel.status.state === Git.State.REBASING
   });
 
   commands.addCommand(CommandIDs.gitStash, {

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1,6 +1,8 @@
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import {
-  Dialog, InputDialog, MainAreaWidget,
+  Dialog,
+  InputDialog,
+  MainAreaWidget,
   ReactWidget,
   showDialog,
   showErrorMessage,
@@ -853,7 +855,7 @@ export function addCommands(
       gitModel.branches.some(
         branch => !branch.is_current_branch && !branch.is_remote_branch
       )
-  })
+  });
 
   commands.addCommand(CommandIDs.gitStash, {
     label: trans.__('Stash Changes'),

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -858,38 +858,46 @@ export function addCommands(
   });
 
   commands.addCommand(CommandIDs.gitResolveRebase, {
-    label: (args = {}) => {switch((args.action)) {
-      case 'continue':
-        return trans.__('Continue rebase')
-      case 'skip':
-        return trans.__('Skip current commit')
-      case 'abort':
-        return trans.__('Abort rebase')
-      default:
-        return trans.__('Resolve rebase')
-    }},
-    caption:(args = {}) => {switch((args.action)) {
-      case 'continue':
-        return trans.__('Continue the rebase by committing the current state.')
-      case 'skip':
-        return trans.__('Skip current commit and continue the rebase.')
-      case 'abort':
-        return trans.__('Abort the rebase')
-      default:
-        return trans.__('Resolve rebase')
-    }},
+    label: (args = {}) => {
+      switch (args.action) {
+        case 'continue':
+          return trans.__('Continue rebase');
+        case 'skip':
+          return trans.__('Skip current commit');
+        case 'abort':
+          return trans.__('Abort rebase');
+        default:
+          return trans.__('Resolve rebase');
+      }
+    },
+    caption: (args = {}) => {
+      switch (args.action) {
+        case 'continue':
+          return trans.__(
+            'Continue the rebase by committing the current state.'
+          );
+        case 'skip':
+          return trans.__('Skip current commit and continue the rebase.');
+        case 'abort':
+          return trans.__('Abort the rebase');
+        default:
+          return trans.__('Resolve rebase');
+      }
+    },
     execute: async (args: { action?: string } = {}) => {
       const { action } = args;
 
       if (['continue', 'abort', 'skip'].includes(action)) {
-        const message = ((action) => {switch((action)) {
-          case 'continue':
-            return trans.__('Continue the rebase…')
-          case 'skip':
-            return trans.__('Skip current commit…')
-          case 'abort':
-            return trans.__('Abort the rebase…')
-        }})(action)
+        const message = (action => {
+          switch (action) {
+            case 'continue':
+              return trans.__('Continue the rebase…');
+            case 'skip':
+              return trans.__('Skip current commit…');
+            case 'abort':
+              return trans.__('Abort the rebase…');
+          }
+        })(action);
 
         logger.log({
           level: Level.RUNNING,
@@ -898,14 +906,16 @@ export function addCommands(
         try {
           await gitModel.resolveRebase(action as any);
         } catch (err) {
-          const message = ((action) => {switch((action)) {
-            case 'continue':
-              return trans.__('Fail to continue rebasing.')
-            case 'skip':
-              return trans.__('Fail to skip current commit when rebasing.')
-            case 'abort':
-              return trans.__('Fail to abort the rebase.')
-          }})(action)
+          const message = (action => {
+            switch (action) {
+              case 'continue':
+                return trans.__('Fail to continue rebasing.');
+              case 'skip':
+                return trans.__('Fail to skip current commit when rebasing.');
+              case 'abort':
+                return trans.__('Fail to abort the rebase.');
+            }
+          })(action);
           logger.log({
             level: Level.ERROR,
             message,
@@ -914,14 +924,16 @@ export function addCommands(
           return;
         }
 
-        const message_ = ((action) => {switch((action)) {
-          case 'continue':
-            return trans.__('Commit submitted continuing rebase.')
-          case 'skip':
-            return trans.__('Current commit skipped.')
-          case 'abort':
-            return trans.__('Rebase aborted.')
-        }})(action)
+        const message_ = (action => {
+          switch (action) {
+            case 'continue':
+              return trans.__('Commit submitted continuing rebase.');
+            case 'skip':
+              return trans.__('Current commit skipped.');
+            case 'abort':
+              return trans.__('Rebase aborted.');
+          }
+        })(action);
         logger.log({
           level: Level.SUCCESS,
           message: message_
@@ -932,7 +944,7 @@ export function addCommands(
       gitModel.branches.some(
         branch => !branch.is_current_branch && !branch.is_remote_branch
       )
-  })
+  });
 
   commands.addCommand(CommandIDs.gitStash, {
     label: trans.__('Stash Changes'),

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -941,9 +941,7 @@ export function addCommands(
       }
     },
     isEnabled: () =>
-      gitModel.branches.some(
-        branch => !branch.is_current_branch && !branch.is_remote_branch
-      )
+      gitModel.status.state === Git.State.REBASING
   });
 
   commands.addCommand(CommandIDs.gitStash, {

--- a/src/components/BranchMenu.tsx
+++ b/src/components/BranchMenu.tsx
@@ -230,9 +230,16 @@ export class BranchMenu extends React.Component<
   private _renderBranchList(): React.ReactElement {
     // Perform a "simple" filter... (TODO: consider implementing fuzzy filtering)
     const filter = this.state.filter;
-    const branches = this.props.branches.filter(
-      branch => !filter || branch.name.includes(filter)
-    );
+    const branches = this.props.branches.filter(branch => {
+      // Don't include "current branch" is the repository is not in default state
+      if (
+        this.props.model.status.state !== Git.State.DEFAULT &&
+        branch.is_current_branch
+      ) {
+        return false;
+      }
+      return !filter || branch.name.includes(filter);
+    });
     return (
       <FixedSizeList
         height={Math.min(
@@ -260,7 +267,7 @@ export class BranchMenu extends React.Component<
   private _renderItem = (props: ListChildComponentProps): JSX.Element => {
     const { data, index, style } = props;
     const branch = data[index] as Git.IBranch;
-    const isActive = branch.name === this.props.currentBranch;
+    const isActive = branch.is_current_branch;
     return (
       <ListItem
         button

--- a/src/components/BranchPicker.tsx
+++ b/src/components/BranchPicker.tsx
@@ -34,9 +34,14 @@ const ITEM_HEIGHT = 27.5; // HTML element height for a single branch
 const HEIGHT = 200; // HTML element height for the branches list
 
 /**
- * MergeBranchDialog component properties
+ * BranchPicker component properties
  */
-export interface IMergeBranchDialogProps {
+export interface IBranchPickerProps {
+  /**
+   * Action for which to pick a branch
+   */
+  action?: 'merge' | 'rebase'
+
   /**
    * Current branch name.
    */
@@ -59,12 +64,12 @@ export interface IMergeBranchDialogProps {
 }
 
 /**
- * MergeBranchDialog React component
+ * BranchPicker React component
  *
  * @param props Component properties
  * @returns React element
  */
-export function MergeBranchDialog(props: IMergeBranchDialogProps): JSX.Element {
+export function BranchPicker(props: IBranchPickerProps): JSX.Element {
   const [filter, setFilter] = React.useState<string>('');
   const [selectedBranch, setSelectedBranch] = React.useState<string | null>(
     null
@@ -74,7 +79,8 @@ export function MergeBranchDialog(props: IMergeBranchDialogProps): JSX.Element {
     branch => !filter || branch.name.includes(filter)
   );
 
-  const { trans } = props;
+  const { action, trans } = props;
+  const act = action ?? 'merge';
 
   function renderItem(props: ListChildComponentProps): JSX.Element {
     const { data, index, style } = props;
@@ -84,7 +90,7 @@ export function MergeBranchDialog(props: IMergeBranchDialogProps): JSX.Element {
     return (
       <ListItem
         button
-        title={trans.__('Create a new branch based on: %1', branch.name)}
+        title={act === 'merge' ? trans.__('Merge branch %1', branch.name) : trans.__('Rebase branch %1', branch.name)}
         className={classes(
           listItemClass,
           isSelected ? activeListItemClass : null
@@ -111,7 +117,7 @@ export function MergeBranchDialog(props: IMergeBranchDialogProps): JSX.Element {
       onClose={props.onClose}
     >
       <div className={titleWrapperClass}>
-        <p className={titleClass}>{trans.__('Merge Branch')}</p>
+        <p className={titleClass}>{act === 'merge' ? trans.__('Merge Branch') : trans.__('Rebase Branch')}</p>
         <button className={closeButtonClass}>
           <ClearIcon
             titleAccess={trans.__('Close this dialog')}
@@ -124,7 +130,7 @@ export function MergeBranchDialog(props: IMergeBranchDialogProps): JSX.Element {
       </div>
       <div className={contentWrapperClass}>
         <p>
-          {trans.__('Select the branch to merge in %1', props.currentBranch)}
+          {act === 'merge' ? trans.__('Select the branch to merge in %1', props.currentBranch) : trans.__('Select the branch to rebase %1 onto', props.currentBranch)}
         </p>
         <div className={filterWrapperClass}>
           <div className={filterClass}>
@@ -169,7 +175,7 @@ export function MergeBranchDialog(props: IMergeBranchDialogProps): JSX.Element {
         <input
           className={classes(buttonClass, cancelButtonClass)}
           type="button"
-          title={trans.__('Close this dialog without merging a branch')}
+          title={act === 'merge' ? trans.__('Close this dialog without merging a branch') : trans.__('Close this dialog without rebasing the branch')}
           value={trans.__('Cancel')}
           onClick={() => {
             props.onClose();
@@ -178,8 +184,8 @@ export function MergeBranchDialog(props: IMergeBranchDialogProps): JSX.Element {
         <input
           className={classes(buttonClass, createButtonClass)}
           type="button"
-          title={trans.__('Merge branch')}
-          value={trans.__('Merge')}
+          title={act === 'merge' ? trans.__('Merge branch') : trans.__('Rebase branch')}
+          value={act === 'merge' ? trans.__('Merge') : trans.__('Rebase')}
           onClick={() => {
             props.onClose(selectedBranch);
           }}

--- a/src/components/BranchPicker.tsx
+++ b/src/components/BranchPicker.tsx
@@ -40,7 +40,7 @@ export interface IBranchPickerProps {
   /**
    * Action for which to pick a branch
    */
-  action?: 'merge' | 'rebase'
+  action?: 'merge' | 'rebase';
 
   /**
    * Current branch name.
@@ -90,7 +90,11 @@ export function BranchPicker(props: IBranchPickerProps): JSX.Element {
     return (
       <ListItem
         button
-        title={act === 'merge' ? trans.__('Merge branch %1', branch.name) : trans.__('Rebase branch %1', branch.name)}
+        title={
+          act === 'merge'
+            ? trans.__('Merge branch %1', branch.name)
+            : trans.__('Rebase branch %1', branch.name)
+        }
         className={classes(
           listItemClass,
           isSelected ? activeListItemClass : null
@@ -117,7 +121,11 @@ export function BranchPicker(props: IBranchPickerProps): JSX.Element {
       onClose={props.onClose}
     >
       <div className={titleWrapperClass}>
-        <p className={titleClass}>{act === 'merge' ? trans.__('Merge Branch') : trans.__('Rebase Branch')}</p>
+        <p className={titleClass}>
+          {act === 'merge'
+            ? trans.__('Merge Branch')
+            : trans.__('Rebase Branch')}
+        </p>
         <button className={closeButtonClass}>
           <ClearIcon
             titleAccess={trans.__('Close this dialog')}
@@ -130,7 +138,12 @@ export function BranchPicker(props: IBranchPickerProps): JSX.Element {
       </div>
       <div className={contentWrapperClass}>
         <p>
-          {act === 'merge' ? trans.__('Select the branch to merge in %1', props.currentBranch) : trans.__('Select the branch to rebase %1 onto', props.currentBranch)}
+          {act === 'merge'
+            ? trans.__('Select the branch to merge in %1', props.currentBranch)
+            : trans.__(
+                'Select the branch to rebase %1 onto',
+                props.currentBranch
+              )}
         </p>
         <div className={filterWrapperClass}>
           <div className={filterClass}>
@@ -175,7 +188,11 @@ export function BranchPicker(props: IBranchPickerProps): JSX.Element {
         <input
           className={classes(buttonClass, cancelButtonClass)}
           type="button"
-          title={act === 'merge' ? trans.__('Close this dialog without merging a branch') : trans.__('Close this dialog without rebasing the branch')}
+          title={
+            act === 'merge'
+              ? trans.__('Close this dialog without merging a branch')
+              : trans.__('Close this dialog without rebasing the branch')
+          }
           value={trans.__('Cancel')}
           onClick={() => {
             props.onClose();
@@ -184,7 +201,11 @@ export function BranchPicker(props: IBranchPickerProps): JSX.Element {
         <input
           className={classes(buttonClass, createButtonClass)}
           type="button"
-          title={act === 'merge' ? trans.__('Merge branch') : trans.__('Rebase branch')}
+          title={
+            act === 'merge'
+              ? trans.__('Merge branch')
+              : trans.__('Rebase branch')
+          }
           value={act === 'merge' ? trans.__('Merge') : trans.__('Rebase')}
           onClick={() => {
             props.onClose(selectedBranch);

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -558,10 +558,10 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           />
         ) : (
           <RebaseAction
+            commands={this.props.commands}
             hasConflict={this.state.files.some(
               file => file.status === 'unmerged'
             )}
-            model={this.props.model}
             trans={this.props.trans}
           ></RebaseAction>
         )}

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -34,6 +34,7 @@ import { GitStash } from './GitStash';
 import { ActionButton } from './ActionButton';
 import { addIcon, rewindIcon, trashIcon } from '../style/icons';
 import { hiddenButtonStyle } from '../style/ActionButtonStyle';
+import { RebaseAction } from './RebaseAction';
 
 /**
  * Interface describing component properties.
@@ -528,30 +529,42 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           trans={this.props.trans}
         />
 
-        <CommitBox
-          commands={this.props.commands}
-          hasFiles={
-            inSimpleMode ? this._markedFiles.length > 0 : this._hasStagedFile()
-          }
-          trans={this.props.trans}
-          label={buttonLabel}
-          summary={this.state.commitSummary}
-          description={this.state.commitDescription}
-          amend={this.state.commitAmend}
-          setSummary={this._setCommitSummary}
-          setDescription={this._setCommitDescription}
-          setAmend={this._setCommitAmend}
-          onCommit={this.commitFiles}
-          warning={
-            this.state.hasDirtyFiles && (
-              <WarningBox
-                headerIcon={<WarningRoundedIcon />}
-                title={warningTitle}
-                content={warningContent}
-              />
-            )
-          }
-        />
+        {this.props.model.status.state !== Git.State.REBASING ? (
+          <CommitBox
+            commands={this.props.commands}
+            hasFiles={
+              inSimpleMode
+                ? this._markedFiles.length > 0
+                : this._hasStagedFile()
+            }
+            trans={this.props.trans}
+            label={buttonLabel}
+            summary={this.state.commitSummary}
+            description={this.state.commitDescription}
+            amend={this.state.commitAmend}
+            setSummary={this._setCommitSummary}
+            setDescription={this._setCommitDescription}
+            setAmend={this._setCommitAmend}
+            onCommit={this.commitFiles}
+            warning={
+              this.state.hasDirtyFiles && (
+                <WarningBox
+                  headerIcon={<WarningRoundedIcon />}
+                  title={warningTitle}
+                  content={warningContent}
+                />
+              )
+            }
+          />
+        ) : (
+          <RebaseAction
+            hasConflict={this.state.files.some(
+              file => file.status === 'unmerged'
+            )}
+            model={this.props.model}
+            trans={this.props.trans}
+          ></RebaseAction>
+        )}
       </React.Fragment>
     );
   }

--- a/src/components/GitStash.tsx
+++ b/src/components/GitStash.tsx
@@ -18,10 +18,12 @@ import {
   sectionButtonContainerStyle,
   sectionHeaderLabelStyle,
   stashFileStyle,
-  stashEntryMessageStyle
+  stashEntryMessageStyle,
+  stashContainerStyle
 } from '../style/GitStashStyle';
 import { FilePath } from './FilePath';
 import { stopPropagationWrapper } from '../utils';
+import { classes } from 'typestyle';
 
 const HEADER_HEIGHT = 34;
 const ITEM_HEIGHT = 25;
@@ -215,7 +217,7 @@ export const GitStash: React.FunctionComponent<IGitStashProps> = (
   );
 
   return (
-    <div className={sectionFileContainerStyle}>
+    <div className={classes(sectionFileContainerStyle, stashContainerStyle)}>
       <div
         className={sectionAreaStyle}
         onClick={() => {

--- a/src/components/RebaseAction.tsx
+++ b/src/components/RebaseAction.tsx
@@ -1,5 +1,6 @@
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 import { TranslationBundle } from '@jupyterlab/translation';
+import { CommandRegistry } from '@lumino/commands';
 import {
   Button,
   ButtonGroup,
@@ -19,7 +20,8 @@ import {
   disabledStyle
 } from '../style/CommitBox';
 import { verticalMoreIcon } from '../style/icons';
-import { IGitExtension } from '../tokens';
+import { rebaseActionStyle } from '../style/RebaseActionStyle';
+import { CommandIDs } from '../tokens';
 
 /**
  * RebaseAction property
@@ -30,9 +32,9 @@ export interface IRebaseActionProps {
    */
   hasConflict: boolean;
   /**
-   * Git model.
+   * Application command registry
    */
-  model: IGitExtension;
+  commands: CommandRegistry
   /**
    * Translation object.
    */
@@ -60,10 +62,10 @@ export function RebaseAction(props: IRebaseActionProps): JSX.Element {
     []
   );
   const onContinue = React.useCallback(async () => {
-    await props.model.resolveRebase('continue');
+    await props.commands.execute(CommandIDs.gitResolveRebase, {action: 'continue'});
   }, []);
   const onSkip = React.useCallback(async () => {
-    await props.model.resolveRebase('skip');
+    await props.commands.execute(CommandIDs.gitResolveRebase, {action: 'skip'});
   }, []);
   const onAbort = React.useCallback(async () => {
     const answer = await showDialog({
@@ -76,12 +78,12 @@ export function RebaseAction(props: IRebaseActionProps): JSX.Element {
     });
 
     if (answer.button.accept) {
-      await props.model.resolveRebase('abort');
+      await props.commands.execute(CommandIDs.gitResolveRebase, {action: 'abort'});
     }
   }, []);
 
   return (
-    <>
+    <div className={rebaseActionStyle}>
       <ButtonGroup ref={anchor} fullWidth={true} size="small">
         <Button
           classes={{
@@ -135,6 +137,6 @@ export function RebaseAction(props: IRebaseActionProps): JSX.Element {
           </Grow>
         )}
       </Popper>
-    </>
+    </div>
   );
 }

--- a/src/components/RebaseAction.tsx
+++ b/src/components/RebaseAction.tsx
@@ -34,7 +34,7 @@ export interface IRebaseActionProps {
   /**
    * Application command registry
    */
-  commands: CommandRegistry
+  commands: CommandRegistry;
   /**
    * Translation object.
    */
@@ -62,10 +62,14 @@ export function RebaseAction(props: IRebaseActionProps): JSX.Element {
     []
   );
   const onContinue = React.useCallback(async () => {
-    await props.commands.execute(CommandIDs.gitResolveRebase, {action: 'continue'});
+    await props.commands.execute(CommandIDs.gitResolveRebase, {
+      action: 'continue'
+    });
   }, []);
   const onSkip = React.useCallback(async () => {
-    await props.commands.execute(CommandIDs.gitResolveRebase, {action: 'skip'});
+    await props.commands.execute(CommandIDs.gitResolveRebase, {
+      action: 'skip'
+    });
   }, []);
   const onAbort = React.useCallback(async () => {
     const answer = await showDialog({
@@ -78,7 +82,9 @@ export function RebaseAction(props: IRebaseActionProps): JSX.Element {
     });
 
     if (answer.button.accept) {
-      await props.commands.execute(CommandIDs.gitResolveRebase, {action: 'abort'});
+      await props.commands.execute(CommandIDs.gitResolveRebase, {
+        action: 'abort'
+      });
     }
   }, []);
 

--- a/src/components/RebaseAction.tsx
+++ b/src/components/RebaseAction.tsx
@@ -1,0 +1,140 @@
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { TranslationBundle } from '@jupyterlab/translation';
+import {
+  Button,
+  ButtonGroup,
+  ClickAwayListener,
+  Grow,
+  MenuItem,
+  MenuList,
+  Paper,
+  Popper
+} from '@material-ui/core';
+import React from 'react';
+import {
+  commitButtonClass,
+  commitPaperClass,
+  commitRoot,
+  commitVariantSelector,
+  disabledStyle
+} from '../style/CommitBox';
+import { verticalMoreIcon } from '../style/icons';
+import { IGitExtension } from '../tokens';
+
+/**
+ * RebaseAction property
+ */
+export interface IRebaseActionProps {
+  /**
+   * Whether some files are in conflict or not.
+   */
+  hasConflict: boolean;
+  /**
+   * Git model.
+   */
+  model: IGitExtension;
+  /**
+   * Translation object.
+   */
+  trans: TranslationBundle;
+}
+
+/**
+ * Component to trigger action resolving a rebase.
+ *
+ * @param props Component properties
+ */
+export function RebaseAction(props: IRebaseActionProps): JSX.Element {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const anchor = React.useRef<HTMLDivElement>();
+  const onToggle = React.useCallback(() => {
+    setOpen(!open);
+  }, []);
+  const onClose = React.useCallback(
+    (event: React.MouseEvent<Document, MouseEvent>) => {
+      if (anchor.current.contains(event.target as HTMLElement)) {
+        return;
+      }
+      setOpen(false);
+    },
+    []
+  );
+  const onContinue = React.useCallback(async () => {
+    await props.model.resolveRebase('continue');
+  }, []);
+  const onSkip = React.useCallback(async () => {
+    await props.model.resolveRebase('skip');
+  }, []);
+  const onAbort = React.useCallback(async () => {
+    const answer = await showDialog({
+      title: props.trans.__('Abort rebase'),
+      body: props.trans.__('Are you sure you want to abort the rebase?'),
+      buttons: [
+        Dialog.cancelButton(),
+        Dialog.warnButton({ label: props.trans.__('Abort') })
+      ]
+    });
+
+    if (answer.button.accept) {
+      await props.model.resolveRebase('abort');
+    }
+  }, []);
+
+  return (
+    <>
+      <ButtonGroup ref={anchor} fullWidth={true} size="small">
+        <Button
+          classes={{
+            root: commitButtonClass,
+            disabled: disabledStyle
+          }}
+          disabled={props.hasConflict}
+          title={props.trans.__('Continue the rebase.')}
+          onClick={onContinue}
+        >
+          {props.trans.__('Continue')}
+        </Button>
+        <Button
+          classes={{
+            root: commitButtonClass
+          }}
+          className={commitVariantSelector}
+          onClick={onToggle}
+          size="small"
+          aria-controls={open ? 'rebase-split-button-menu' : undefined}
+          aria-expanded={open ? 'true' : undefined}
+        >
+          <verticalMoreIcon.react tag="span"></verticalMoreIcon.react>
+        </Button>
+      </ButtonGroup>
+      <Popper open={open} anchorEl={anchor.current} transition disablePortal>
+        {({ TransitionProps }) => (
+          <Grow {...TransitionProps}>
+            <Paper classes={{ root: commitRoot }} className={commitPaperClass}>
+              <ClickAwayListener onClickAway={onClose}>
+                <MenuList id="rebase-split-button-menu">
+                  <MenuItem
+                    key={'skip'}
+                    classes={{ root: commitRoot }}
+                    onClick={onSkip}
+                    title={props.trans.__('Skip the current commit.')}
+                  >
+                    {props.trans.__('Skip')}
+                  </MenuItem>
+                  <MenuItem
+                    key={'abort'}
+                    classes={{ root: commitRoot }}
+                    onClick={onAbort}
+                    title={props.trans.__('Abort the rebase.')}
+                  >
+                    {props.trans.__('Abort')}
+                  </MenuItem>
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </>
+  );
+}

--- a/src/components/RebaseAction.tsx
+++ b/src/components/RebaseAction.tsx
@@ -97,6 +97,7 @@ export function RebaseAction(props: IRebaseActionProps): JSX.Element {
           {props.trans.__('Continue')}
         </Button>
         <Button
+          title={props.trans.__('Pick another rebase action.')}
           classes={{
             root: commitButtonClass
           }}

--- a/src/components/StatusWidget.tsx
+++ b/src/components/StatusWidget.tsx
@@ -202,6 +202,12 @@ namespace Private {
         case 'git:pushing':
           status = 'pushing changes…';
           break;
+        case 'git:rebase':
+          status = 'rebasing…';
+          break;
+        case 'git:rebase:resolve':
+          status = 'resolving rebase…';
+          break;
         case 'git:refresh':
           status = 'refreshing…';
           break;

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -260,12 +260,25 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
    * @returns React element
    */
   private _renderBranchMenu(): React.ReactElement | null {
-    let branchTitle = this.props.trans.__('Current Branch');
+    let branchTitle = '';
     if (this.props.model.pathRepository === null) {
       return null;
     }
-    if (this.props.model.currentBranch?.detached) {
-      branchTitle = this.props.trans.__('Detached Head at');
+    switch(this.props.model.status.state) {
+      case Git.State.CHERRY_PICKING:
+        branchTitle = this.props.trans.__('Cherry picking in')
+        break;
+      case Git.State.DETACHED:
+        branchTitle = this.props.trans.__('Detached Head at');
+        break;
+      case Git.State.MERGING:
+        branchTitle = this.props.trans.__('Merging in');
+        break;
+      case Git.State.REBASING:
+        branchTitle = this.props.trans.__('Rebasing');
+        break;
+      default:
+        branchTitle = this.props.trans.__('Current Branch');
     }
 
     return (

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -264,9 +264,9 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
     if (this.props.model.pathRepository === null) {
       return null;
     }
-    switch(this.props.model.status.state) {
+    switch (this.props.model.status.state) {
       case Git.State.CHERRY_PICKING:
-        branchTitle = this.props.trans.__('Cherry picking in')
+        branchTitle = this.props.trans.__('Cherry picking in');
         break;
       case Git.State.DETACHED:
         branchTitle = this.props.trans.__('Detached Head at');

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,7 @@ async function activate(
         CommandIDs.gitShowDiff,
         CommandIDs.gitInit,
         CommandIDs.gitMerge,
+        CommandIDs.gitRebase,
         CommandIDs.gitPush,
         CommandIDs.gitPull,
         CommandIDs.gitResetToRemote,

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,6 @@ async function activate(
         CommandIDs.gitToggleSimpleStaging,
         CommandIDs.gitToggleDoubleClickDiff,
         CommandIDs.gitOpenGitignore,
-        CommandIDs.gitShowDiff,
         CommandIDs.gitInit,
         CommandIDs.gitMerge,
         CommandIDs.gitRebase,

--- a/src/model.ts
+++ b/src/model.ts
@@ -1021,6 +1021,32 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
+   * Rebase the current branch onto the provided one.
+   *
+   * @param branch to rebase onto
+   * @returns promise which resolves upon rebase action
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  async rebase(branch: string): Promise<Git.IResultWithMessage>{
+    const path = await this._getPathRepository();
+    return this._taskHandler.execute<Git.IResultWithMessage>(
+      'git:rebase',
+      () => {
+        return requestAPI<Git.IResultWithMessage>(
+          URLExt.join(path, 'rebase'),
+          'POST',
+          {
+            branch
+          }
+        );
+      }
+    );
+  }
+
+  /**
    * Refresh the repository.
    *
    * @returns promise which resolves upon refreshing the repository

--- a/src/model.ts
+++ b/src/model.ts
@@ -1062,14 +1062,6 @@ export class GitExtension implements IGitExtension {
 
       this._branches = data.branches ?? [];
 
-      const detachedHeadRegex = /\(HEAD detached at (.+)\)/;
-      const result = data.current_branch.name.match(detachedHeadRegex);
-
-      if (result && result.length > 1) {
-        data.current_branch.name = result[1];
-        data.current_branch.detached = true;
-      }
-
       this._currentBranch = data.current_branch;
       if (this._currentBranch) {
         // Set up the marker obj for the current (valid) repo/branch combination
@@ -1149,6 +1141,7 @@ export class GitExtension implements IGitExtension {
         remote: data.remote || null,
         ahead: data.ahead || 0,
         behind: data.behind || 0,
+        state: data.state ?? 0,
         files
       });
       await this.refreshDirtyStatus();
@@ -1868,6 +1861,7 @@ export class GitExtension implements IGitExtension {
       remote: null,
       ahead: 0,
       behind: 0,
+      state: Git.State.DEFAULT,
       files: []
     };
   }
@@ -1912,6 +1906,7 @@ export class GitExtension implements IGitExtension {
       this._status.ahead === v.ahead &&
       this._status.behind === v.behind &&
       this._status.branch === v.branch &&
+      this._status.state === v.state &&
       this._status.files.length === v.files.length;
     if (areEqual) {
       for (const file of v.files) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1047,6 +1047,31 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
+   * Resolve in progress rebase.
+   *
+   * @param action to perform
+   * @returns promise which resolves upon rebase action
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  async resolveRebase(
+    action: 'continue' | 'skip' | 'abort'
+  ): Promise<Git.IResultWithMessage> {
+    const path = await this._getPathRepository();
+    return this._taskHandler.execute<Git.IResultWithMessage>(
+      'git:rebase:resolve',
+      () =>
+        requestAPI<Git.IResultWithMessage>(
+          URLExt.join(path, 'rebase'),
+          'POST',
+          { action }
+        )
+    );
+  }
+
+  /**
    * Refresh the repository.
    *
    * @returns promise which resolves upon refreshing the repository

--- a/src/model.ts
+++ b/src/model.ts
@@ -1030,7 +1030,7 @@ export class GitExtension implements IGitExtension {
    * @throws {Git.GitResponseError} If the server response is not ok
    * @throws {ServerConnection.NetworkError} If the request cannot be made
    */
-  async rebase(branch: string): Promise<Git.IResultWithMessage>{
+  async rebase(branch: string): Promise<Git.IResultWithMessage> {
     const path = await this._getPathRepository();
     return this._taskHandler.execute<Git.IResultWithMessage>(
       'git:rebase',

--- a/src/style/FileListStyle.ts
+++ b/src/style/FileListStyle.ts
@@ -1,6 +1,7 @@
 import { style } from 'typestyle';
 
 export const fileListWrapperClass = style({
+  flex: '1 1 auto',
   minHeight: '150px',
 
   overflow: 'hidden',

--- a/src/style/GitStashStyle.ts
+++ b/src/style/GitStashStyle.ts
@@ -1,4 +1,17 @@
 import { style } from 'typestyle';
+import type { NestedCSSProperties } from 'typestyle/lib/types';
+import { sectionAreaStyle } from './GitStageStyle';
+
+export const stashContainerStyle = style((() => {
+  const styled: NestedCSSProperties = { $nest: {} };
+
+  styled.$nest[`& > .${sectionAreaStyle}`] = {
+    margin: 0,
+  }
+  return styled;
+}
+
+)())
 
 export const sectionHeaderLabelStyle = style({
   fontSize: 'var(--jp-ui-font-size1)',

--- a/src/style/GitStashStyle.ts
+++ b/src/style/GitStashStyle.ts
@@ -2,16 +2,16 @@ import { style } from 'typestyle';
 import type { NestedCSSProperties } from 'typestyle/lib/types';
 import { sectionAreaStyle } from './GitStageStyle';
 
-export const stashContainerStyle = style((() => {
-  const styled: NestedCSSProperties = { $nest: {} };
+export const stashContainerStyle = style(
+  (() => {
+    const styled: NestedCSSProperties = { $nest: {} };
 
-  styled.$nest[`& > .${sectionAreaStyle}`] = {
-    margin: 0,
-  }
-  return styled;
-}
-
-)())
+    styled.$nest[`& > .${sectionAreaStyle}`] = {
+      margin: 0
+    };
+    return styled;
+  })()
+);
 
 export const sectionHeaderLabelStyle = style({
   fontSize: 'var(--jp-ui-font-size1)',

--- a/src/style/RebaseActionStyle.ts
+++ b/src/style/RebaseActionStyle.ts
@@ -1,5 +1,5 @@
 import { style } from 'typestyle';
 
 export const rebaseActionStyle = style({
-    padding: '8px'
-})
+  padding: '8px'
+});

--- a/src/style/RebaseActionStyle.ts
+++ b/src/style/RebaseActionStyle.ts
@@ -1,0 +1,5 @@
+import { style } from 'typestyle';
+
+export const rebaseActionStyle = style({
+    padding: '8px'
+})

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -908,7 +908,6 @@ export namespace Git {
     upstream: string | null;
     top_commit: string;
     tag: string | null;
-
   }
 
   /** Interface for GitBranch request result,

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -477,6 +477,18 @@ export interface IGitExtension extends IDisposable {
   ): Promise<Git.IResultWithMessage>;
 
   /**
+   * Rebase the current branch onto the provided one.
+   *
+   * @param branch to rebase onto
+   * @returns promise which resolves upon rebase action
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  rebase(branch: string): Promise<Git.IResultWithMessage>;
+
+  /**
    * General Git refresh
    */
   refresh(): Promise<void>;
@@ -1332,6 +1344,7 @@ export enum CommandIDs {
   gitOpenGitignore = 'git:open-gitignore',
   gitPush = 'git:push',
   gitPull = 'git:pull',
+  gitRebase = 'git:rebase',
   gitResetToRemote = 'git:reset-to-remote',
   gitSubmitCommand = 'git:submit-commit',
   gitShowDiff = 'git:show-diff',

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -755,12 +755,38 @@ export namespace Git {
 
     export enum SpecialRef {
       // Working version
-      'WORKING',
+      WORKING,
       // Index version
-      'INDEX',
+      INDEX,
       // Common ancestor version (useful for unmerged files)
-      'BASE'
+      BASE
     }
+  }
+
+  /**
+   * Git repository state
+   */
+  export enum State {
+    /**
+     * Default state
+     */
+    DEFAULT = 0,
+    /**
+     * Detached head state
+     */
+    DETACHED,
+    /**
+     * Merge in progress
+     */
+    MERGING,
+    /**
+     * Rebase in progress
+     */
+    REBASING,
+    /**
+     * Cherry-pick in progress
+     */
+    CHERRY_PICKING
   }
 
   /**
@@ -870,7 +896,7 @@ export namespace Git {
     upstream: string | null;
     top_commit: string;
     tag: string | null;
-    detached?: boolean;
+
   }
 
   /** Interface for GitBranch request result,
@@ -928,6 +954,10 @@ export namespace Git {
      */
     behind: number;
     /**
+     * Git repository state
+     */
+    state: Git.State;
+    /**
      * Files status
      */
     files: IStatusFile[];
@@ -962,6 +992,7 @@ export namespace Git {
     remote?: string | null;
     ahead?: number;
     behind?: number;
+    state?: number;
     files?: IStatusFileResult[];
   }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1358,6 +1358,7 @@ export enum CommandIDs {
   gitPush = 'git:push',
   gitPull = 'git:pull',
   gitRebase = 'git:rebase',
+  gitResolveRebase = 'git:resolve-rebase',
   gitResetToRemote = 'git:reset-to-remote',
   gitSubmitCommand = 'git:submit-commit',
   gitShowDiff = 'git:show-diff',

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -489,6 +489,20 @@ export interface IGitExtension extends IDisposable {
   rebase(branch: string): Promise<Git.IResultWithMessage>;
 
   /**
+   * Resolve in progress rebase.
+   *
+   * @param action to perform
+   * @returns promise which resolves upon rebase action
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  resolveRebase(
+    action: 'continue' | 'skip' | 'abort'
+  ): Promise<Git.IResultWithMessage>;
+
+  /**
    * General Git refresh
    */
   refresh(): Promise<void>;

--- a/ui-tests/tests/merge-conflict.spec.ts
+++ b/ui-tests/tests/merge-conflict.spec.ts
@@ -22,19 +22,28 @@ test.describe('Merge conflict tests', () => {
 
     // Click on a-branch merge button
     await page.locator('text=a-branch').hover();
-    await page.getByRole('button', { name: 'Merge this branch into the current one', exact: true }).click();
+    await page
+      .getByRole('button', {
+        name: 'Merge this branch into the current one',
+        exact: true
+      })
+      .click();
 
     // Hide branch panel
     await page.getByRole('button', { name: 'Current Branch master' }).click();
 
     // Force refresh
     await page
-      .getByRole('button', { name: 'Refresh the repository to detect local and remote changes' })
+      .getByRole('button', {
+        name: 'Refresh the repository to detect local and remote changes'
+      })
       .click();
   });
 
   test('should diff conflicted text file', async ({ page }) => {
-    await page.getByTitle('file.txt • Conflicted', { exact: true }).click({ clickCount: 2 });
+    await page
+      .getByTitle('file.txt • Conflicted', { exact: true })
+      .click({ clickCount: 2 });
     await page.waitForSelector(
       '.jp-git-diff-parent-widget[id^="Current-Incoming"] .jp-spinner',
       { state: 'detached' }
@@ -52,7 +61,7 @@ test.describe('Merge conflict tests', () => {
   });
 
   test('should diff conflicted notebook file', async ({ page }) => {
-    await page.getByTitle('example.ipynb • Conflicted').click( {
+    await page.getByTitle('example.ipynb • Conflicted').click({
       clickCount: 2
     });
     await page.waitForSelector(

--- a/ui-tests/tests/rebase.spec.ts
+++ b/ui-tests/tests/rebase.spec.ts
@@ -5,7 +5,7 @@ import { extractFile } from './utils';
 const baseRepositoryPath = 'test-repository.tar.gz';
 test.use({ autoGoto: false, mockSettings: galata.DEFAULT_SETTINGS });
 
-test.describe('Merge conflict tests', () => {
+test.describe('Rebase', () => {
   test.beforeEach(async ({ baseURL, page, tmpPath }) => {
     await extractFile(
       baseURL,
@@ -20,12 +20,18 @@ test.describe('Merge conflict tests', () => {
 
     await page.getByRole('button', { name: 'Current Branch master' }).click();
 
-    // Click on a-branch merge button
-    await page.locator('text=a-branch').hover();
-    await page.getByRole('button', { name: 'Merge this branch into the current one', exact: true }).click();
+    // Switch to a-branch
+    await page.getByRole('button', { name: 'a-branch' }).click();
 
     // Hide branch panel
-    await page.getByRole('button', { name: 'Current Branch master' }).click();
+    await page.getByRole('button', { name: 'Current Branch a-branch' }).click();
+
+    // Rebase on master
+    await page.getByRole('main').press('Control+Shift+C');
+    await page.getByRole('textbox', { name: 'SEARCH' }).fill('rebase');
+    await page.getByText('Rebase branch…').click();
+    await page.getByRole('button', { name: 'master' }).click();
+    await page.getByRole('button', { name: 'Rebase' }).click();
 
     // Force refresh
     await page

--- a/ui-tests/tests/rebase.spec.ts
+++ b/ui-tests/tests/rebase.spec.ts
@@ -35,12 +35,16 @@ test.describe('Rebase', () => {
 
     // Force refresh
     await page
-      .getByRole('button', { name: 'Refresh the repository to detect local and remote changes' })
+      .getByRole('button', {
+        name: 'Refresh the repository to detect local and remote changes'
+      })
       .click();
   });
 
   test('should diff conflicted text file', async ({ page }) => {
-    await page.getByTitle('file.txt • Conflicted', { exact: true }).click({ clickCount: 2 });
+    await page
+      .getByTitle('file.txt • Conflicted', { exact: true })
+      .click({ clickCount: 2 });
     await page.waitForSelector(
       '.jp-git-diff-parent-widget[id^="Current-Incoming"] .jp-spinner',
       { state: 'detached' }
@@ -58,7 +62,7 @@ test.describe('Rebase', () => {
   });
 
   test('should diff conflicted notebook file', async ({ page }) => {
-    await page.getByTitle('example.ipynb • Conflicted').click( {
+    await page.getByTitle('example.ipynb • Conflicted').click({
       clickCount: 2
     });
     await page.waitForSelector(

--- a/ui-tests/tests/rebase.spec.ts
+++ b/ui-tests/tests/rebase.spec.ts
@@ -43,9 +43,7 @@ test.describe('Rebase', () => {
 
   test('should resolve a conflicted rebase', async ({ page }) => {
     // Resolve conflicts
-    await page
-      .getByTitle('file.txt • Conflicted', { exact: true })
-      .dblclick()
+    await page.getByTitle('file.txt • Conflicted', { exact: true }).dblclick();
     await page.waitForSelector(
       '.jp-git-diff-parent-widget[id^="Current-Incoming"] .jp-spinner',
       { state: 'detached' }
@@ -58,14 +56,14 @@ test.describe('Rebase', () => {
     await expect.soft(banner).toHaveText(/Result/);
     await expect.soft(banner).toHaveText(/Incoming/);
 
-    await page.getByRole('button', { name: 'Mark as resolved' }).click()
+    await page.getByRole('button', { name: 'Mark as resolved' }).click();
 
     await page
       .getByTitle('another_file.txt • Conflicted', { exact: true })
-      .dblclick()
+      .dblclick();
 
-    await page.getByRole('button', { name: 'Mark as resolved' }).click()
-    
+    await page.getByRole('button', { name: 'Mark as resolved' }).click();
+
     await page.getByTitle('example.ipynb • Conflicted').click({
       clickCount: 2
     });
@@ -79,42 +77,42 @@ test.describe('Rebase', () => {
     await expect.soft(banner).toHaveText(/Current/);
     await expect.soft(banner).toHaveText(/Incoming/);
 
-    await page.getByRole('button', { name: 'Mark as resolved' }).click()
+    await page.getByRole('button', { name: 'Mark as resolved' }).click();
 
     // Continue rebase as all conflicts are resolved
     await page.getByRole('button', { name: 'Continue' }).click();
 
-    await page.getByRole('tab', {name: 'History'}).click();
+    await page.getByRole('tab', { name: 'History' }).click();
 
     // Master changes must be part of the history following the rebase
     await expect.soft(page.getByTitle('View commit details')).toHaveCount(3);
     await expect(page.getByText('master changes')).toBeVisible();
   });
 
-  test('should abort a rebase', async ({page}) => {
+  test('should abort a rebase', async ({ page }) => {
     await page.getByTitle('Pick another rebase action.').click();
 
     await page.getByRole('menuitem', { name: 'Abort' }).click();
 
     await page.getByRole('button', { name: 'Abort' }).click();
 
-    await page.getByRole('tab', {name: 'History'}).click();
+    await page.getByRole('tab', { name: 'History' }).click();
 
     // Master changes must not be part of the history following the abort
     await expect.soft(page.getByTitle('View commit details')).toHaveCount(2);
     await expect(page.getByText('a-branch changes')).toBeVisible();
-  })
+  });
 
-  test('should skip the current commit', async ({page}) => {
+  test('should skip the current commit', async ({ page }) => {
     await page.getByTitle('Pick another rebase action.').click();
 
     await page.getByRole('menuitem', { name: 'Skip' }).click();
 
-    await page.getByRole('tab', {name: 'History'}).click();
+    await page.getByRole('tab', { name: 'History' }).click();
 
     // Master changes must be part of the history following the rebase but not
     // the old a-branch commit.
     await expect(page.getByTitle('View commit details')).toHaveCount(2);
     await expect(page.getByText('master changes')).toBeVisible();
-  })
+  });
 });


### PR DESCRIPTION
This PR
- fixes #1217
- fixes #1242

by
- adding support for rebase:
  - The status of a repository gain a `state` to notify if a repo is in detached head, merge, cherry-pick or rebase state
  - In case a rebase is in progress, the commit box is replaced by a group button that by default allow to continue (after resolving the conflicts) or optionally skip or abort the rebase.
- some styling improvement
- fix checking out from a detached head to another ref