### PR TITLE
fix: read version from package.json instead of hatch at workspace root

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,8 +39,6 @@ To create a Python source package (`.tar.gz`) and the binary package (`.whl`) in
 python -m build
 ```
 
-> `python setup.py sdist bdist_wheel` is deprecated and will not work for this package.
-
 Then to upload the package to PyPI, do:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,18 @@
+[build-system]
+requires = ["hatchling", "hatch-nodejs-version"]
+build-backend = "hatchling.build"
+
+[project]
+name = "jupyterlab-git-workspace"
+dynamic = ["version"]
+
+[tool.hatch.version]
+source = "nodejs"
+path = "package.json"
+
+[tool.hatch.metadata.hooks.nodejs]
+fields = ["description"]
+
 [tool.uv.workspace]
 members = ["packages/core", "packages/jupyterlab"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "jupyterlab-git-workspace"
 dynamic = ["version"]
+classifiers = ["Private :: Do Not Upload"]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/setup.py
+++ b/setup.py
@@ -1,1 +1,0 @@
-__import__("setuptools").setup()


### PR DESCRIPTION
hatch version fails at the uv workspace root (no build backend) causing jupyter-releaser to fall back to 0.0.0 for the release tag.
Add a minimal hatchling + hatch-nodejs-version config at the root so hatch version works from there, reading the version from package.json.
The root package is not published; python-packages controls what gets released.
