### PR TITLE
Add environment variable inheritance to git status and branch API calls

### DIFF
--- a/packages/core/jupyterlab_git_core/git.py
+++ b/packages/core/jupyterlab_git_core/git.py
@@ -522,7 +522,7 @@ class Git:
         Execute git status command & return the result.
         """
         cmd = ["git", "status", "--porcelain", "-b", "-u", "-z"]
-        code, status, my_error = await self.__execute(cmd, cwd=path)
+        code, status, my_error = await self.__execute(cmd, cwd=path, env=os.environ.copy())
 
         if code != 0:
             return {
@@ -877,7 +877,7 @@ class Git:
             "refs/heads/",
         ]
 
-        code, output, error = await self.__execute(cmd, cwd=path)
+        code, output, error = await self.__execute(cmd, cwd=path, env=os.environ.copy())
         if code != 0:
             return {"code": code, "command": " ".join(cmd), "message": error}
 
@@ -943,7 +943,7 @@ class Git:
             "refs/remotes/",
         ]
 
-        code, output, error = await self.__execute(cmd, cwd=path)
+        code, output, error = await self.__execute(cmd, cwd=path, env=os.environ.copy())
         if code != 0:
             return {"code": code, "command": " ".join(cmd), "message": error}
 

--- a/packages/core/jupyterlab_git_core/git.py
+++ b/packages/core/jupyterlab_git_core/git.py
@@ -522,7 +522,9 @@ class Git:
         Execute git status command & return the result.
         """
         cmd = ["git", "status", "--porcelain", "-b", "-u", "-z"]
-        code, status, my_error = await self.__execute(cmd, cwd=path, env=os.environ.copy())
+        code, status, my_error = await self.__execute(
+            cmd, cwd=path, env=os.environ.copy()
+        )
 
         if code != 0:
             return {

--- a/packages/core/jupyterlab_git_core/git.py
+++ b/packages/core/jupyterlab_git_core/git.py
@@ -879,9 +879,7 @@ class Git:
             "refs/heads/",
         ]
 
-        code, output, error = await self.__execute(
-            cmd, cwd=path, env=os.environ.copy()
-        )
+        code, output, error = await self.__execute(cmd, cwd=path, env=os.environ.copy())
         if code != 0:
             return {"code": code, "command": " ".join(cmd), "message": error}
 
@@ -947,9 +945,7 @@ class Git:
             "refs/remotes/",
         ]
 
-        code, output, error = await self.__execute(
-            cmd, cwd=path, env=os.environ.copy()
-        )
+        code, output, error = await self.__execute(cmd, cwd=path, env=os.environ.copy())
         if code != 0:
             return {"code": code, "command": " ".join(cmd), "message": error}
 

--- a/packages/core/jupyterlab_git_core/git.py
+++ b/packages/core/jupyterlab_git_core/git.py
@@ -879,7 +879,9 @@ class Git:
             "refs/heads/",
         ]
 
-        code, output, error = await self.__execute(cmd, cwd=path, env=os.environ.copy())
+        code, output, error = await self.__execute(
+            cmd, cwd=path, env=os.environ.copy()
+        )
         if code != 0:
             return {"code": code, "command": " ".join(cmd), "message": error}
 
@@ -945,7 +947,9 @@ class Git:
             "refs/remotes/",
         ]
 
-        code, output, error = await self.__execute(cmd, cwd=path, env=os.environ.copy())
+        code, output, error = await self.__execute(
+            cmd, cwd=path, env=os.environ.copy()
+        )
         if code != 0:
             return {"code": code, "command": " ".join(cmd), "message": error}
 

--- a/packages/core/tests/test_branch.py
+++ b/packages/core/tests/test_branch.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import ANY, call, patch
 
 import pytest
 
@@ -743,7 +743,7 @@ async def test_branch_success():
                         "refs/heads/",
                     ],
                     cwd=str(Path("/bin") / "test_curr_path"),
-                    env=None,
+                    env=ANY,
                     username=None,
                     password=None,
                     is_binary=False,
@@ -757,7 +757,7 @@ async def test_branch_success():
                         "refs/remotes/",
                     ],
                     cwd=str(Path("/bin") / "test_curr_path"),
-                    env=None,
+                    env=ANY,
                     username=None,
                     password=None,
                     is_binary=False,
@@ -886,7 +886,7 @@ async def test_branch_success_detached_head():
                         "refs/heads/",
                     ],
                     cwd=str(Path("/bin") / "test_curr_path"),
-                    env=None,
+                    env=ANY,
                     username=None,
                     password=None,
                     is_binary=False,
@@ -918,7 +918,7 @@ async def test_branch_success_detached_head():
                         "refs/remotes/",
                     ],
                     cwd=str(Path("/bin") / "test_curr_path"),
-                    env=None,
+                    env=ANY,
                     username=None,
                     password=None,
                     is_binary=False,
@@ -1020,7 +1020,7 @@ async def test_branch_success_rebasing():
                         "refs/heads/",
                     ],
                     cwd=str(Path("/bin") / "test_curr_path"),
-                    env=None,
+                    env=ANY,
                     username=None,
                     password=None,
                     is_binary=False,
@@ -1052,7 +1052,7 @@ async def test_branch_success_rebasing():
                         "refs/remotes/",
                     ],
                     cwd=str(Path("/bin") / "test_curr_path"),
-                    env=None,
+                    env=ANY,
                     username=None,
                     password=None,
                     is_binary=False,

--- a/packages/core/tests/test_branch.py
+++ b/packages/core/tests/test_branch.py
@@ -797,7 +797,7 @@ async def test_branch_failure():
         mock_execute.assert_called_once_with(
             expected_cmd,
             cwd=str(Path("/bin") / "test_curr_path"),
-            env=None,
+            env=ANY,
             username=None,
             password=None,
             is_binary=False,

--- a/packages/core/tests/test_status.py
+++ b/packages/core/tests/test_status.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, patch
+from unittest.mock import ANY, call, patch
 
 import pytest
 
@@ -368,7 +368,7 @@ async def test_status(tmp_path, output, diff_output, expected):
             call(
                 ["git", "status", "--porcelain", "-b", "-u", "-z"],
                 cwd=str(repository),
-                env=None,
+                env=ANY,
                 username=None,
                 password=None,
                 is_binary=False,


### PR DESCRIPTION
Several git subprocess calls in the status and branch APIs were not inheriting the parent process environment variables, which could cause git commands to fail when custom environment configurations are needed (e.g., custom PATH, GIT_*
  variables, proxy settings, or authentication tokens).


Added env=os.environ.copy() parameter to the following subprocess calls:

-   Status API (git.py:status() method):
-   Branch API:

Issue: https://github.com/jupyterlab/jupyterlab-git/issues/1416