### PR TITLE
fix: GitCloneForm checkboxes return correct booleans

### DIFF
--- a/src/__tests__/git-clone-form.spec.tsx
+++ b/src/__tests__/git-clone-form.spec.tsx
@@ -1,0 +1,38 @@
+import { GitCloneForm } from '../widgets/GitCloneForm';
+import { TranslationBundle } from '@jupyterlab/translation';
+
+const trans = { __: (s: string) => s } as TranslationBundle;
+
+describe('GitCloneForm.getValue', () => {
+  let form: GitCloneForm;
+
+  beforeEach(() => {
+    form = new GitCloneForm(trans);
+  });
+
+  it('returns false for submodules and versioning if checkboxes are unchecked', () => {
+    (form.node.querySelector('#submodules') as HTMLInputElement).checked =
+      false;
+    (form.node.querySelector('#download') as HTMLInputElement).checked = false;
+    (form.node.querySelector('#input-link') as HTMLInputElement).value =
+      'https://github.com/example/repo.git';
+
+    const value = form.getValue();
+    expect(value.url).toBe(
+      encodeURIComponent('https://github.com/example/repo.git')
+    );
+    expect(value.submodules).toBe(false);
+    expect(value.versioning).toBe(false);
+  });
+
+  it('returns true if checkboxes are checked', () => {
+    (form.node.querySelector('#submodules') as HTMLInputElement).checked = true;
+    (form.node.querySelector('#download') as HTMLInputElement).checked = true;
+    (form.node.querySelector('#input-link') as HTMLInputElement).value =
+      'https://github.com/example/repo.git';
+
+    const value = form.getValue();
+    expect(value.submodules).toBe(true);
+    expect(value.versioning).toBe(true);
+  });
+});

--- a/src/widgets/GitCloneForm.ts
+++ b/src/widgets/GitCloneForm.ts
@@ -24,14 +24,10 @@ export class GitCloneForm extends Widget {
         ).value.trim()
       ),
       versioning: Boolean(
-        encodeURIComponent(
-          (this.node.querySelector('#download') as HTMLInputElement).checked
-        )
+        (this.node.querySelector('#download') as HTMLInputElement).checked
       ),
       submodules: Boolean(
-        encodeURIComponent(
-          (this.node.querySelector('#submodules') as HTMLInputElement).checked
-        )
+        (this.node.querySelector('#submodules') as HTMLInputElement).checked
       )
     };
   }


### PR DESCRIPTION
Removed unnecessary encodeURIComponent around boolean checkbox values in GitCloneForm.
Previously, unchecked boxes were always returning true due to Boolean("false") behavior.
Now, versioning and submodules checkboxes correctly reflect user selection.

fix #1456