### PR TITLE
Fix jitter in git panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 ### Documentation improvements
 
-- add kentarolim10 as a contributor for code [#1297](https://github.com/jupyterlab/jupyterlab-git/pull/1297) ([@allcontributors](https://github.com/allcontributors))
+- add kentarolim10 as a contributor for code [#1297](https://github.com/jupyterlab/jupyterlab-git/pull/1297) ([@allcontributors](https://github.com/all-contributors))
 - Add constrain in install instructions [#1271](https://github.com/jupyterlab/jupyterlab-git/pull/1271) ([@fcollonval](https://github.com/fcollonval))
 - Hotfix/dependency update [#1249](https://github.com/jupyterlab/jupyterlab-git/pull/1249) ([@mfakaehler](https://github.com/mfakaehler))
 

--- a/src/style/GitStageStyle.ts
+++ b/src/style/GitStageStyle.ts
@@ -12,6 +12,8 @@ export const sectionAreaStyle = style(
     borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
     letterSpacing: '1px',
     fontSize: '12px',
+    overflowY: 'hidden',
+    height: '16px',
 
     $nest: {
       '&:hover': {

--- a/src/style/GitStashStyle.ts
+++ b/src/style/GitStashStyle.ts
@@ -20,7 +20,8 @@ export const sectionHeaderLabelStyle = style({
   overflow: 'hidden',
   whiteSpace: 'nowrap',
   display: 'flex',
-  justifyContent: 'space-between'
+  justifyContent: 'space-between',
+  alignSelf: 'flex-start'
 });
 
 export const sectionButtonContainerStyle = style({


### PR DESCRIPTION
Fixes #1296

Adds:
- `overflow-y: hidden` to hide scrollbars
- `height: 16px` to prevent jitter in Staged/Changed/Untracked
- `align-self: flex-start` to prevent jitter in Stash


| Before | After |
|--|--|
| ![before](https://github.com/jupyterlab/jupyterlab-git/assets/5832902/f4276720-9812-4b37-bfad-da0b62b9238f) | ![after](https://github.com/jupyterlab/jupyterlab-git/assets/5832902/ee9334b7-56c6-47aa-9a2c-3091834a392e) |