### PR TITLE
Load gitignore file

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -1698,6 +1698,8 @@ class Git:
                 if content[-1] != "\n":
                     with gitignore.open("a") as f:
                         f.write("\n")
+                else:  # .gitignore exists, but the file is hidden
+                    return {"code": -2, "message": ".gitignore exists but is hidden"}
         except BaseException as error:
             return {"code": -1, "message": str(error)}
         return {"code": 0}

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -1681,7 +1681,7 @@ class Git:
 
         return response
 
-    async def read_file(self, path):
+    def read_file(self, path):
         """
         Reads file content located at path and returns it as a string
 
@@ -1690,12 +1690,10 @@ class Git:
         """
         try:
             file = pathlib.Path(path)
-            if file.stat().st_size > 0:
-                content = file.read_text()
-                return content
-            return ""
+            content = file.read_text()
+            return {"code": 0, "content": content}
         except BaseException as error:
-            return ""
+            return {"code": -1, "content": ""}
 
     async def ensure_gitignore(self, path):
         """Handle call to ensure .gitignore file exists and the
@@ -1737,7 +1735,7 @@ class Git:
             return {"code": -1, "message": str(error)}
         return {"code": 0}
 
-    async def writeGitignore(self, path, content):
+    async def write_gitignore(self, path, content):
         """
         Handle call to overwrite .gitignore.
         Takes the .gitignore file and clears its previous contents
@@ -1753,12 +1751,9 @@ class Git:
             if res["code"] != 0:
                 return res
             gitignore = pathlib.Path(path) / ".gitignore"
-            with gitignore.open("a") as f:
-                f.truncate(0)
-                f.seek(0)
-                f.write(content)
-                if content[-1] != "\n":
-                    f.write("\n")
+            if content and content[-1] != "\n":
+                content += "\n"
+            gitignore.write_text(content)
         except BaseException as error:
             return {"code": -1, "message": str(error)}
         return {"code": 0}

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -1682,11 +1682,16 @@ class Git:
         return response
 
     async def read_file(self, path):
+        """
+        Reads file content located at path and returns it as a string
+
+        path: str
+            The path of the file
+        """
         try:
             file = pathlib.Path(path)
             if file.stat().st_size > 0:
                 content = file.read_text()
-                print(content)
                 return content
             return ""
         except BaseException as error:
@@ -1728,6 +1733,32 @@ class Git:
             gitignore = pathlib.Path(path) / ".gitignore"
             with gitignore.open("a") as f:
                 f.write(file_path + "\n")
+        except BaseException as error:
+            return {"code": -1, "message": str(error)}
+        return {"code": 0}
+
+    async def writeGitignore(self, path, content):
+        """
+        Handle call to overwrite .gitignore.
+        Takes the .gitignore file and clears its previous contents
+        Writes the new content onto the file
+
+        path: str
+            Top Git repository path
+        content: str
+            New file contents
+        """
+        try:
+            res = await self.ensure_gitignore(path)
+            if res["code"] != 0:
+                return res
+            gitignore = pathlib.Path(path) / ".gitignore"
+            with gitignore.open("a") as f:
+                f.truncate(0)
+                f.seek(0)
+                f.write(content)
+                if content[-1] != "\n":
+                    f.write("\n")
         except BaseException as error:
             return {"code": -1, "message": str(error)}
         return {"code": 0}

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -1681,6 +1681,17 @@ class Git:
 
         return response
 
+    async def read_file(self, path):
+        try:
+            file = pathlib.Path(path)
+            if file.stat().st_size > 0:
+                content = file.read_text()
+                print(content)
+                return content
+            return ""
+        except BaseException as error:
+            return ""
+
     async def ensure_gitignore(self, path):
         """Handle call to ensure .gitignore file exists and the
         next append will be on a new line (this means an empty file

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -1698,8 +1698,6 @@ class Git:
                 if content[-1] != "\n":
                     with gitignore.open("a") as f:
                         f.write("\n")
-                else:  # .gitignore exists, but the file is hidden
-                    return {"code": -2, "message": ".gitignore exists but is hidden"}
         except BaseException as error:
             return {"code": -1, "message": str(error)}
         return {"code": 0}

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -826,13 +826,12 @@ class GitIgnoreHandler(GitHandler):
                     file_path = "**/*" + ".".join(suffixes)
             body = await self.git.ignore(local_path, file_path)
         else:
+            body = await self.git.ensure_gitignore(local_path)
             if not self.serverapp.contents_manager.allow_hidden:
                 self.set_status(403, "hidden files cannot be accessed")
-            body = await self.git.ensure_gitignore(local_path)
+                body["content"] = await self.git.read_file(local_path + "/.gitignore")
 
-        if body["code"] == -2:
-            self.set_status(403, body["message"])
-        elif body["code"] != 0:
+        if body["code"] != 0:
             self.set_status(500)
         self.finish(json.dumps(body))
 

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -826,6 +826,8 @@ class GitIgnoreHandler(GitHandler):
                     file_path = "**/*" + ".".join(suffixes)
             body = await self.git.ignore(local_path, file_path)
         else:
+            if not self.serverapp.contents_manager.allow_hidden:
+                self.set_status(403, "hidden files cannot be accessed")
             body = await self.git.ensure_gitignore(local_path)
 
         if body["code"] == -2:

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -827,9 +827,9 @@ class GitIgnoreHandler(GitHandler):
             body = await self.git.ignore(local_path, file_path)
         else:
             body = await self.git.ensure_gitignore(local_path)
-            if not self.serverapp.contents_manager.allow_hidden:
-                self.set_status(403, "hidden files cannot be accessed")
-                body["content"] = await self.git.read_file(local_path + "/.gitignore")
+        if not self.serverapp.contents_manager.allow_hidden:
+            self.set_status(403, "hidden files cannot be accessed")
+            body["content"] = await self.git.read_file(local_path + "/.gitignore")
 
         if body["code"] != 0:
             self.set_status(500)

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -828,7 +828,9 @@ class GitIgnoreHandler(GitHandler):
         else:
             body = await self.git.ensure_gitignore(local_path)
 
-        if body["code"] != 0:
+        if body["code"] == -2:
+            self.set_status(403, body["message"])
+        elif body["code"] != 0:
             self.set_status(500)
         self.finish(json.dumps(body))
 

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -818,8 +818,11 @@ class GitIgnoreHandler(GitHandler):
         local_path = self.url2localpath(path)
         data = self.get_json_body()
         file_path = data.get("file_path", None)
+        content = data.get("content", None)
         use_extension = data.get("use_extension", False)
-        if file_path:
+        if content:
+            body = await self.git.writeGitignore(local_path, content)
+        elif file_path:
             if use_extension:
                 suffixes = Path(file_path).suffixes
                 if len(suffixes) > 0:
@@ -827,7 +830,7 @@ class GitIgnoreHandler(GitHandler):
             body = await self.git.ignore(local_path, file_path)
         else:
             body = await self.git.ensure_gitignore(local_path)
-        if not self.serverapp.contents_manager.allow_hidden:
+        if not self.serverapp.contents_manager.allow_hidden and not content:
             self.set_status(403, "hidden files cannot be accessed")
             body["content"] = await self.git.read_file(local_path + "/.gitignore")
 

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -79,7 +79,7 @@
     },
     "hideHiddenFileWarning": {
       "type": "boolean",
-      "title":"Hide hidden file warning",
+      "title": "Hide hidden file warning",
       "description": "If true, the warning popup when opening the .gitignore file without hidden files will not be displayed.",
       "default": false
     }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -76,6 +76,12 @@
       "title": "Open files behind warning",
       "description": "If true, a popup dialog will be displayed if a user opens a file that is behind its remote branch version, or if an opened file has updates on the remote branch.",
       "default": true
+    },
+    "hideHiddenFileWarning": {
+      "type": "boolean",
+      "title":"Hide hidden file warning",
+      "description": "If true, the warning popup when opening the .gitignore file without hidden files will not be displayed.",
+      "default": false
     }
   },
   "jupyter.lab.shortcuts": [

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -343,6 +343,16 @@ export function addCommands(
     if (result.button.accept) {
       const model = new CodeEditor.Model({});
       const id = 'git-ignore';
+      //
+      const gitIgnoreWidget = find(shell.widgets(), shellWidget => {
+        if (shellWidget.id === id) {
+          return true;
+        }
+      });
+      if (gitIgnoreWidget) {
+        shell.activateById(id);
+        return;
+      }
       model.sharedModel.setSource(error.content ? error.content : '');
       const editor = new CodeEditorWrapper({
         factory: editorServices.factoryService.newDocumentEditor,

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -309,7 +309,40 @@ export function addCommands(
     caption: trans.__('Open .gitignore'),
     isEnabled: () => gitModel.pathRepository !== null,
     execute: async () => {
-      await gitModel.ensureGitignore();
+      try {
+        await gitModel.ensureGitignore();
+      } catch (error: any) {
+        if (error?.name === 'hiddenFile') {
+          await showDialog({
+            title: trans.__('The .gitignore file cannot be accessed'),
+            body: (
+              <div>
+                {trans.__(
+                  'Hidden files by default cannot be accessed. In order to open the .gitignore file you must:'
+                )}
+                <ol>
+                  <li>
+                    {trans.__(
+                      'Print the command below to create a jupyter_server_config.py file with defaults commented out. If you already have the file located in .jupyter, skip this step.'
+                    )}
+                    <div style={{ padding: '0.5rem' }}>
+                      {trans.__('jupyter server --generate-config')}
+                    </div>
+                  </li>
+                  <li>
+                    {trans.__(
+                      'Open jupyter_server_config.py, uncomment out the following line and set it to True:'
+                    )}
+                    <div style={{ padding: '0.5rem' }}>
+                      {trans.__('c.ContentsManager.allow_hidden = False')}
+                    </div>
+                  </li>
+                </ol>
+              </div>
+            )
+          });
+        }
+      }
     }
   });
 

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -54,7 +54,7 @@ import { discardAllChanges } from './widgets/discardAllChanges';
 import { CheckboxForm } from './widgets/GitResetToRemoteForm';
 import { CodeEditor } from '@jupyterlab/codeeditor/lib/editor';
 import { CodeEditorWrapper } from '@jupyterlab/codeeditor/lib/widget';
-import { CodeMirrorEditorFactory } from '@jupyterlab/codemirror/lib/factory';
+import { editorServices } from '@jupyterlab/codemirror';
 
 export interface IGitCloneArgs {
   /**
@@ -350,31 +350,24 @@ export function addCommands(
           });
           if (result.button.accept) {
             const model = new CodeEditor.Model({});
-            // const host = document.createElement('div');
-            const previewWidget = new PreviewMainAreaWidget<Panel>({
-              content: new Panel()
-            });
             const id = 'git-ignore';
-            // document.body.appendChild(host);
             model.sharedModel.setSource(error.content ? error.content : '');
-            const widget = new CodeEditorWrapper({
-              factory: () =>
-                new CodeMirrorEditorFactory().newDocumentEditor({
-                  model: model,
-                  host: previewWidget.node,
-                  config: { readOnly: true }
-                }),
-              model: model
+            const editor = new CodeEditorWrapper({
+              factory: editorServices.factoryService.newDocumentEditor,
+              model: model,
+              config: { readOnly: true }
             });
-            widget.disposed.connect(() => {
+            editor.disposed.connect(() => {
               model.dispose();
             });
-            // widget.id = id;
-            // shell.add(widget);
-            // shell.activateById(widget.id);
-
-            previewWidget.id = id;
-            shell.add(previewWidget);
+            const preview = new PreviewMainAreaWidget({
+              content: editor
+            });
+            preview.title.label = '.gitignore';
+            preview.id = id;
+            preview.title.icon = gitIcon;
+            preview.title.closable = true;
+            shell.add(preview);
           }
         }
       }

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -321,7 +321,7 @@ export function addCommands(
       shell.activateById(id);
       return;
     }
-    model.sharedModel.setSource(contentData.content ? contentData.content : '');
+    model.sharedModel.setSource(contentData ? contentData : '');
     const editor = new CodeEditorWrapper({
       factory: editorServices.factoryService.newDocumentEditor,
       model: model

--- a/src/git.ts
+++ b/src/git.ts
@@ -65,6 +65,9 @@ export async function requestAPI<T>(
   if (!response.ok) {
     if (isJSON) {
       const { message, traceback, ...json } = data;
+      if (response.status === 403) {
+        throw new Git.HiddenFile();
+      }
       throw new Git.GitResponseError(
         response,
         message ||

--- a/src/git.ts
+++ b/src/git.ts
@@ -65,9 +65,6 @@ export async function requestAPI<T>(
   if (!response.ok) {
     if (isJSON) {
       const { message, traceback, ...json } = data;
-      if (response.status === 403) {
-        throw new Git.HiddenFile(data.content);
-      }
       throw new Git.GitResponseError(
         response,
         message ||

--- a/src/git.ts
+++ b/src/git.ts
@@ -66,7 +66,7 @@ export async function requestAPI<T>(
     if (isJSON) {
       const { message, traceback, ...json } = data;
       if (response.status === 403) {
-        throw new Git.HiddenFile();
+        throw new Git.HiddenFile(data.content);
       }
       throw new Git.GitResponseError(
         response,

--- a/src/model.ts
+++ b/src/model.ts
@@ -888,15 +888,15 @@ export class GitExtension implements IGitExtension {
    * @throws {Git.GitResponseError} If the server response is not ok
    * @throws {ServerConnection.NetworkError} If the request cannot be made
    */
-  async readGitIgnore(): Promise<{ code: number; content: string }> {
+  async readGitIgnore(): Promise<string> {
     const path = await this._getPathRepository();
 
-    const res = (await requestAPI(URLExt.join(path, 'ignore'), 'GET')) as {
-      code: number;
-      content: string;
-    };
-    await this.refreshStatus();
-    return res;
+    return (
+      (await requestAPI(URLExt.join(path, 'ignore'), 'GET')) as {
+        code: number;
+        content: string;
+      }
+    ).content;
   }
 
   /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -860,6 +860,7 @@ export class GitExtension implements IGitExtension {
    * @throws {Git.NotInRepository} If the current path is not a Git repository
    * @throws {Git.GitResponseError} If the server response is not ok
    * @throws {ServerConnection.NetworkError} If the request cannot be made
+   * @throws {Git.HiddenFile} If the file is hidden
    */
   async ensureGitignore(): Promise<void> {
     const path = await this._getPathRepository();

--- a/src/model.ts
+++ b/src/model.ts
@@ -871,6 +871,20 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
+   * Overwrites content onto .gitignore file
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  async writeGitIgnore(content: string): Promise<void> {
+    const path = await this._getPathRepository();
+
+    await requestAPI(URLExt.join(path, 'ignore'), 'POST', { content: content });
+    await this.refreshStatus();
+  }
+
+  /**
    * Fetch to get ahead/behind status
    *
    * @param auth - remote authentication information

--- a/src/model.ts
+++ b/src/model.ts
@@ -924,6 +924,7 @@ export class GitExtension implements IGitExtension {
    * @throws {Git.NotInRepository} If the current path is not a Git repository
    * @throws {Git.GitResponseError} If the server response is not ok
    * @throws {ServerConnection.NetworkError} If the request cannot be made
+   * @throws {Git.HiddenFile} If hidden files are not enabled
    */
   async ignore(filePath: string, useExtension: boolean): Promise<void> {
     const path = await this._getPathRepository();

--- a/src/model.ts
+++ b/src/model.ts
@@ -9,6 +9,7 @@ import { AUTH_ERROR_MESSAGES, requestAPI } from './git';
 import { TaskHandler } from './taskhandler';
 import { Git, IGitExtension } from './tokens';
 import { decodeStage } from './utils';
+import { ServerConnection } from '@jupyterlab/services';
 
 // Default refresh interval (in milliseconds) for polling the current Git status (NOTE: this value should be the same value as in the plugin settings schema):
 const DEFAULT_REFRESH_INTERVAL = 3000; // ms
@@ -866,8 +867,36 @@ export class GitExtension implements IGitExtension {
     const path = await this._getPathRepository();
 
     await requestAPI(URLExt.join(path, 'ignore'), 'POST', {});
+    try {
+      await this._docmanager.services.contents.get(`${path}/.gitignore`, {
+        content: false
+      });
+    } catch (e) {
+      // If the previous request failed with a 404 error, it means hidden file cannot be accessed
+      if ((e as ServerConnection.ResponseError).response?.status === 404) {
+        throw new Git.HiddenFile();
+      }
+    }
     this._openGitignore();
     await this.refreshStatus();
+  }
+
+  /**
+   * Reads content of .gitignore file
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  async readGitIgnore(): Promise<{ code: number; content: string }> {
+    const path = await this._getPathRepository();
+
+    const res = (await requestAPI(URLExt.join(path, 'ignore'), 'GET')) as {
+      code: number;
+      content: string;
+    };
+    await this.refreshStatus();
+    return res;
   }
 
   /**
@@ -947,7 +976,16 @@ export class GitExtension implements IGitExtension {
       file_path: filePath,
       use_extension: useExtension
     });
-
+    try {
+      await this._docmanager.services.contents.get(`${path}/.gitignore`, {
+        content: false
+      });
+    } catch (e) {
+      // If the previous request failed with a 404 error, it means hidden file cannot be accessed
+      if ((e as ServerConnection.ResponseError).response?.status === 404) {
+        throw new Git.HiddenFile();
+      }
+    }
     this._openGitignore();
     await this.refreshStatus();
   }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1300,6 +1300,12 @@ export namespace Git {
     }
   }
 
+  export class HiddenFile extends Error {
+    constructor() {
+      super('File is hidden');
+    }
+  }
+
   /**
    * Interface for dialog with one checkbox.
    */

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1301,12 +1301,10 @@ export namespace Git {
   }
 
   export class HiddenFile extends Error {
-    content: string;
-    constructor(content: string) {
+    constructor() {
       super('File is hidden');
       this.name = 'hiddenFile';
       this.message = 'File is hidden and cannot be accessed.';
-      this.content = content;
     }
   }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1301,10 +1301,12 @@ export namespace Git {
   }
 
   export class HiddenFile extends Error {
-    constructor() {
+    content: string;
+    constructor(content: string) {
       super('File is hidden');
       this.name = 'hiddenFile';
       this.message = 'File is hidden and cannot be accessed.';
+      this.content = content;
     }
   }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1303,6 +1303,8 @@ export namespace Git {
   export class HiddenFile extends Error {
     constructor() {
       super('File is hidden');
+      this.name = 'hiddenFile';
+      this.message = 'File is hidden and cannot be accessed.';
     }
   }
 

--- a/style/diff-common.css
+++ b/style/diff-common.css
@@ -180,3 +180,17 @@ button.jp-git-diff-resolve .jp-ToolbarButtonComponent-label {
     var(--jp-border-color0) 12px
   );
 }
+
+.not-saved
+  > .lm-TabBar-tabCloseIcon
+  > :not(:hover)
+  > .jp-icon-busy[fill] {
+  fill: var(--jp-inverse-layout-color3);
+}
+
+.not-saved
+  > .lm-TabBar-tabCloseIcon
+  > :not(:hover)
+  > .jp-icon3[fill] {
+  fill: none;
+}

--- a/style/diff-common.css
+++ b/style/diff-common.css
@@ -181,16 +181,10 @@ button.jp-git-diff-resolve .jp-ToolbarButtonComponent-label {
   );
 }
 
-.not-saved
-  > .lm-TabBar-tabCloseIcon
-  > :not(:hover)
-  > .jp-icon-busy[fill] {
+.not-saved > .lm-TabBar-tabCloseIcon > :not(:hover) > .jp-icon-busy[fill] {
   fill: var(--jp-inverse-layout-color3);
 }
 
-.not-saved
-  > .lm-TabBar-tabCloseIcon
-  > :not(:hover)
-  > .jp-icon3[fill] {
+.not-saved > .lm-TabBar-tabCloseIcon > :not(:hover) > .jp-icon3[fill] {
   fill: none;
 }


### PR DESCRIPTION
## Description

-Throws a 403 if the user tries to open a .gitignore file but the file is hidden
-Displays a helpful message showing how to enable hidden files
-Adds checkbox to not show helpful message in the feature
-Allow user to open, view and edit the .gitignore file

Temporary fix for the opening the .gitignore file in #1168 