### PR TITLE
Fix check release

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -17,8 +17,6 @@ jobs:
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          PIP_FIND_LINKS: ${{ github.workspace }}/.jupyter_releaser_checkout/dist
 
       - name: Upload Distributions
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ addopts = "--import-mode=importlib"
 [tool.check-wheel-contents]
 ignore = ["W002"]
 
+[tool.jupyter-releaser]
+skip = ["check-python"]
+
 [tool.jupyter-releaser.options]
 version_cmd = "hatch version"
 python-packages = ["packages/core", "packages/jupyterlab"]


### PR DESCRIPTION
- Remove the custom logic in the check release workflow to avoid differences in behavior with the actual release workflows.
- Skip `check-python` for now