### PR TITLE
Fix switching branches by adding double dash separator

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -312,7 +312,7 @@ class Git:
             elif base == "INDEX":
                 cmd = ["git", "diff", "--staged", remote, "--name-only", "-z"]
             else:
-                cmd = ["git", "diff", base, remote, "--name-only", "-z"]
+                cmd = ["git", "diff", base, remote, "--name-only", "-z", "--"]
         else:
             raise tornado.web.HTTPError(
                 400, "Either single_commit or (base and remote) must be provided"

--- a/jupyterlab_git/tests/test_diff.py
+++ b/jupyterlab_git/tests/test_diff.py
@@ -112,7 +112,7 @@ async def test_changed_files_two_commits():
 
         # Then
         mock_execute.assert_called_once_with(
-            ["git", "diff", "HEAD", "origin/HEAD", "--name-only", "-z"],
+            ["git", "diff", "HEAD", "origin/HEAD", "--name-only", "-z", "--"],
             cwd="test-path",
             timeout=20,
             env=None,
@@ -136,7 +136,7 @@ async def test_changed_files_git_diff_error():
 
         # Then
         mock_execute.assert_called_once_with(
-            ["git", "diff", "HEAD", "origin/HEAD", "--name-only", "-z"],
+            ["git", "diff", "HEAD", "origin/HEAD", "--name-only", "-z", "--"],
             cwd="test-path",
             timeout=20,
             env=None,


### PR DESCRIPTION
This PR addresses #1318 by treating the parameters as Git objects and not files (e.g., [Double Hyphens in Git Diff](https://vincenttam.github.io/blog/2014/08/07/double-hyphens-in-git-diff/)). 

I'm happy to provide some tests to ensure the correctness of the functionality (testing it manually works, though).
However, the test base contains a lot of mocks. It would be awesome if you could point out some tests that actually rely on the created Git repositories and the underlying files.


