### PR TITLE
Add context menu on commits in the HistorySidebar with add tag command

### DIFF
--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -1569,7 +1569,6 @@ export function addCommands(
           trans={trans}
           open={tagDialog}
           onClose={(tagName?: string) => {
-            // () => {
             dialog.dispose();
             waitForDialog.resolve(tagName ?? null);
           }}

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -1,6 +1,8 @@
 import { TranslationBundle } from '@jupyterlab/translation';
 import { closeIcon } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
+import { Menu } from '@lumino/widgets';
+import { addHistoryMenuItems } from '../commandsAndMenu';
 import * as React from 'react';
 import { GitExtension } from '../model';
 import { hiddenButtonStyle } from '../style/ActionButtonStyle';
@@ -10,7 +12,7 @@ import {
   selectedHistoryFileStyle,
   historySideBarWrapperStyle
 } from '../style/HistorySideBarStyle';
-import { Git } from '../tokens';
+import { ContextCommandIDs, Git } from '../tokens';
 import { openFileDiff } from '../utils';
 import { ActionButton } from './ActionButton';
 import { FileItem } from './FileItem';
@@ -79,6 +81,8 @@ export interface IHistorySideBarProps {
   ) => (event: React.MouseEvent<HTMLElement, MouseEvent>) => Promise<void>;
 }
 
+export const CONTEXT_COMMANDS = [ContextCommandIDs.gitTagAdd];
+
 /**
  * Returns a React component for displaying commit history.
  *
@@ -144,6 +148,25 @@ export const HistorySideBar: React.FunctionComponent<IHistorySideBarProps> = (
     );
     return () => resizeObserver.disconnect();
   }, [props.commits]);
+
+  /**
+   * Open the context menu on the advanced view
+   *
+   * @param selectedCommit The commit on which the context menu is opened
+   * @param event The click event
+   */
+  const openContextMenu = (
+    selectedCommit: Git.ISingleCommitInfo,
+    event: React.MouseEvent
+  ): void => {
+    event.preventDefault();
+
+    const contextMenu = new Menu({ commands: props.commands });
+    const commands = [ContextCommandIDs.gitTagAdd];
+    addHistoryMenuItems(commands, contextMenu, selectedCommit);
+
+    contextMenu.open(event.clientX, event.clientY);
+  };
 
   return (
     <div className={historySideBarWrapperStyle}>
@@ -232,6 +255,7 @@ export const HistorySideBar: React.FunctionComponent<IHistorySideBarProps> = (
                     }
                   })
                 }
+                contextMenu={openContextMenu}
               >
                 {!props.model.selectedHistoryFile && (
                   <SinglePastCommitInfo

--- a/src/components/NewTagDialog.tsx
+++ b/src/components/NewTagDialog.tsx
@@ -46,7 +46,7 @@ export interface INewTagDialogProps {
   pastCommits: Git.ISingleCommitInfo[];
 
   /**
-   * Extension logger
+   * Extension logger.
    */
   logger: Logger;
 
@@ -69,6 +69,11 @@ export interface INewTagDialogProps {
    * The application language translator.
    */
   trans: TranslationBundle;
+
+  /**
+   * Dialog box open from the context menu?
+   */
+  isSingleCommit: boolean;
 }
 
 /**
@@ -109,6 +114,11 @@ export interface IDialogBoxCommitGraphProps {
    * Update function for baseCommitId.
    */
   updateBaseCommitId: React.Dispatch<React.SetStateAction<string>>;
+
+  /**
+   * Dialog box open from the context menu.
+   */
+  isSingleCommit: boolean;
 }
 
 /**
@@ -183,6 +193,10 @@ export const DialogBoxCommitGraph: React.FunctionComponent<
   let isFilter;
   if (filter === '') {
     isFilter = true;
+  }
+
+  if (props.isSingleCommit === true) {
+    isFilter = false;
   }
 
   return (
@@ -457,6 +471,7 @@ export const NewTagDialogBox: React.FunctionComponent<INewTagDialogProps> = (
             filter={filterState}
             baseCommitId={baseCommitIdState}
             updateBaseCommitId={setBaseCommitIdState}
+            isSingleCommit={props.isSingleCommit}
           />
         }
       </div>

--- a/src/components/NewTagDialog.tsx
+++ b/src/components/NewTagDialog.tsx
@@ -441,27 +441,29 @@ export const NewTagDialogBox: React.FunctionComponent<INewTagDialogProps> = (
           title={props.trans.__('Enter a tag name')}
         />
         <p>{props.trans.__('Create tag pointing to…')}</p>
-        <div className={filterWrapperClass}>
-          <div className={filterClass}>
-            <input
-              className={filterInputClass}
-              type="text"
-              onChange={onFilterChange}
-              value={filterState}
-              placeholder={props.trans.__('Filter by commit message')}
-              title={props.trans.__('Filter history of commits menu')}
-            />
-            {filterState ? (
-              <button className={filterClearClass}>
-                <ClearIcon
-                  titleAccess={props.trans.__('Clear the current filter')}
-                  fontSize="small"
-                  onClick={resetFilter}
-                />
-              </button>
-            ) : null}
+        {props.isSingleCommit ? null : (
+          <div className={filterWrapperClass}>
+            <div className={filterClass}>
+              <input
+                className={filterInputClass}
+                type="text"
+                onChange={onFilterChange}
+                value={filterState}
+                placeholder={props.trans.__('Filter by commit message')}
+                title={props.trans.__('Filter history of commits menu')}
+              />
+              {filterState ? (
+                <button className={filterClearClass}>
+                  <ClearIcon
+                    titleAccess={props.trans.__('Clear the current filter')}
+                    fontSize="small"
+                    onClick={resetFilter}
+                  />
+                </button>
+              ) : null}
+            </div>
           </div>
-        </div>
+        )}
         {
           <DialogBoxCommitGraph
             pastCommits={props.pastCommits}

--- a/src/components/PastCommitNode.tsx
+++ b/src/components/PastCommitNode.tsx
@@ -118,6 +118,14 @@ export interface IPastCommitNodeProps {
    * @param el the <li> element representing a past commit
    */
   setRef: (el: HTMLLIElement) => void;
+
+  /**
+   * Callback to open a context menu on the commit
+   */
+  contextMenu?: (
+    commit: Git.ISingleCommitInfo,
+    event: React.MouseEvent
+  ) => void;
 }
 
 /**
@@ -162,6 +170,12 @@ export class PastCommitNode extends React.Component<
             : this.props.trans.__('View file changes')
         }
         onClick={event => this._onCommitClick(event, this.props.commit.commit)}
+        onContextMenu={
+          this.props.contextMenu &&
+          (event => {
+            this.props.contextMenu(this.props.commit, event);
+          })
+        }
       >
         <div className={commitHeaderClass}>
           <span className={commitHeaderItemClass}>

--- a/src/components/TagMenu.tsx
+++ b/src/components/TagMenu.tsx
@@ -265,6 +265,7 @@ export class TagMenu extends React.Component<ITagMenuProps, ITagMenuState> {
    * @returns React element
    */
   private _renderNewTagDialog(): React.ReactElement {
+    const isSingleCommit = false;
     return (
       <NewTagDialogBox
         pastCommits={this.props.pastCommits}
@@ -273,6 +274,7 @@ export class TagMenu extends React.Component<ITagMenuProps, ITagMenuState> {
         trans={this.props.trans}
         open={this.state.tagDialog}
         onClose={this._onNewTagDialogClose}
+        isSingleCommit={isSingleCommit}
       />
     );
   }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1373,7 +1373,8 @@ export enum ContextCommandIDs {
   gitIgnoreExtension = 'git:context-ignoreExtension',
   gitNoAction = 'git:no-action',
   openFileFromDiff = 'git:open-file-from-diff',
-  gitFileStashPop = 'git:context-stash-pop'
+  gitFileStashPop = 'git:context-stash-pop',
+  gitTagAdd = 'git:context-tag-add'
 }
 
 /**

--- a/ui-tests/tests/add-tag.spec.ts
+++ b/ui-tests/tests/add-tag.spec.ts
@@ -1,0 +1,73 @@
+import { expect, galata, test } from '@jupyterlab/galata';
+import path from 'path';
+import { extractFile } from './utils';
+
+const baseRepositoryPath = 'test-repository-dirty.tar.gz';
+test.use({ autoGoto: false, mockSettings: galata.DEFAULT_SETTINGS });
+
+test.describe('Add tag', () => {
+  test.beforeEach(async ({ baseURL, page, tmpPath }) => {
+    await extractFile(
+      baseURL,
+      path.resolve(__dirname, 'data', baseRepositoryPath),
+      path.join(tmpPath, 'repository.tar.gz')
+    );
+
+    // URL for merge conflict example repository
+    await page.goto(`tree/${tmpPath}/test-repository`);
+
+    await page.sidebar.openTab('jp-git-sessions');
+  });
+
+  test('should show Add Tag command on commit from history sidebar', async ({
+    page
+  }) => {
+    await page.click('button:has-text("History")');
+
+    const commits = page.locator('li[title="View commit details"]');
+
+    expect(await commits.count()).toBeGreaterThanOrEqual(2);
+
+    // Right click the first commit to open the context menu, with the add tag command
+    await page.getByText('master changes').click({ button: 'right' });
+
+    expect(await page.getByRole('menuitem', { name: 'Add Tag' })).toBeTruthy();
+  });
+
+  test('should open new tag dialog box', async ({ page }) => {
+    await page.click('button:has-text("History")');
+
+    const commits = page.locator('li[title="View commit details"]');
+
+    expect(await commits.count()).toBeGreaterThanOrEqual(2);
+
+    // Right click the first commit to open the context menu, with the add tag command
+    await page.getByText('master changes').click({ button: 'right' });
+
+    // Click on the add tag command
+    await page.getByRole('menuitem', { name: 'Add Tag' }).click();
+
+    expect(page.getByText('Create a Tag')).toBeTruthy();
+  });
+
+  test('should create new tag pointing to selected commit', async ({
+    page
+  }) => {
+    await page.click('button:has-text("History")');
+
+    const commits = page.locator('li[title="View commit details"]');
+    expect(await commits.count()).toBeGreaterThanOrEqual(2);
+
+    // Right click the first commit to open the context menu, with the add tag command
+    await page.getByText('master changes').click({ button: 'right' });
+
+    // Click on the add tag command
+    await page.getByRole('menuitem', { name: 'Add Tag' }).click();
+
+    // Create a test tag
+    await page.getByRole('textbox').fill('testTag');
+    await page.getByRole('button', { name: 'Create Tag' }).click();
+
+    expect(await page.getByText('testTag')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Created a context menu for the commits showing inside the HistorySidebar and added a new command `Add Tag`. 

Users can now right click on a commit and use the `Add Tag` command to directly create a tag pointing to that specific commit. Once clicking on the command, the `NewTagDialogBox` pops up, showing only the selected commit. 

[Screencast-Add-Tag-from-Context-Menu.webm](https://github.com/jupyterlab/jupyterlab-git/assets/91504950/b38fd172-7910-4f27-b2a1-11b930b85d91)
