### PR TITLE
Create new branch in new repo

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -1323,6 +1323,15 @@ class Git:
             }
         return {"code": code, "actions": actions}
 
+    async def _empty_commit_for_init(self, path):
+        cmd = ["git", "commit", "--allow-empty", "-m", '"First Commit"']
+
+        code, _, error = await self.__execute(cmd, cwd=path)
+
+        if code != 0:
+            return {"code": code, "command": " ".join(cmd), "message": error}
+        return {"code": code}
+
     async def _maybe_run_actions(self, name, cwd):
         code = 0
         actions = None

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -715,6 +715,9 @@ class GitInitHandler(GitHandler):
         """
         body = await self.git.init(self.url2localpath(path))
 
+        if body["code"] == 0:
+            body = await self.git._empty_commit_for_init(self.url2localpath(path))
+
         if body["code"] != 0:
             self.set_status(500)
 


### PR DESCRIPTION
Fix for #1354

The issue was caused because in the command for creating a new branch `git checkout -b <branch_name> <start_point>`, git tries to resolve `<start_point>` to a commit hash, but there isn't one until a commit is made, so I added an empty commit to the `init` endpoint. 

![new_branch](https://github.com/user-attachments/assets/1942482f-b0e5-4e09-b3a8-57a6d92772ec)
