### PR TITLE
Add link to ignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,4 +169,4 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: https://www.linkedin.com/.*
+          ignore_links: "https://www.linkedin.com/.* https://fellowship.mlh.io/.*"


### PR DESCRIPTION
Trying to fix the failing `check-links` by ignoring https://fellowship.mlh.io/ for now.