### PR TITLE
Remove drive from path.

### DIFF
--- a/src/cloneCommand.tsx
+++ b/src/cloneCommand.tsx
@@ -69,7 +69,9 @@ export const gitCloneCommandPlugin: JupyterFrontEndPlugin<void> = {
               Operation.Clone,
               trans,
               {
-                path: fileBrowserModel.path,
+                path: app.serviceManager.contents.localPath(
+                  fileBrowserModel.path
+                ),
                 url: result.value.url,
                 versioning: result.value.versioning,
                 submodules: result.value.submodules
@@ -125,7 +127,13 @@ export const gitCloneCommandPlugin: JupyterFrontEndPlugin<void> = {
     );
 
     // Add the context menu items for the default file browser
-    addFileBrowserContextMenu(gitModel, fileBrowser, app.contextMenu, trans);
+    addFileBrowserContextMenu(
+      gitModel,
+      fileBrowser,
+      app.serviceManager.contents,
+      app.contextMenu,
+      trans
+    );
 
     if (palette) {
       // Add the commands to the command palette

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -210,7 +210,9 @@ export function addCommands(
       'Create an empty Git repository or reinitialize an existing one'
     ),
     execute: async () => {
-      const currentPath = fileBrowserModel.path;
+      const currentPath = app.serviceManager.contents.localPath(
+        fileBrowserModel.path
+      );
       const result = await showDialog({
         title: trans.__('Initialize a Repository'),
         body: trans.__('Do you really want to make this directory a Git Repo?'),
@@ -1314,7 +1316,9 @@ export function addCommands(
                 change.newValue?.last_modified ?? 0
               ).valueOf();
               if (
-                change.newValue?.path === fullPath &&
+                app.serviceManager.contents.localPath(
+                  change.newValue?.path ?? ''
+                ) === fullPath &&
                 model.challenger.updateAt !== updateAt
               ) {
                 model.challenger = {
@@ -1794,6 +1798,7 @@ export function addHistoryMenuItems(
 export function addFileBrowserContextMenu(
   model: IGitExtension,
   filebrowser: FileBrowser,
+  contents: Contents.IManager,
   contextMenu: ContextMenuSvg,
   trans: TranslationBundle
 ): void {
@@ -1809,11 +1814,12 @@ export function addFileBrowserContextMenu(
     const statuses = new Set<Git.Status>(
       // @ts-expect-error file cannot be undefined or null
       items
-        .map(item =>
-          model.pathRepository === null
+        .map(item => {
+          const itemPath = contents.localPath(item.path);
+          return model.pathRepository === null
             ? undefined
-            : model.getFile(item.path)?.status
-        )
+            : model.getFile(itemPath)?.status;
+        })
         .filter(status => typeof status !== 'undefined')
     );
 


### PR DESCRIPTION
Drop drive from path before passing it to the git extension.

Fixes #1282

> Using the extension with a drive that is not a physical drive will still fail as git commands won't run on it.