### PR TITLE
Drop Python 3.9 on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         architecture: 'x64'
     - uses: actions/download-artifact@v4.1.7
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.13']
+        python-version: ['3.10', '3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/jupyterlab_git/tests/conftest.py
+++ b/jupyterlab_git/tests/conftest.py
@@ -7,16 +7,16 @@ import os
 import shlex
 import shutil
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from subprocess import check_call
-from typing import Callable, Dict, List, Union
 
 from pytest import fixture, skip
 
 FILES_PATH = Path(__file__).parent / "files"
 
 
-def call(cmd: Union[str, List[str]], cwd: Union[str, Path, None] = None) -> int:
+def call(cmd: str | list[str], cwd: str | Path | None = None) -> int:
     """Call a command
     if str, split into command list
     """

--- a/jupyterlab_git/tests/test_branch.py
+++ b/jupyterlab_git/tests/test_branch.py
@@ -5,8 +5,6 @@ import pytest
 
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.parametrize(
     "branch,expected",
@@ -29,7 +27,7 @@ def test_is_remote_branch(branch, expected):
 async def test_get_current_branch_success():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, "feature-foo", ""))
+        mock_execute.return_value = (0, "feature-foo", "")
 
         # When
         actual_response = await Git().get_current_branch(
@@ -59,12 +57,10 @@ async def test_checkout_branch_noref_success():
 
     with patch("jupyterlab_git.git.execute") as mock_execute:
         with patch.object(
-            Git, "_get_branch_reference", return_value=maybe_future(None)
+            Git, "_get_branch_reference", return_value=None
         ) as mock__get_branch_reference:
             # Given
-            mock_execute.return_value = maybe_future(
-                (rc, stdout_message, stderr_message)
-            )
+            mock_execute.return_value = (rc, stdout_message, stderr_message)
 
             # When
             actual_response = await Git().checkout_branch(
@@ -99,12 +95,10 @@ async def test_checkout_branch_noref_failure():
     rc = 1
     with patch("jupyterlab_git.git.execute") as mock_execute:
         with patch.object(
-            Git, "_get_branch_reference", return_value=maybe_future(None)
+            Git, "_get_branch_reference", return_value=None
         ) as mock__get_branch_reference:
             # Given
-            mock_execute.return_value = maybe_future(
-                (rc, stdout_message, stderr_message)
-            )
+            mock_execute.return_value = (rc, stdout_message, stderr_message)
 
             # When
             actual_response = await Git().checkout_branch(
@@ -145,12 +139,10 @@ async def test_checkout_branch_remoteref_success():
         with patch.object(
             Git,
             "_get_branch_reference",
-            return_value=maybe_future("refs/remotes/remote_branch"),
+            return_value="refs/remotes/remote_branch",
         ) as mock__get_branch_reference:
             # Given
-            mock_execute.return_value = maybe_future(
-                (rc, stdout_message, stderr_message)
-            )
+            mock_execute.return_value = (rc, stdout_message, stderr_message)
 
             # When
             actual_response = await Git().checkout_branch(
@@ -188,12 +180,10 @@ async def test_checkout_branch_headsref_failure():
         with patch.object(
             Git,
             "_get_branch_reference",
-            return_value=maybe_future("refs/heads/local_branch"),
+            return_value="refs/heads/local_branch",
         ) as mock__get_branch_reference:
             # Given
-            mock_execute.return_value = maybe_future(
-                (rc, stdout_message, stderr_message)
-            )
+            mock_execute.return_value = (rc, stdout_message, stderr_message)
 
             # When
             actual_response = await Git().checkout_branch(
@@ -231,12 +221,10 @@ async def test_checkout_branch_headsref_success():
         with patch.object(
             Git,
             "_get_branch_reference",
-            return_value=maybe_future("refs/heads/local_branch"),
+            return_value="refs/heads/local_branch",
         ):
             # Given
-            mock_execute.return_value = maybe_future(
-                (rc, stdout_message, stderr_message)
-            )
+            mock_execute.return_value = (rc, stdout_message, stderr_message)
 
             # When
             actual_response = await Git().checkout_branch(
@@ -271,12 +259,10 @@ async def test_checkout_branch_remoteref_failure():
         with patch.object(
             Git,
             "_get_branch_reference",
-            return_value=maybe_future("refs/remotes/remote_branch"),
+            return_value="refs/remotes/remote_branch",
         ):
             # Given
-            mock_execute.return_value = maybe_future(
-                (rc, stdout_message, stderr_message)
-            )
+            mock_execute.return_value = (rc, stdout_message, stderr_message)
 
             # When
             actual_response = await Git().checkout_branch(
@@ -309,7 +295,7 @@ async def test_get_branch_reference_success():
         branch = "test-branch"
         reference = "refs/remotes/origin/test_branch"
 
-        mock_execute.return_value = maybe_future((0, reference, ""))
+        mock_execute.return_value = (0, reference, "")
 
         # When
         actual_response = await Git()._get_branch_reference(
@@ -336,14 +322,12 @@ async def test_get_branch_reference_failure():
         branch = "test-branch"
         reference = "test-branch"
         # Given
-        mock_execute.return_value = maybe_future(
-            (
-                128,
-                reference,
-                "fatal: ambiguous argument '{}': unknown revision or path not in the working tree.".format(
-                    branch
-                ),
-            )
+        mock_execute.return_value = (
+            128,
+            reference,
+            "fatal: ambiguous argument '{}': unknown revision or path not in the working tree.".format(
+                branch
+            ),
         )
 
         # When
@@ -368,12 +352,10 @@ async def test_get_branch_reference_failure():
 async def test_get_current_branch_failure():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future(
-            (
-                128,
-                "",
-                "fatal: Not a git repository (or any of the parent directories): .git",
-            )
+        mock_execute.return_value = (
+            128,
+            "",
+            "fatal: Not a git repository (or any of the parent directories): .git",
         )
 
         # When
@@ -407,7 +389,7 @@ async def test_get_current_branch_detached_success():
             "  remotes/origin/feature-foo",
             "  remotes/origin/HEAD",
         ]
-        mock_execute.return_value = maybe_future((0, "\n".join(process_output), ""))
+        mock_execute.return_value = (0, "\n".join(process_output), "")
 
         # When
         actual_response = await Git()._get_current_branch_detached(
@@ -431,12 +413,10 @@ async def test_get_current_branch_detached_success():
 async def test_get_current_branch_detached_failure():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future(
-            (
-                128,
-                "",
-                "fatal: Not a git repository (or any of the parent directories): .git",
-            )
+        mock_execute.return_value = (
+            128,
+            "",
+            "fatal: Not a git repository (or any of the parent directories): .git",
         )
 
         # When
@@ -477,8 +457,8 @@ async def test_get_upstream_branch_success(branch, upstream, remotename):
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.side_effect = [
-            maybe_future((0, remotename + "/" + upstream, "")),
-            maybe_future((0, remotename, "")),
+            (0, remotename + "/" + upstream, ""),
+            (0, remotename, ""),
         ]
 
         # When
@@ -545,7 +525,7 @@ async def test_get_upstream_branch_success(branch, upstream, remotename):
 async def test_get_upstream_branch_failure(outputs, message):
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future(outputs)
+        mock_execute.return_value = outputs
 
         # When
         response = await Git().get_upstream_branch(
@@ -580,7 +560,7 @@ async def test_get_upstream_branch_failure(outputs, message):
 async def test_get_tag_success():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, "v0.3.0", ""))
+        mock_execute.return_value = (0, "v0.3.0", "")
 
         # When
         actual_response = await Git()._get_tag(
@@ -606,13 +586,11 @@ async def test_get_tag_failure():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.side_effect = [
-            maybe_future((128, "", "fatal: Not a valid object name blah")),
-            maybe_future(
-                (
-                    128,
-                    "",
-                    "fatal: No tags can describe '01234567899999abcdefghijklmnopqrstuvwxyz'.",
-                )
+            (128, "", "fatal: Not a valid object name blah"),
+            (
+                128,
+                "",
+                "fatal: No tags can describe '01234567899999abcdefghijklmnopqrstuvwxyz'.",
             ),
         ]
 
@@ -670,8 +648,10 @@ async def test_get_tag_failure():
 async def test_no_tags():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future(
-            (128, "", "fatal: No names found, cannot describe anything.\n")
+        mock_execute.return_value = (
+            128,
+            "",
+            "fatal: No names found, cannot describe anything.\n",
         )
 
         # When
@@ -708,9 +688,9 @@ async def test_branch_success():
 
         mock_execute.side_effect = [
             # Response for get all refs/heads
-            maybe_future((0, "\n".join(process_output_heads), "")),
+            (0, "\n".join(process_output_heads), ""),
             # Response for get all refs/remotes
-            maybe_future((0, "\n".join(process_output_remotes), "")),
+            (0, "\n".join(process_output_remotes), ""),
         ]
 
         expected_response = {
@@ -820,12 +800,10 @@ async def test_branch_failure():
             "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)",
             "refs/heads/",
         ]
-        mock_execute.return_value = maybe_future(
-            (
-                128,
-                "",
-                "fatal: Not a git repository (or any of the parent directories): .git",
-            )
+        mock_execute.return_value = (
+            128,
+            "",
+            "fatal: Not a git repository (or any of the parent directories): .git",
         )
         expected_response = {
             "code": 128,
@@ -868,13 +846,13 @@ async def test_branch_success_detached_head():
 
         mock_execute.side_effect = [
             # Response for get all refs/heads
-            maybe_future((0, "\n".join(process_output_heads), "")),
+            (0, "\n".join(process_output_heads), ""),
             # Response for get current branch
-            maybe_future((128, "", "fatal: ref HEAD is not a symbolic ref")),
+            (128, "", "fatal: ref HEAD is not a symbolic ref"),
             # Response for get current branch detached
-            maybe_future((0, "\n".join(detached_head_output), "")),
+            (0, "\n".join(detached_head_output), ""),
             # Response for get all refs/remotes
-            maybe_future((0, "\n".join(process_output_remotes), "")),
+            (0, "\n".join(process_output_remotes), ""),
         ]
 
         expected_response = {
@@ -998,13 +976,13 @@ async def test_branch_success_rebasing():
 
         mock_execute.side_effect = [
             # Response for get all refs/heads
-            maybe_future((0, "\n".join(process_output_heads), "")),
+            (0, "\n".join(process_output_heads), ""),
             # Response for get current branch
-            maybe_future((128, "", "fatal: ref HEAD is not a symbolic ref")),
+            (128, "", "fatal: ref HEAD is not a symbolic ref"),
             # Response for get current branch detached
-            maybe_future((0, "\n".join(detached_head_output), "")),
+            (0, "\n".join(detached_head_output), ""),
             # Response for get all refs/remotes
-            maybe_future((0, "\n".join(process_output_remotes), "")),
+            (0, "\n".join(process_output_remotes), ""),
         ]
 
         expected_response = {

--- a/jupyterlab_git/tests/test_clone.py
+++ b/jupyterlab_git/tests/test_clone.py
@@ -7,8 +7,6 @@ import pytest
 from jupyterlab_git import JupyterLabGit
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.asyncio
 async def test_git_clone_success():
@@ -16,7 +14,7 @@ async def test_git_clone_success():
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
             output = "output"
-            mock_execute.return_value = maybe_future((0, output, "error"))
+            mock_execute.return_value = (0, output, "error")
 
             # When
             actual_response = await Git().clone(
@@ -46,7 +44,7 @@ async def test_git_download_success(tmp_path):
 
             def create_fake_git_repo(*args, **kwargs):
                 git_folder.mkdir(parents=True)
-                return maybe_future((0, output, "error"))
+                return (0, output, "error")
 
             mock_execute.side_effect = create_fake_git_repo
 
@@ -78,7 +76,7 @@ async def test_git_submodules_success(tmp_path):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
             output = "output"
-            mock_execute.return_value = maybe_future((0, output, "error"))
+            mock_execute.return_value = (0, output, "error")
 
             # When
             actual_response = await Git().clone(
@@ -110,8 +108,10 @@ async def test_git_clone_failure_from_git():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = maybe_future(
-                (128, "test_output", "fatal: Not a git repository")
+            mock_execute.return_value = (
+                128,
+                "test_output",
+                "fatal: Not a git repository",
             )
 
             # When
@@ -141,7 +141,7 @@ async def test_git_clone_with_auth_success():
         with patch("jupyterlab_git.git.execute") as mock_authentication:
             # Given
             output = "output"
-            mock_authentication.return_value = maybe_future((0, output, ""))
+            mock_authentication.return_value = (0, output, "")
 
             # When
             auth = {"username": "asdf", "password": "qwerty"}
@@ -172,8 +172,10 @@ async def test_git_clone_with_auth_wrong_repo_url_failure_from_git():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_authentication:
             # Given
-            mock_authentication.return_value = maybe_future(
-                (128, "", "fatal: repository 'ghjkhjkl' does not exist")
+            mock_authentication.return_value = (
+                128,
+                "",
+                "fatal: repository 'ghjkhjkl' does not exist",
             )
 
             # When
@@ -208,12 +210,10 @@ async def test_git_clone_with_auth_auth_failure_from_git():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_authentication:
             # Given
-            mock_authentication.return_value = maybe_future(
-                (
-                    128,
-                    "",
-                    "remote: Invalid username or password.\r\nfatal: Authentication failed for 'ghjkhjkl'",
-                )
+            mock_authentication.return_value = (
+                128,
+                "",
+                "remote: Invalid username or password.\r\nfatal: Authentication failed for 'ghjkhjkl'",
             )
 
             # When
@@ -251,9 +251,9 @@ async def test_git_clone_with_auth_and_cache_credentials():
             credential_helper = default_config.credential_helper
             test_path = "test_curr_path"
             mock_execute.side_effect = [
-                maybe_future((0, "", "")),
-                maybe_future((0, "", "")),
-                maybe_future((0, "", "")),
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
             ]
             # When
             auth = {
@@ -317,8 +317,8 @@ async def test_git_clone_with_auth_and_cache_credentials_and_existing_credential
         default_config = JupyterLabGit()
         test_path = str(Path("/bin") / "test_curr_path")
         mock_execute.side_effect = [
-            maybe_future((0, "credential.helper=something", "")),
-            maybe_future((0, "", "")),
+            (0, "credential.helper=something", ""),
+            (0, "", ""),
         ]
         # When
         auth = {"username": "asdf", "password": "qwerty", "cache_credentials": True}

--- a/jupyterlab_git/tests/test_config.py
+++ b/jupyterlab_git/tests/test_config.py
@@ -3,14 +3,14 @@ from unittest.mock import call, patch
 
 from jupyterlab_git.handlers import NAMESPACE
 
-from .testutils import maybe_future
-
 
 @patch("jupyterlab_git.git.execute")
 async def test_git_get_config_success(mock_execute, jp_fetch, jp_root_dir):
     # Given
-    mock_execute.return_value = maybe_future(
-        (0, "user.name=John Snow\nuser.email=john.snow@iscoming.com", "")
+    mock_execute.return_value = (
+        0,
+        "user.name=John Snow\nuser.email=john.snow@iscoming.com",
+        "",
     )
     local_path = jp_root_dir / "test_path"
 
@@ -56,7 +56,7 @@ async def test_git_get_config_multiline(mock_execute, jp_fetch, jp_root_dir):
         '";   };f\n'
         'alias.topic-start=!f(){     topic_branch="$1";     git topic-create "$topic_branch";     git topic-push;   };f'
     )
-    mock_execute.return_value = maybe_future((0, output, ""))
+    mock_execute.return_value = (0, output, "")
     local_path = jp_root_dir / "test_path"
 
     # When
@@ -105,7 +105,7 @@ async def test_git_get_config_accepted_multiline(mock_execute, jp_fetch, jp_root
         '";   };f\n'
         'alias.topic-start=!f(){     topic_branch="$1";     git topic-create "$topic_branch";     git topic-push;   };f'
     )
-    mock_execute.return_value = maybe_future((0, output, ""))
+    mock_execute.return_value = (0, output, "")
     local_path = jp_root_dir / "test_path"
 
     # When
@@ -142,7 +142,7 @@ async def test_git_get_config_accepted_multiline(mock_execute, jp_fetch, jp_root
 @patch("jupyterlab_git.git.execute")
 async def test_git_set_config_success(mock_execute, jp_fetch, jp_root_dir):
     # Given
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
     local_path = jp_root_dir / "test_path"
 
     # When

--- a/jupyterlab_git/tests/test_detailed_log.py
+++ b/jupyterlab_git/tests/test_detailed_log.py
@@ -5,8 +5,6 @@ import pytest
 
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.asyncio
 async def test_detailed_log():
@@ -25,9 +23,7 @@ async def test_detailed_log():
             "-\t-\tbinary_file.png",
         ]
 
-        mock_execute.return_value = maybe_future(
-            (0, "\x00".join(process_output) + "\x00", "")
-        )
+        mock_execute.return_value = (0, "\x00".join(process_output) + "\x00", "")
 
         expected_response = {
             "code": 0,

--- a/jupyterlab_git/tests/test_diff.py
+++ b/jupyterlab_git/tests/test_diff.py
@@ -9,8 +9,6 @@ import tornado
 
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.asyncio
 async def test_changed_files_invalid_input():
@@ -24,7 +22,7 @@ async def test_changed_files_invalid_input():
 async def test_changed_files_single_commit():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, "file1.ipynb\x00file2.py\x00", ""))
+        mock_execute.return_value = (0, "file1.ipynb\x00file2.py\x00", "")
 
         # When
         actual_response = await Git().changed_files(
@@ -55,7 +53,7 @@ async def test_changed_files_single_commit():
 async def test_changed_files_working_tree():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, "file1.ipynb\x00file2.py", ""))
+        mock_execute.return_value = (0, "file1.ipynb\x00file2.py", "")
 
         # When
         actual_response = await Git().changed_files(
@@ -79,7 +77,7 @@ async def test_changed_files_working_tree():
 async def test_changed_files_index():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, "file1.ipynb\x00file2.py", ""))
+        mock_execute.return_value = (0, "file1.ipynb\x00file2.py", "")
 
         # When
         actual_response = await Git().changed_files(
@@ -103,7 +101,7 @@ async def test_changed_files_index():
 async def test_changed_files_two_commits():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, "file1.ipynb\x00file2.py", ""))
+        mock_execute.return_value = (0, "file1.ipynb\x00file2.py", "")
 
         # When
         actual_response = await Git().changed_files(
@@ -244,7 +242,7 @@ async def test_changed_files_git_diff_error():
 async def test_is_binary_file(args, cli_result, cmd, expected):
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future(cli_result)
+        mock_execute.return_value = cli_result
 
         if isinstance(expected, type) and issubclass(expected, Exception):
             with pytest.raises(expected):

--- a/jupyterlab_git/tests/test_fetch.py
+++ b/jupyterlab_git/tests/test_fetch.py
@@ -6,14 +6,12 @@ import pytest
 from jupyterlab_git import JupyterLabGit
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.asyncio
 async def test_git_fetch_success():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, "", ""))
+        mock_execute.return_value = (0, "", "")
 
         # When
         actual_response = await Git().fetch(path="test_path")
@@ -35,7 +33,7 @@ async def test_git_fetch_success():
 async def test_git_fetch_fail():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((1, "", "error"))
+        mock_execute.return_value = (1, "", "error")
 
         # When
         actual_response = await Git().fetch(path="test_path")
@@ -62,7 +60,7 @@ async def test_git_fetch_fail():
 async def test_git_fetch_with_auth_success():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, "", ""))
+        mock_execute.return_value = (0, "", "")
 
         # When
         actual_response = await Git().fetch(
@@ -87,12 +85,10 @@ async def test_git_fetch_with_auth_fail():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         error_message = "remote: Invalid username or password.\r\nfatal: Authentication failed for 'test_repo'"
-        mock_execute.return_value = maybe_future(
-            (
-                128,
-                "",
-                error_message,
-            )
+        mock_execute.return_value = (
+            128,
+            "",
+            error_message,
         )
 
         # When
@@ -130,9 +126,9 @@ async def test_git_fetch_with_auth_and_cache_credentials():
             credential_helper = default_config.credential_helper
             test_path = "test_path"
             mock_execute.side_effect = [
-                maybe_future((0, "", "")),
-                maybe_future((0, "", "")),
-                maybe_future((0, "", "")),
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
             ]
             # When
             actual_response = await Git(config=default_config).fetch(
@@ -194,8 +190,8 @@ async def test_git_fetch_with_auth_and_cache_credentials_and_existing_credential
         default_config = JupyterLabGit()
         test_path = "test_path"
         mock_execute.side_effect = [
-            maybe_future((0, "credential.helper=something", "")),
-            maybe_future((0, "", "")),
+            (0, "credential.helper=something", ""),
+            (0, "", ""),
         ]
         # When
         actual_response = await Git(config=default_config).fetch(

--- a/jupyterlab_git/tests/test_handlers.py
+++ b/jupyterlab_git/tests/test_handlers.py
@@ -7,7 +7,7 @@ import tornado
 from jupyterlab_git.git import Git
 from jupyterlab_git.handlers import NAMESPACE, setup_handlers, GitHandler
 
-from .testutils import assert_http_error, maybe_future
+from .testutils import assert_http_error
 from tornado.httpclient import HTTPClientError
 
 from pathlib import Path
@@ -47,10 +47,10 @@ async def test_all_history_handler_localbranch(mock_git, jp_fetch, jp_root_dir):
 
     local_path = jp_root_dir / "test_path"
 
-    mock_git.show_top_level.return_value = maybe_future(show_top_level)
-    mock_git.branch.return_value = maybe_future(branch)
-    mock_git.log.return_value = maybe_future(log)
-    mock_git.status.return_value = maybe_future(status)
+    mock_git.show_top_level.return_value = show_top_level
+    mock_git.branch.return_value = branch
+    mock_git.log.return_value = log
+    mock_git.status.return_value = status
 
     # When
     body = {"history_count": 25}
@@ -84,7 +84,7 @@ async def test_git_show_prefix(mock_execute, jp_fetch, jp_root_dir):
 
     local_path = jp_root_dir / "test_path"
 
-    mock_execute.return_value = maybe_future((0, str(path), ""))
+    mock_execute.return_value = (0, str(path), "")
 
     # When
     response = await jp_fetch(
@@ -116,7 +116,7 @@ async def test_git_show_prefix(mock_execute, jp_fetch, jp_root_dir):
 
 @patch("jupyterlab_git.git.execute")
 async def test_git_show_prefix_nested_directory(mock_execute, jp_fetch, jp_root_dir):
-    mock_execute.return_value = maybe_future((0, f"{jp_root_dir.name}/", ""))
+    mock_execute.return_value = (0, f"{jp_root_dir.name}/", "")
     # When
     response = await jp_fetch(
         NAMESPACE,
@@ -165,9 +165,7 @@ async def test_git_show_prefix_not_a_git_repo(mock_execute, jp_fetch, jp_root_di
     # Given
     local_path = jp_root_dir / "test_path"
 
-    mock_execute.return_value = maybe_future(
-        (128, "", "fatal: not a git repository (or any")
-    )
+    mock_execute.return_value = (128, "", "fatal: not a git repository (or any")
 
     # When
     response = await jp_fetch(
@@ -204,7 +202,7 @@ async def test_git_show_top_level(mock_execute, jp_fetch, jp_root_dir):
 
     local_path = jp_root_dir / "test_path"
 
-    mock_execute.return_value = maybe_future((0, str(path), ""))
+    mock_execute.return_value = (0, str(path), "")
 
     # When
     response = await jp_fetch(
@@ -239,9 +237,7 @@ async def test_git_show_top_level_not_a_git_repo(mock_execute, jp_fetch, jp_root
     # Given
     local_path = jp_root_dir / "test_path"
 
-    mock_execute.return_value = maybe_future(
-        (128, "", "fatal: not a git repository (or any")
-    )
+    mock_execute.return_value = (128, "", "fatal: not a git repository (or any")
 
     # When
     response = await jp_fetch(
@@ -321,7 +317,7 @@ async def test_branch_handler_localbranch(mock_git, jp_fetch, jp_root_dir):
         ],
     }
 
-    mock_git.branch.return_value = maybe_future(branch)
+    mock_git.branch.return_value = branch
 
     # When
     response = await jp_fetch(
@@ -341,7 +337,7 @@ async def test_log_handler(mock_git, jp_fetch, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
     log = {"code": 0, "commits": []}
-    mock_git.log.return_value = maybe_future(log)
+    mock_git.log.return_value = log
 
     # When
     body = {"history_count": 20}
@@ -362,7 +358,7 @@ async def test_log_handler_no_history_count(mock_git, jp_fetch, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
     log = {"code": 0, "commits": []}
-    mock_git.log.return_value = maybe_future(log)
+    mock_git.log.return_value = log
 
     # When
     response = await jp_fetch(
@@ -381,11 +377,13 @@ async def test_log_handler_no_history_count(mock_git, jp_fetch, jp_root_dir):
 async def test_push_handler_localbranch(mock_git, jp_fetch, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
-    mock_git.get_current_branch.return_value = maybe_future("localbranch")
-    mock_git.get_upstream_branch.return_value = maybe_future(
-        {"code": 0, "remote_short_name": ".", "remote_branch": "localbranch"}
-    )
-    mock_git.push.return_value = maybe_future({"code": 0})
+    mock_git.get_current_branch.return_value = "localbranch"
+    mock_git.get_upstream_branch.return_value = {
+        "code": 0,
+        "remote_short_name": ".",
+        "remote_branch": "localbranch",
+    }
+    mock_git.push.return_value = {"code": 0}
 
     # When
     response = await jp_fetch(
@@ -408,14 +406,14 @@ async def test_push_handler_localbranch(mock_git, jp_fetch, jp_root_dir):
 async def test_push_handler_remotebranch(mock_git, jp_fetch, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
-    mock_git.get_current_branch.return_value = maybe_future("foo/bar")
+    mock_git.get_current_branch.return_value = "foo/bar"
     upstream = {
         "code": 0,
         "remote_short_name": "origin/something",
         "remote_branch": "remote-branch-name",
     }
-    mock_git.get_upstream_branch.return_value = maybe_future(upstream)
-    mock_git.push.return_value = maybe_future({"code": 0})
+    mock_git.get_upstream_branch.return_value = upstream
+    mock_git.push.return_value = {"code": 0}
 
     # When
     response = await jp_fetch(
@@ -443,16 +441,16 @@ async def test_push_handler_remotebranch(mock_git, jp_fetch, jp_root_dir):
 async def test_push_handler_noupstream(mock_git, jp_fetch, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
-    mock_git.get_current_branch.return_value = maybe_future("foo")
+    mock_git.get_current_branch.return_value = "foo"
     upstream = {
         "code": 128,
         "command": "",
         "message": "fatal: no upstream configured for branch 'foo'",
     }
-    mock_git.get_upstream_branch.return_value = maybe_future(upstream)
-    mock_git.config.return_value = maybe_future({"options": dict()})
-    mock_git.remote_show.return_value = maybe_future({})
-    mock_git.push.return_value = maybe_future({"code": 0})
+    mock_git.get_upstream_branch.return_value = upstream
+    mock_git.config.return_value = {"options": dict()}
+    mock_git.remote_show.return_value = {}
+    mock_git.push.return_value = {"code": 0}
 
     # When
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
@@ -481,12 +479,12 @@ async def test_push_handler_multipleupstream(mock_git, jp_fetch, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
     remotes = ["origin", "upstream"]
-    mock_git.get_current_branch.return_value = maybe_future("foo")
+    mock_git.get_current_branch.return_value = "foo"
     upstream = {"code": -1, "message": "oups"}
-    mock_git.get_upstream_branch.return_value = maybe_future(upstream)
-    mock_git.config.return_value = maybe_future({"options": dict()})
-    mock_git.remote_show.return_value = maybe_future({"remotes": remotes})
-    mock_git.push.return_value = maybe_future({"code": 0})
+    mock_git.get_upstream_branch.return_value = upstream
+    mock_git.config.return_value = {"options": dict()}
+    mock_git.remote_show.return_value = {"remotes": remotes}
+    mock_git.push.return_value = {"code": 0}
 
     # When
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
@@ -514,12 +512,12 @@ async def test_push_handler_noupstream_unique_remote(mock_git, jp_fetch, jp_root
     # Given
     local_path = jp_root_dir / "test_path"
     remote = "origin"
-    mock_git.get_current_branch.return_value = maybe_future("foo")
+    mock_git.get_current_branch.return_value = "foo"
     upstream = {"code": -1, "message": "oups"}
-    mock_git.get_upstream_branch.return_value = maybe_future(upstream)
-    mock_git.config.return_value = maybe_future({"options": dict()})
-    mock_git.remote_show.return_value = maybe_future({"remotes": [remote]})
-    mock_git.push.return_value = maybe_future({"code": 0})
+    mock_git.get_upstream_branch.return_value = upstream
+    mock_git.config.return_value = {"options": dict()}
+    mock_git.remote_show.return_value = {"remotes": [remote]}
+    mock_git.push.return_value = {"code": 0}
 
     # When
     response = await jp_fetch(
@@ -550,14 +548,12 @@ async def test_push_handler_noupstream_pushdefault(mock_git, jp_fetch, jp_root_d
     # Given
     local_path = jp_root_dir / "test_path"
     remote = "rorigin"
-    mock_git.get_current_branch.return_value = maybe_future("foo")
+    mock_git.get_current_branch.return_value = "foo"
     upstream = {"code": -1, "message": "oups"}
-    mock_git.get_upstream_branch.return_value = maybe_future(upstream)
-    mock_git.config.return_value = maybe_future(
-        {"options": {"remote.pushdefault": remote}}
-    )
-    mock_git.remote_show.return_value = maybe_future({"remotes": [remote, "upstream"]})
-    mock_git.push.return_value = maybe_future({"code": 0})
+    mock_git.get_upstream_branch.return_value = upstream
+    mock_git.config.return_value = {"options": {"remote.pushdefault": remote}}
+    mock_git.remote_show.return_value = {"remotes": [remote, "upstream"]}
+    mock_git.push.return_value = {"code": 0}
 
     # When
     response = await jp_fetch(
@@ -589,12 +585,12 @@ async def test_push_handler_noupstream_pass_remote_nobranch(
 ):
     # Given
     local_path = jp_root_dir / "test_path"
-    mock_git.get_current_branch.return_value = maybe_future("foo")
+    mock_git.get_current_branch.return_value = "foo"
     upstream = {"code": -1, "message": "oups"}
-    mock_git.get_upstream_branch.return_value = maybe_future(upstream)
-    mock_git.config.return_value = maybe_future({"options": dict()})
-    mock_git.remote_show.return_value = maybe_future({})
-    mock_git.push.return_value = maybe_future({"code": 0})
+    mock_git.get_upstream_branch.return_value = upstream
+    mock_git.config.return_value = {"options": dict()}
+    mock_git.remote_show.return_value = {}
+    mock_git.push.return_value = {"code": 0}
 
     remote = "online"
 
@@ -624,12 +620,12 @@ async def test_push_handler_noupstream_pass_remote_branch(
 ):
     # Given
     local_path = jp_root_dir / "test_path"
-    mock_git.get_current_branch.return_value = maybe_future("foo")
+    mock_git.get_current_branch.return_value = "foo"
     upstream = {"code": -1, "message": "oups"}
-    mock_git.get_upstream_branch.return_value = maybe_future(upstream)
-    mock_git.config.return_value = maybe_future({"options": dict()})
-    mock_git.remote_show.return_value = maybe_future({})
-    mock_git.push.return_value = maybe_future({"code": 0})
+    mock_git.get_upstream_branch.return_value = upstream
+    mock_git.config.return_value = {"options": dict()}
+    mock_git.remote_show.return_value = {}
+    mock_git.push.return_value = {"code": 0}
 
     remote = "online"
     remote_branch = "onfoo"
@@ -658,13 +654,13 @@ async def test_push_handler_noupstream_pass_remote_branch(
 async def test_upstream_handler_forward_slashes(mock_git, jp_fetch, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
-    mock_git.get_current_branch.return_value = maybe_future("foo/bar")
+    mock_git.get_current_branch.return_value = "foo/bar"
     upstream = {
         "code": 0,
         "remote_short_name": "origin/something",
         "remote_branch": "foo/bar",
     }
-    mock_git.get_upstream_branch.return_value = maybe_future(upstream)
+    mock_git.get_upstream_branch.return_value = upstream
 
     # When
     response = await jp_fetch(
@@ -684,9 +680,9 @@ async def test_upstream_handler_forward_slashes(mock_git, jp_fetch, jp_root_dir)
 async def test_upstream_handler_localbranch(mock_git, jp_fetch, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
-    mock_git.get_current_branch.return_value = maybe_future("foo/bar")
+    mock_git.get_current_branch.return_value = "foo/bar"
     upstream = {"code": 0, "remote_short_name": ".", "remote_branch": "foo/bar"}
-    mock_git.get_upstream_branch.return_value = maybe_future(upstream)
+    mock_git.get_upstream_branch.return_value = upstream
 
     # When
     response = await jp_fetch(
@@ -710,8 +706,8 @@ async def test_content(mock_execute, jp_fetch, jp_root_dir):
     content = "dummy content file\nwith multiple lines"
 
     mock_execute.side_effect = [
-        maybe_future((0, "1\t1\t{}".format(filename), "")),
-        maybe_future((0, content, "")),
+        (0, "1\t1\t{}".format(filename), ""),
+        (0, content, ""),
     ]
 
     # When
@@ -833,8 +829,8 @@ async def test_content_index(mock_execute, jp_fetch, jp_root_dir):
     content = "dummy content file\nwith multiple lines"
 
     mock_execute.side_effect = [
-        maybe_future((0, "1\t1\t{}".format(filename), "")),
-        maybe_future((0, content, "")),
+        (0, "1\t1\t{}".format(filename), ""),
+        (0, content, ""),
     ]
 
     # When
@@ -891,16 +887,14 @@ async def test_content_base(mock_execute, jp_fetch, jp_root_dir):
     obj_ref = "915bb14609daab65e5304e59d89c626283ae49fc"
 
     mock_execute.side_effect = [
-        maybe_future(
-            (
-                0,
-                "100644 {1} 1       {0}\x00100644 285bdbc14e499b85ec407512a3bb3992fa3d4082 2 {0}\x00100644 66ac842dfb0b5c20f757111d6b3edd56d80622b4 3 {0}\x00".format(
-                    filename, obj_ref
-                ),
-                "",
-            )
+        (
+            0,
+            "100644 {1} 1       {0}\x00100644 285bdbc14e499b85ec407512a3bb3992fa3d4082 2 {0}\x00100644 66ac842dfb0b5c20f757111d6b3edd56d80622b4 3 {0}\x00".format(
+                filename, obj_ref
+            ),
+            "",
         ),
-        maybe_future((0, content, "")),
+        (0, content, ""),
     ]
 
     # When
@@ -948,8 +942,8 @@ async def test_content_unknown_special(mock_execute, jp_fetch, jp_root_dir):
     content = "dummy content file\nwith multiple lines"
 
     mock_execute.side_effect = [
-        maybe_future((0, "1\t1\t{}".format(filename), "")),
-        maybe_future((0, content, "")),
+        (0, "1\t1\t{}".format(filename), ""),
+        (0, content, ""),
     ]
 
     # When
@@ -971,14 +965,12 @@ async def test_content_show_handled_error(mock_execute, jp_fetch, jp_root_dir):
     local_path = jp_root_dir / "test_path"
     filename = "my/file"
 
-    mock_execute.return_value = maybe_future(
-        (
-            -1,
-            "",
-            "fatal: Path '{}' does not exist (neither on disk nor in the index)".format(
-                filename
-            ),
-        )
+    mock_execute.return_value = (
+        -1,
+        "",
+        "fatal: Path '{}' does not exist (neither on disk nor in the index)".format(
+            filename
+        ),
     )
 
     # When
@@ -1002,7 +994,7 @@ async def test_content_binary(mock_execute, jp_fetch, jp_root_dir):
     local_path = jp_root_dir / "test_path"
     filename = "my/file"
 
-    mock_execute.return_value = maybe_future((0, "-\t-\t{}".format(filename), ""))
+    mock_execute.return_value = (0, "-\t-\t{}".format(filename), "")
 
     # When
     body = {
@@ -1053,7 +1045,7 @@ async def test_content_show_unhandled_error(mock_execute, jp_fetch, jp_root_dir)
     local_path = jp_root_dir / "test_path"
     filename = "my/file"
 
-    mock_execute.return_value = maybe_future((-1, "", "Dummy error"))
+    mock_execute.return_value = (-1, "", "Dummy error")
 
     # When
     body = {

--- a/jupyterlab_git/tests/test_init.py
+++ b/jupyterlab_git/tests/test_init.py
@@ -5,14 +5,12 @@ import pytest
 from jupyterlab_git import JupyterLabGit
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.asyncio
 async def test_init():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
-        mock_execute.return_value = maybe_future((0, "", ""))
+        mock_execute.return_value = (0, "", "")
 
         # When
         actual_response = await Git().init("test_curr_path")
@@ -35,8 +33,8 @@ async def test_init_and_post_init():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.side_effect = [
-            maybe_future((0, "", "")),
-            maybe_future((0, "hello", "")),
+            (0, "", ""),
+            (0, "hello", ""),
         ]
 
         # When
@@ -67,8 +65,8 @@ async def test_init_and_post_init_fail():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.side_effect = [
-            maybe_future((0, "", "")),
-            maybe_future((1, "", "not_there: command not found")),
+            (0, "", ""),
+            (1, "", "not_there: command not found"),
         ]
 
         # When
@@ -106,7 +104,7 @@ async def test_init_and_post_init_fail_to_run():
     with patch("jupyterlab_git.git.execute") as mock_execute:
         # Given
         mock_execute.side_effect = [
-            maybe_future((0, "", "")),
+            (0, "", ""),
             Exception("Not a command!"),
         ]
 

--- a/jupyterlab_git/tests/test_pushpull.py
+++ b/jupyterlab_git/tests/test_pushpull.py
@@ -6,17 +6,13 @@ import pytest
 from jupyterlab_git import JupyterLabGit
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.asyncio
 async def test_git_pull_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = maybe_future(
-                (1, "output", "Authentication failed")
-            )
+            mock_execute.return_value = (1, "output", "Authentication failed")
 
             # When
             actual_response = await Git().pull("test_curr_path")
@@ -39,12 +35,10 @@ async def test_git_pull_with_conflict_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = maybe_future(
-                (
-                    1,
-                    "",
-                    "Automatic merge failed; fix conflicts and then commit the result.",
-                )
+            mock_execute.return_value = (
+                1,
+                "",
+                "Automatic merge failed; fix conflicts and then commit the result.",
             )
 
             # When
@@ -75,12 +69,10 @@ async def test_git_pull_with_auth_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
-            mock_execute_with_authentication.return_value = maybe_future(
-                (
-                    1,
-                    "",
-                    "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'",
-                )
+            mock_execute_with_authentication.return_value = (
+                1,
+                "",
+                "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'",
             )
 
             # When
@@ -109,7 +101,7 @@ async def test_git_pull_success():
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
             output = "output"
-            mock_execute.return_value = maybe_future((0, output, ""))
+            mock_execute.return_value = (0, output, "")
 
             # When
             actual_response = await Git().pull("test_curr_path")
@@ -133,9 +125,7 @@ async def test_git_pull_with_auth_success():
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
             output = "output"
-            mock_execute_with_authentication.return_value = maybe_future(
-                (0, output, "")
-            )
+            mock_execute_with_authentication.return_value = (0, output, "")
 
             # When
             auth = {"username": "asdf", "password": "qwerty"}
@@ -159,12 +149,10 @@ async def test_git_pull_with_auth_success_and_conflict_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
-            mock_execute_with_authentication.return_value = maybe_future(
-                (
-                    1,
-                    "output",
-                    "Automatic merge failed; fix conflicts and then commit the result.",
-                )
+            mock_execute_with_authentication.return_value = (
+                1,
+                "output",
+                "Automatic merge failed; fix conflicts and then commit the result.",
             )
 
             # When
@@ -203,9 +191,9 @@ async def test_git_pull_with_auth_and_cache_credentials():
             credential_helper = default_config.credential_helper
             test_path = "test_path"
             mock_execute.side_effect = [
-                maybe_future((0, "", "")),
-                maybe_future((0, "", "")),
-                maybe_future((0, "", "")),
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
             ]
 
             # When
@@ -262,8 +250,8 @@ async def test_git_pull_with_auth_and_cache_credentials_and_existing_credential_
         default_config = JupyterLabGit()
         test_path = "test_path"
         mock_execute.side_effect = [
-            maybe_future((0, "credential.helper=something", "")),
-            maybe_future((0, "", "")),
+            (0, "credential.helper=something", ""),
+            (0, "", ""),
         ]
 
         # When
@@ -302,9 +290,7 @@ async def test_git_push_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
-            mock_execute.return_value = maybe_future(
-                (1, "output", "Authentication failed")
-            )
+            mock_execute.return_value = (1, "output", "Authentication failed")
 
             # When
             actual_response = await Git().push(
@@ -329,12 +315,10 @@ async def test_git_push_with_auth_fail():
     with patch("os.environ", {"TEST": "test"}):
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
-            mock_execute_with_authentication.return_value = maybe_future(
-                (
-                    1,
-                    "",
-                    "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'",
-                )
+            mock_execute_with_authentication.return_value = (
+                1,
+                "",
+                "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'",
             )
 
             # When
@@ -365,7 +349,7 @@ async def test_git_push_success():
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
             output = "output"
-            mock_execute.return_value = maybe_future((0, output, "does not matter"))
+            mock_execute.return_value = (0, output, "does not matter")
 
             # When
             actual_response = await Git().push(
@@ -391,8 +375,10 @@ async def test_git_push_with_auth_success():
         with patch("jupyterlab_git.git.execute") as mock_execute_with_authentication:
             # Given
             output = "output"
-            mock_execute_with_authentication.return_value = maybe_future(
-                (0, output, "does not matter")
+            mock_execute_with_authentication.return_value = (
+                0,
+                output,
+                "does not matter",
             )
 
             # When
@@ -426,9 +412,9 @@ async def test_git_push_with_auth_and_cache_credentials():
             credential_helper = default_config.credential_helper
             test_path = "test_path"
             mock_execute.side_effect = [
-                maybe_future((0, "", "")),
-                maybe_future((0, "", "")),
-                maybe_future((0, "", "")),
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
             ]
 
             # When
@@ -487,8 +473,8 @@ async def test_git_push_with_auth_and_cache_credentials_and_existing_credential_
         default_config = JupyterLabGit()
         test_path = "test_path"
         mock_execute.side_effect = [
-            maybe_future((0, "credential.helper=something", "")),
-            maybe_future((0, "", "")),
+            (0, "credential.helper=something", ""),
+            (0, "", ""),
         ]
 
         # When
@@ -530,7 +516,7 @@ async def test_git_push_no_tags_success():
         with patch("jupyterlab_git.git.execute") as mock_execute:
             # Given
             output = "output"
-            mock_execute.return_value = maybe_future((0, output, "does not matter"))
+            mock_execute.return_value = (0, output, "does not matter")
 
             # When
             actual_response = await Git().push(

--- a/jupyterlab_git/tests/test_remote.py
+++ b/jupyterlab_git/tests/test_remote.py
@@ -6,7 +6,7 @@ import tornado
 
 from jupyterlab_git.git import Git
 from jupyterlab_git.handlers import NAMESPACE
-from .testutils import assert_http_error, maybe_future
+from .testutils import assert_http_error
 
 
 @patch("jupyterlab_git.git.execute")
@@ -14,7 +14,7 @@ async def test_git_add_remote_success_no_name(mock_execute, jp_fetch, jp_root_di
     # Given
     local_path = jp_root_dir / "test_path"
     url = "http://github.com/myid/myrepository.git"
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
 
     # When
     body = {
@@ -55,7 +55,7 @@ async def test_git_add_remote_success(mock_execute, jp_fetch, jp_root_dir):
     local_path = jp_root_dir / "test_path"
     url = "http://github.com/myid/myrepository.git"
     name = "distant"
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
 
     # When
     body = {"url": url, "name": name}
@@ -95,7 +95,7 @@ async def test_git_add_remote_failure(mock_execute, jp_fetch, jp_root_dir):
     url = "http://github.com/myid/myrepository.git"
     error_msg = "Fake failure"
     error_code = 128
-    mock_execute.return_value = maybe_future((error_code, "", error_msg))
+    mock_execute.return_value = (error_code, "", error_msg)
 
     # When
     body = {
@@ -129,9 +129,7 @@ async def test_git_add_remote_failure(mock_execute, jp_fetch, jp_root_dir):
 async def test_git_remote_show(mock_execute, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
-    mock_execute.return_value = maybe_future(
-        (0, os.linesep.join(["origin", "test"]), "")
-    )
+    mock_execute.return_value = (0, os.linesep.join(["origin", "test"]), "")
 
     # When
     output = await Git().remote_show(str(local_path), False)
@@ -162,7 +160,7 @@ async def test_git_remote_show_verbose(mock_execute, jp_fetch, jp_root_dir):
     process_output = os.linesep.join(
         [f"origin\t{url} (fetch)", f"origin\t{url} (push)"]
     )
-    mock_execute.return_value = maybe_future((0, process_output, ""))
+    mock_execute.return_value = (0, process_output, "")
 
     # When
     response = await jp_fetch(
@@ -200,7 +198,7 @@ async def test_git_remote_show_verbose(mock_execute, jp_fetch, jp_root_dir):
 async def test_git_remote_remove(mock_execute, jp_fetch, jp_root_dir):
     # Given
     local_path = jp_root_dir / "test_path"
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
 
     # When
     name = "origin"

--- a/jupyterlab_git/tests/test_settings.py
+++ b/jupyterlab_git/tests/test_settings.py
@@ -6,16 +6,16 @@ from packaging.version import parse
 from jupyterlab_git import __version__
 from jupyterlab_git.handlers import NAMESPACE
 
-from .testutils import maybe_future
-
 
 @patch("jupyterlab_git.git.execute")
 async def test_git_get_settings_success(mock_execute, jp_fetch):
     # Given
     git_version = "2.10.3"
     jlab_version = "2.1.42-alpha.24"
-    mock_execute.return_value = maybe_future(
-        (0, "git version {}.os_platform.42".format(git_version), "")
+    mock_execute.return_value = (
+        0,
+        "git version {}.os_platform.42".format(git_version),
+        "",
     )
 
     # When
@@ -80,8 +80,10 @@ async def test_git_get_settings_no_git(mock_execute, jp_fetch):
 async def test_git_get_settings_no_jlab(mock_execute, jp_fetch):
     # Given
     git_version = "2.10.3"
-    mock_execute.return_value = maybe_future(
-        (0, "git version {}.os_platform.42".format(git_version), "")
+    mock_execute.return_value = (
+        0,
+        "git version {}.os_platform.42".format(git_version),
+        "",
     )
 
     # When

--- a/jupyterlab_git/tests/test_single_file_log.py
+++ b/jupyterlab_git/tests/test_single_file_log.py
@@ -5,8 +5,6 @@ import pytest
 
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.asyncio
 async def test_single_file_log():
@@ -31,7 +29,7 @@ async def test_single_file_log():
             "1	1	test.txt",
         ]
 
-        mock_execute.return_value = maybe_future((0, "\n".join(process_output), ""))
+        mock_execute.return_value = (0, "\n".join(process_output), "")
 
         expected_response = {
             "code": 0,

--- a/jupyterlab_git/tests/test_stash.py
+++ b/jupyterlab_git/tests/test_stash.py
@@ -5,7 +5,7 @@ import tornado
 import os
 from jupyterlab_git.git import Git
 from jupyterlab_git.handlers import NAMESPACE
-from .testutils import assert_http_error, maybe_future
+from .testutils import assert_http_error
 
 # Git Stash - POST
 
@@ -19,7 +19,7 @@ async def test_git_stash_without_message(mock_execute, jp_fetch, jp_root_dir):
 
     local_path = jp_root_dir / "test_path"
 
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
     # When
     response = await jp_fetch(
         NAMESPACE,
@@ -54,7 +54,7 @@ async def test_git_stash_failure(mock_execute, jp_fetch, jp_root_dir):
     error_msg = "Fake failure"
     error_code = 128
 
-    mock_execute.return_value = maybe_future((error_code, "", error_msg))
+    mock_execute.return_value = (error_code, "", error_msg)
 
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         response = await jp_fetch(
@@ -84,7 +84,7 @@ async def test_git_stash_with_message(mock_execute, jp_fetch, jp_root_dir):
     local_path = jp_root_dir / "test_path"
     stash_message = "Custom stash message"
 
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
 
     # When
     response = await jp_fetch(
@@ -121,12 +121,10 @@ async def test_git_stash_show_with_index(mock_execute, jp_fetch, jp_root_dir):
     local_path = jp_root_dir / "test_path"
     stash_index = 1
 
-    mock_execute.return_value = maybe_future(
-        (
-            0,
-            "node_modules/playwright-core/README.md\nnode_modules/playwright-core/package.json\n",
-            "",
-        )
+    mock_execute.return_value = (
+        0,
+        "node_modules/playwright-core/README.md\nnode_modules/playwright-core/package.json\n",
+        "",
     )
 
     # When
@@ -171,12 +169,10 @@ async def test_git_stash_show_without_index(mock_execute, jp_fetch, jp_root_dir)
     env["GIT_TERMINAL_PROMPT"] = "0"
     local_path = jp_root_dir / "test_path"
 
-    mock_execute.return_value = maybe_future(
-        (
-            0,
-            "stash@{0}: On main: testsd\nstash@{1}: WIP on main: bea6895 first commit\n",
-            "",
-        )
+    mock_execute.return_value = (
+        0,
+        "stash@{0}: On main: testsd\nstash@{1}: WIP on main: bea6895 first commit\n",
+        "",
     )
 
     # When
@@ -220,7 +216,7 @@ async def test_git_stash_show_failure(mock_execute, jp_fetch, jp_root_dir):
     error_msg = "Fake failure"
     error_code = 128
 
-    mock_execute.return_value = maybe_future((error_code, "", error_msg))
+    mock_execute.return_value = (error_code, "", error_msg)
 
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         response = await jp_fetch(
@@ -264,7 +260,7 @@ async def test_git_drop_stash_single_success(mock_execute, jp_fetch, jp_root_dir
     local_path = jp_root_dir / "test_path"
     stash_index = 1
 
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
 
     # When
     response = await jp_fetch(
@@ -300,7 +296,7 @@ async def test_git_drop_stash_single_failure(mock_execute, jp_fetch, jp_root_dir
     error_code = 128
     stash_index = 1
 
-    mock_execute.return_value = maybe_future((error_code, "", error_msg))
+    mock_execute.return_value = (error_code, "", error_msg)
 
     # When
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
@@ -335,7 +331,7 @@ async def test_git_drop_stash_all_success(mock_execute, jp_fetch, jp_root_dir):
 
     local_path = jp_root_dir / "test_path"
 
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
 
     # When
     response = await jp_fetch(
@@ -370,7 +366,7 @@ async def test_git_apply_stash_with_index(mock_execute, jp_fetch, jp_root_dir):
     env["GIT_TERMINAL_PROMPT"] = "0"
     local_path = jp_root_dir / "test_path"
     stash_index = 1
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
 
     # When
     response = await jp_fetch(
@@ -404,7 +400,7 @@ async def test_git_apply_stash_without_index(mock_execute, jp_fetch, jp_root_dir
 
     local_path = jp_root_dir / "test_path"
 
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
 
     # When
     response = await jp_fetch(
@@ -436,7 +432,7 @@ async def test_git_apply_stash_failure(mock_execute, jp_fetch, jp_root_dir):
     error_code = 128
     stash_index = 1
 
-    mock_execute.return_value = maybe_future((error_code, "", error_msg))
+    mock_execute.return_value = (error_code, "", error_msg)
 
     # When
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
@@ -473,7 +469,7 @@ async def test_git_pop_stash_with_index(mock_execute, jp_fetch, jp_root_dir):
     local_path = jp_root_dir / "test_path"
     stash_index = 1
 
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
     # When
     response = await jp_fetch(
         NAMESPACE,
@@ -505,7 +501,7 @@ async def test_git_pop_stash_without_index(mock_execute, jp_fetch, jp_root_dir):
     local_path = jp_root_dir / "test_path"
     stash_index = None
 
-    mock_execute.return_value = maybe_future((0, "", ""))
+    mock_execute.return_value = (0, "", "")
     # When
     response = await jp_fetch(
         NAMESPACE,
@@ -539,7 +535,7 @@ async def test_git_pop_stash_failure(mock_execute, jp_fetch, jp_root_dir):
     stash_index = 1
     error_msg = "Fake failure"
     error_code = 128
-    mock_execute.return_value = maybe_future((error_code, "", error_msg))
+    mock_execute.return_value = (error_code, "", error_msg)
 
     # When
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:

--- a/jupyterlab_git/tests/test_status.py
+++ b/jupyterlab_git/tests/test_status.py
@@ -5,8 +5,6 @@ import pytest
 # local lib
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -354,16 +352,12 @@ async def test_status(tmp_path, output, diff_output, expected):
         (repository / ".git" / "rebase-merge").mkdir(parents=True)
 
         mock_execute.side_effect = [
-            maybe_future((0, "\x00".join(output) + "\x00", "")),
-            maybe_future((0, "\x00".join(diff_output) + "\x00", "")),
-            maybe_future((0 if expected["state"] == 4 else 128, "", "cherry pick")),
-            maybe_future((0 if expected["state"] == 2 else 128, "", "merge")),
-            maybe_future(
-                (0 if expected["state"] == 3 else 128, ".git/rebase-merge", "rebase")
-            ),
-            maybe_future(
-                (0 if expected["state"] == 3 else 128, ".git/rebase-apply", "rebase")
-            ),
+            (0, "\x00".join(output) + "\x00", ""),
+            (0, "\x00".join(diff_output) + "\x00", ""),
+            (0 if expected["state"] == 4 else 128, "", "cherry pick"),
+            (0 if expected["state"] == 2 else 128, "", "merge"),
+            (0 if expected["state"] == 3 else 128, ".git/rebase-merge", "rebase"),
+            (0 if expected["state"] == 3 else 128, ".git/rebase-apply", "rebase"),
         ]
 
         # When

--- a/jupyterlab_git/tests/test_tag.py
+++ b/jupyterlab_git/tests/test_tag.py
@@ -4,8 +4,6 @@ import pytest
 
 from jupyterlab_git.git import Git
 
-from .testutils import maybe_future
-
 
 @pytest.mark.asyncio
 async def test_git_tag_success():
@@ -13,7 +11,7 @@ async def test_git_tag_success():
         output_tags = "v1.0.0\t6db57bf4987d387d439acd16ddfe8d54d46e8f4\nv2.0.1\t2aeae86b6010dd1f05b820d8753cff8349c181a6"
 
         # Given
-        mock_execute.return_value = maybe_future((0, output_tags, ""))
+        mock_execute.return_value = (0, output_tags, "")
 
         # When
         actual_response = await Git().tags("test_curr_path")
@@ -57,7 +55,7 @@ async def test_git_tag_checkout_success():
         with patch("jupyterlab_git.git.execute") as mock_execute:
             tag = "mock_tag"
             # Given
-            mock_execute.return_value = maybe_future((0, "", ""))
+            mock_execute.return_value = (0, "", "")
 
             # When
             actual_response = await Git().tag_checkout("test_curr_path", "mock_tag")
@@ -86,7 +84,7 @@ async def test_set_tag_succes():
             tag = "mock_tag"
             commitId = "mock_commit_id"
             # Given
-            mock_execute.return_value = maybe_future((0, "", ""))
+            mock_execute.return_value = (0, "", "")
 
             # When
             actual_response = await Git().set_tag(

--- a/jupyterlab_git/tests/testutils.py
+++ b/jupyterlab_git/tests/testutils.py
@@ -2,14 +2,7 @@
 
 import json
 
-try:
-    from unittest.mock import AsyncMock  # New in Python 3.8 and used by unittest.mock
-except ImportError:
-    AsyncMock = None
-
-
 import tornado
-from jupyter_server.utils import ensure_async
 
 
 def assert_http_error(error, expected_code, expected_message=None):
@@ -43,10 +36,3 @@ def assert_http_error(error, expected_code, expected_message=None):
 class FakeContentManager:
     def get(self, path=None):
         return {"content": ""}
-
-
-def maybe_future(args):
-    if AsyncMock is None:
-        return ensure_async(args)
-    else:
-        return args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyterlab_git"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "jupyter_server>=2.0.1,<3",


### PR DESCRIPTION
Python 3.9 is EOL

- [x] Drop testing with Python 3.9 on CI
- [x] Rotate supported versions
- [x] Clean up test files