### PR TITLE
Git panel UI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,14 @@ Once installed, extension behavior can be modified via the following settings wh
 - **disableBranchWithChanges**: disable all branch operations, such as creating a new branch or switching to a different branch, when there are changed/staged files. When set to `true`, this setting guards against overwriting and/or losing uncommitted changes.
 - **displayStatus**: display Git extension status updates in the JupyterLab status bar. If `true`, the extension displays status updates in the JupyterLab status bar, such as when pulling and pushing changes, switching branches, and polling for changes. Depending on the level of extension activity, some users may find the status updates distracting. In which case, setting this to `false` should reduce visual noise.
 - **fileClickAction**: what happens when you click or double-click a file in the Git panel file list. One of:
-  - `"open-on-double"` *(default)*: double-click opens the file in an editor.
+
+  - `"open-on-double"` _(default)_: double-click opens the file in an editor.
   - `"diff-on-double"`: double-click opens a diff of the file (no-op when no diff is available).
   - `"diff-on-single"`: single-click opens a diff (or the file itself when no diff is available, e.g. for untracked or remote-changed files).
   - `"select-only"`: clicking only selects the file; no other action is triggered.
 
   This setting replaces the previous boolean `doubleClickDiff`. User settings using the old key are migrated automatically on load (`doubleClickDiff: true` → `"diff-on-double"`).
+
 - **historyCount**: number of commits shown in the history log, beginning with the most recent. Displaying a larger number of commits can lead to performance degradation, so use caution when modifying this setting.
 - **promptUserIdentity**: Whether to prompt for user name and email on every commit.
 - **refreshIfHidden**: whether to refresh even if the Git tab is hidden; default to `false` (i.e. refresh is turned off if the Git tab is hidden).

--- a/README.md
+++ b/README.md
@@ -124,7 +124,13 @@ Once installed, extension behavior can be modified via the following settings wh
 - **commitAndPush**: Whether to trigger or not a push for each commit; default is `false`.
 - **disableBranchWithChanges**: disable all branch operations, such as creating a new branch or switching to a different branch, when there are changed/staged files. When set to `true`, this setting guards against overwriting and/or losing uncommitted changes.
 - **displayStatus**: display Git extension status updates in the JupyterLab status bar. If `true`, the extension displays status updates in the JupyterLab status bar, such as when pulling and pushing changes, switching branches, and polling for changes. Depending on the level of extension activity, some users may find the status updates distracting. In which case, setting this to `false` should reduce visual noise.
-- **doubleClickDiff**: double click a file in the Git extension panel to open a diff of the file instead of opening the file for editing.
+- **fileClickAction**: what happens when you click or double-click a file in the Git panel file list. One of:
+  - `"open-on-double"` *(default)*: double-click opens the file in an editor.
+  - `"diff-on-double"`: double-click opens a diff of the file (no-op when no diff is available).
+  - `"diff-on-single"`: single-click opens a diff (or the file itself when no diff is available, e.g. for untracked or remote-changed files).
+  - `"select-only"`: clicking only selects the file; no other action is triggered.
+
+  This setting replaces the previous boolean `doubleClickDiff`. User settings using the old key are migrated automatically on load (`doubleClickDiff: true` → `"diff-on-double"`).
 - **historyCount**: number of commits shown in the history log, beginning with the most recent. Displaying a larger number of commits can lead to performance degradation, so use caution when modifying this setting.
 - **promptUserIdentity**: Whether to prompt for user name and email on every commit.
 - **refreshIfHidden**: whether to refresh even if the Git tab is hidden; default to `false` (i.e. refresh is turned off if the Git tab is hidden).

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,7 +1,6 @@
 {
   "jupyter.lab.setting-icon": "git",
   "jupyter.lab.setting-icon-label": "Git",
-  "jupyter.lab.transform": true,
   "title": "Git",
   "description": "jupyterlab-git settings.",
   "type": "object",
@@ -103,11 +102,10 @@
       "default": false
     },
     "clearOutputsBeforeCommit": {
-      "type": "boolean",
+      "type": ["boolean", "null"],
       "title": "Clear outputs before commit",
       "description": "If true, notebook outputs will be cleared before committing. If false, outputs are kept. If null, ask each time.",
-      "default": null,
-      "nullable": true
+      "default": null
     }
   },
   "jupyter.lab.shortcuts": [

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,6 +1,7 @@
 {
   "jupyter.lab.setting-icon": "git",
   "jupyter.lab.setting-icon-label": "Git",
+  "jupyter.lab.transform": true,
   "title": "Git",
   "description": "jupyterlab-git settings.",
   "type": "object",
@@ -29,11 +30,29 @@
       "description": "Display Git extension status updates in the JupyterLab status bar. If true, the extension displays status updates in the JupyterLab status bar, such as when pulling and pushing changes, switching branches, and polling for changes. Depending on the level of extension activity, some users may find the status updates distracting. In which case, setting this to false should reduce visual noise.",
       "default": true
     },
-    "doubleClickDiff": {
-      "type": "boolean",
-      "title": "Show diff on double click",
-      "description": "If true, double clicking a file in the list of changed files will open a diff.",
-      "default": false
+    "fileClickAction": {
+      "type": "string",
+      "title": "File click action",
+      "description": "What happens when you click or double-click a file in the Git panel file list.",
+      "oneOf": [
+        {
+          "const": "open-on-double",
+          "title": "Double click opens the file"
+        },
+        {
+          "const": "diff-on-double",
+          "title": "Double click opens a diff"
+        },
+        {
+          "const": "diff-on-single",
+          "title": "Single click opens a diff"
+        },
+        {
+          "const": "select-only",
+          "title": "Click only selects the file"
+        }
+      ],
+      "default": "open-on-double"
     },
     "historyCount": {
       "type": "integer",
@@ -142,9 +161,6 @@
           },
           {
             "command": "git:toggle-simple-staging"
-          },
-          {
-            "command": "git:toggle-double-click-diff"
           },
           {
             "type": "separator"

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -257,15 +257,6 @@ export function addCommands(
     }
   });
 
-  /** add toggle for double click opens diffs */
-  commands.addCommand(CommandIDs.gitToggleDoubleClickDiff, {
-    label: trans.__('Double click opens diff'),
-    isToggled: () => !!settings.composite['doubleClickDiff'],
-    execute: args => {
-      settings.set('doubleClickDiff', !settings.composite['doubleClickDiff']);
-    }
-  });
-
   /** Command to add a remote Git repository */
   commands.addCommand(CommandIDs.gitManageRemote, {
     label: trans.__('Manage Remote Repositories'),
@@ -1833,8 +1824,6 @@ export function createGitMenu(
   menu.addItem({ type: 'separator' });
 
   menu.addItem({ command: CommandIDs.gitToggleSimpleStaging });
-
-  menu.addItem({ command: CommandIDs.gitToggleDoubleClickDiff });
 
   menu.addItem({ type: 'separator' });
 

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -11,6 +11,7 @@ import {
   fileChangedLabelInfoStyle,
   fileChangedLabelModifiedStyle,
   fileChangedLabelStyle,
+  fileClickableStyle,
   fileStyle,
   gitMarkBoxStyle,
   selectedFileChangedLabelStyle,
@@ -196,9 +197,12 @@ export class FileItem extends React.PureComponent<IFileItemProps> {
   }
 
   protected _getFileClass(): string {
+    // Show the pointer cursor only when a single click triggers an action
+    // beyond selection (i.e. when `onClick` is provided by the parent).
+    const clickableClass = this.props.onClick ? fileClickableStyle : '';
     const baseClass = this.props.selected
-      ? classes(fileStyle, selectedFileStyle)
-      : fileStyle;
+      ? classes(fileStyle, selectedFileStyle, clickableClass)
+      : classes(fileStyle, clickableClass);
 
     return this.props.className
       ? `${baseClass} ${this.props.className}`

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -157,7 +157,11 @@ export class FileItem extends React.PureComponent<IFileItemProps> {
         this.props.setSelection!(this.props.file, { group: true });
       } else {
         this.props.setSelection!(this.props.file, { singleton: true });
-        this.props.onClick?.(this.props.file);
+        // Skip on the second click of a double-click so a `diff-on-single`
+        // navigation isn't triggered twice on the way to `onDoubleClick`.
+        if (event.detail <= 1) {
+          this.props.onClick?.(this.props.file);
+        }
       }
     }
   };

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -100,12 +100,7 @@ export interface IFileItemProps {
    */
   onDoubleClick: () => void;
   /**
-   * Callback when the row is clicked with no modifier keys.
-   *
-   * Used for the row's primary action (e.g. opening a diff). Modifier
-   * key clicks remain dedicated to multi-selection and skip this handler.
-   * Not invoked in mark-box (simple staging) mode where a plain click
-   * toggles the file's mark instead.
+   * Callback on plain (non-modifier) click
    */
   onClick?: (file: Git.IStatusFile) => void;
   /**
@@ -174,10 +169,6 @@ export class FileItem extends React.PureComponent<IFileItemProps> {
   }
 
   protected _getFileChangedLabelClass(change: string): string {
-    // Map each porcelain status code to a semantic color (green for new
-    // content, red for removed, warn for modified/renamed, info for
-    // anything else). `!` is only emitted for unmerged conflicts here,
-    // so it gets the deleted/error color rather than warn.
     let colorStyle: string;
     switch (change) {
       case 'A':
@@ -196,7 +187,11 @@ export class FileItem extends React.PureComponent<IFileItemProps> {
         colorStyle = fileChangedLabelInfoStyle;
     }
     return this.props.selected
-      ? classes(fileChangedLabelStyle, colorStyle, selectedFileChangedLabelStyle)
+      ? classes(
+          fileChangedLabelStyle,
+          colorStyle,
+          selectedFileChangedLabelStyle
+        )
       : classes(fileChangedLabelStyle, colorStyle);
   }
 
@@ -213,14 +208,8 @@ export class FileItem extends React.PureComponent<IFileItemProps> {
   render(): JSX.Element {
     const { file } = this.props;
     const status_code = file.status === 'staged' ? file.x : file.y;
-    // Letter shown in the status badge: `!` for unmerged conflicts, `U`
-    // for untracked, otherwise the staged or unstaged porcelain code.
     const badge_code =
-      file.status === 'unmerged'
-        ? '!'
-        : file.y === '?'
-        ? 'U'
-        : status_code;
+      file.status === 'unmerged' ? '!' : file.y === '?' ? 'U' : status_code;
     const status =
       file.status === 'unmerged'
         ? this.props.trans.__('Conflicted')

--- a/src/components/FileItem.tsx
+++ b/src/components/FileItem.tsx
@@ -6,10 +6,11 @@ import {
   checkboxLabelContainerStyle,
   checkboxLabelLastContainerStyle,
   checkboxLabelStyle,
-  fileChangedLabelBrandStyle,
+  fileChangedLabelAddedStyle,
+  fileChangedLabelDeletedStyle,
   fileChangedLabelInfoStyle,
+  fileChangedLabelModifiedStyle,
   fileChangedLabelStyle,
-  fileChangedLabelWarnStyle,
   fileStyle,
   gitMarkBoxStyle,
   selectedFileChangedLabelStyle,
@@ -99,6 +100,15 @@ export interface IFileItemProps {
    */
   onDoubleClick: () => void;
   /**
+   * Callback when the row is clicked with no modifier keys.
+   *
+   * Used for the row's primary action (e.g. opening a diff). Modifier
+   * key clicks remain dedicated to multi-selection and skip this handler.
+   * Not invoked in mark-box (simple staging) mode where a plain click
+   * toggles the file's mark instead.
+   */
+  onClick?: (file: Git.IStatusFile) => void;
+  /**
    * Is the file selected?
    */
   selected?: boolean;
@@ -151,6 +161,7 @@ export class FileItem extends React.PureComponent<IFileItemProps> {
         this.props.setSelection!(this.props.file, { group: true });
       } else {
         this.props.setSelection!(this.props.file, { singleton: true });
+        this.props.onClick?.(this.props.file);
       }
     }
   };
@@ -163,31 +174,30 @@ export class FileItem extends React.PureComponent<IFileItemProps> {
   }
 
   protected _getFileChangedLabelClass(change: string): string {
-    if (change === 'M') {
-      return this.props.selected
-        ? classes(
-            fileChangedLabelStyle,
-            fileChangedLabelBrandStyle,
-            selectedFileChangedLabelStyle
-          )
-        : classes(fileChangedLabelStyle, fileChangedLabelBrandStyle);
-    } else if (change === '!') {
-      return this.props.selected
-        ? classes(
-            fileChangedLabelStyle,
-            fileChangedLabelWarnStyle,
-            selectedFileChangedLabelStyle
-          )
-        : classes(fileChangedLabelStyle, fileChangedLabelWarnStyle);
-    } else {
-      return this.props.selected
-        ? classes(
-            fileChangedLabelStyle,
-            fileChangedLabelInfoStyle,
-            selectedFileChangedLabelStyle
-          )
-        : classes(fileChangedLabelStyle, fileChangedLabelInfoStyle);
+    // Map each porcelain status code to a semantic color (green for new
+    // content, red for removed, warn for modified/renamed, info for
+    // anything else). `!` is only emitted for unmerged conflicts here,
+    // so it gets the deleted/error color rather than warn.
+    let colorStyle: string;
+    switch (change) {
+      case 'A':
+      case 'U':
+        colorStyle = fileChangedLabelAddedStyle;
+        break;
+      case 'D':
+      case '!':
+        colorStyle = fileChangedLabelDeletedStyle;
+        break;
+      case 'M':
+      case 'R':
+        colorStyle = fileChangedLabelModifiedStyle;
+        break;
+      default:
+        colorStyle = fileChangedLabelInfoStyle;
     }
+    return this.props.selected
+      ? classes(fileChangedLabelStyle, colorStyle, selectedFileChangedLabelStyle)
+      : classes(fileChangedLabelStyle, colorStyle);
   }
 
   protected _getFileClass(): string {
@@ -203,6 +213,14 @@ export class FileItem extends React.PureComponent<IFileItemProps> {
   render(): JSX.Element {
     const { file } = this.props;
     const status_code = file.status === 'staged' ? file.x : file.y;
+    // Letter shown in the status badge: `!` for unmerged conflicts, `U`
+    // for untracked, otherwise the staged or unstaged porcelain code.
+    const badge_code =
+      file.status === 'unmerged'
+        ? '!'
+        : file.y === '?'
+        ? 'U'
+        : status_code;
     const status =
       file.status === 'unmerged'
         ? this.props.trans.__('Conflicted')
@@ -241,16 +259,8 @@ export class FileItem extends React.PureComponent<IFileItemProps> {
           </div>
           <div className={checkboxLabelLastContainerStyle}>
             {this.props.actions}
-            <span
-              className={this._getFileChangedLabelClass(
-                this.props.file.status === 'unmerged' ? '!' : this.props.file.y
-              )}
-            >
-              {this.props.file.status === 'unmerged'
-                ? '!'
-                : this.props.file.y === '?'
-                ? 'U'
-                : status_code}
+            <span className={this._getFileChangedLabelClass(badge_code)}>
+              {badge_code}
             </span>
           </div>
         </div>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -696,9 +696,16 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   private _renderUnmergedRow = (
     rowProps: ListChildComponentProps
   ): JSX.Element => {
+    const action = this.props.settings.get('fileClickAction')
+      .composite as Git.FileClickAction;
     const { data, index, style } = rowProps;
     const file = data[index] as Git.IStatusFile;
     const diffButton = this._createDiffButton(file);
+    const openDiff = (): void => {
+      void this._openDiffViews([file]);
+    };
+    // Conflicted files only resolve through the diff view, so double-click
+    // opens the diff for every non-`select-only` action.
     return (
       <FileItem
         trans={this.props.trans}
@@ -708,8 +715,10 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         model={this.props.model}
         selected={this._isSelectedFile(file)}
         setSelection={this.setSelection}
-        onClick={() => this._openDiffViews([file])}
-        onDoubleClick={() => this._openDiffViews([file])}
+        onClick={action === 'diff-on-single' ? openDiff : undefined}
+        onDoubleClick={
+          action === 'select-only' ? (): void => undefined : openDiff
+        }
         style={{ ...style }}
       />
     );
@@ -743,8 +752,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   private _renderStagedRow = (
     rowProps: ListChildComponentProps
   ): JSX.Element => {
-    const doubleClickDiff = this.props.settings.get('doubleClickDiff')
-      .composite as boolean;
+    const action = this.props.settings.get('fileClickAction')
+      .composite as Git.FileClickAction;
     const { data, index, style } = rowProps;
     const file = data[index] as Git.IStatusFile;
     const diffButton = this._createDiffButton(file);
@@ -777,18 +786,12 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         model={this.props.model}
         selected={this._isSelectedFile(file)}
         setSelection={this.setSelection}
-        onClick={
+        onClick={this._stagedOrChangedSingleClick(action, file, diffButton)}
+        onDoubleClick={this._stagedOrChangedDoubleClick(
+          action,
+          file,
           diffButton
-            ? () => this._openDiffViews([file])
-            : () => this.openSelectedFiles(file)
-        }
-        onDoubleClick={
-          doubleClickDiff
-            ? diffButton
-              ? () => this._openDiffViews([file])
-              : () => undefined
-            : () => this.openSelectedFiles(file)
-        }
+        )}
         style={style}
       />
     );
@@ -840,8 +843,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   private _renderChangedRow = (
     rowProps: ListChildComponentProps
   ): JSX.Element => {
-    const doubleClickDiff = this.props.settings.get('doubleClickDiff')
-      .composite as boolean;
+    const action = this.props.settings.get('fileClickAction')
+      .composite as Git.FileClickAction;
     const { data, index, style } = rowProps;
     const file = data[index] as Git.IStatusFile;
     const diffButton = this._createDiffButton(file);
@@ -890,18 +893,12 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         model={this.props.model}
         selected={this._isSelectedFile(file)}
         setSelection={this.setSelection}
-        onClick={
+        onClick={this._stagedOrChangedSingleClick(action, file, diffButton)}
+        onDoubleClick={this._stagedOrChangedDoubleClick(
+          action,
+          file,
           diffButton
-            ? () => this._openDiffViews([file])
-            : () => this.openSelectedFiles(file)
-        }
-        onDoubleClick={
-          doubleClickDiff
-            ? diffButton
-              ? () => this._openDiffViews([file])
-              : () => undefined
-            : () => this.openSelectedFiles(file)
-        }
+        )}
         style={style}
       />
     );
@@ -961,8 +958,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   private _renderUntrackedRow = (
     rowProps: ListChildComponentProps
   ): JSX.Element => {
-    const doubleClickDiff = this.props.settings.get('doubleClickDiff')
-      .composite as boolean;
+    const action = this.props.settings.get('fileClickAction')
+      .composite as Git.FileClickAction;
     const { data, index, style } = rowProps;
     const file = data[index] as Git.IStatusFile;
     return (
@@ -999,18 +996,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         file={file}
         contextMenu={this.openContextMenu}
         model={this.props.model}
-        onClick={() =>
-          this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
-            files: [file]
-          } as CommandArguments.IGitContextAction as any)
-        }
-        onDoubleClick={() => {
-          if (!doubleClickDiff) {
-            this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
-              files: [file]
-            } as CommandArguments.IGitContextAction as any);
-          }
-        }}
+        onClick={this._noDiffSingleClick(action, file)}
+        onDoubleClick={this._noDiffDoubleClick(action, file)}
         selected={this._isSelectedFile(file)}
         setSelection={this.setSelection}
         style={style}
@@ -1056,8 +1043,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   private _renderRemoteChangedRow = (
     rowProps: ListChildComponentProps
   ): JSX.Element => {
-    const doubleClickDiff = this.props.settings.get('doubleClickDiff')
-      .composite as boolean;
+    const action = this.props.settings.get('fileClickAction')
+      .composite as Git.FileClickAction;
     const { data, index, style } = rowProps;
     const file = data[index] as Git.IStatusFile;
     return (
@@ -1078,18 +1065,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         file={file}
         contextMenu={this.openContextMenu}
         model={this.props.model}
-        onClick={() =>
-          this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
-            files: [file]
-          } as CommandArguments.IGitContextAction as any)
-        }
-        onDoubleClick={() => {
-          if (!doubleClickDiff) {
-            this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
-              files: [file]
-            } as CommandArguments.IGitContextAction as any);
-          }
-        }}
+        onClick={this._noDiffSingleClick(action, file)}
+        onDoubleClick={this._noDiffDoubleClick(action, file)}
         selected={this._isSelectedFile(file)}
         setSelection={this.setSelection}
         style={style}
@@ -1137,8 +1114,14 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
   private _renderSimpleStageRow = (rowProps: ListChildComponentProps) => {
     const { data, index, style } = rowProps;
     const file = data[index] as Git.IStatusFile;
-    const doubleClickDiff = this.props.settings.get('doubleClickDiff')
-      .composite as boolean;
+    const action = this.props.settings.get('fileClickAction')
+      .composite as Git.FileClickAction;
+    // Simple-stage rows reserve single-click for toggling the file's mark,
+    // so the `diff-on-single` action is mapped to the same double-click
+    // behaviour as `diff-on-double`.
+    const wantsDiff =
+      action === 'diff-on-double' || action === 'diff-on-single';
+    const wantsSelectOnly = action === 'select-only';
 
     const openFile = (): void => {
       this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
@@ -1155,7 +1138,8 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         onClick={stopPropagationWrapper(openFile)}
       />
     );
-    let onDoubleClick = doubleClickDiff ? (): void => undefined : openFile;
+    let onDoubleClick =
+      wantsSelectOnly || wantsDiff ? () => undefined : openFile;
 
     if (file.status === 'unstaged' || file.status === 'partially-staged') {
       const diffButton = this._createDiffButton(file);
@@ -1178,7 +1162,9 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           />
         </React.Fragment>
       );
-      onDoubleClick = doubleClickDiff
+      onDoubleClick = wantsSelectOnly
+        ? () => undefined
+        : wantsDiff
         ? diffButton
           ? () => this._openDiffViews([file])
           : () => undefined
@@ -1204,7 +1190,9 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           />
         </React.Fragment>
       );
-      onDoubleClick = doubleClickDiff
+      onDoubleClick = wantsSelectOnly
+        ? () => undefined
+        : wantsDiff
         ? diffButton
           ? () => this._openDiffViews([file])
           : () => undefined
@@ -1295,6 +1283,83 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         />
       )
     );
+  }
+
+  /**
+   * Single-click handler for a Staged or Changed row, or `undefined` when
+   * the action doesn't trigger anything on a single click.
+   */
+  private _stagedOrChangedSingleClick(
+    action: Git.FileClickAction,
+    file: Git.IStatusFile,
+    diffButton: React.ReactNode
+  ): (() => void) | undefined {
+    if (action !== 'diff-on-single') {
+      return undefined;
+    }
+    return diffButton
+      ? () => void this._openDiffViews([file])
+      : () => this.openSelectedFiles(file);
+  }
+
+  /**
+   * Double-click handler for a Staged or Changed row. A no-op for
+   * `diff-on-single` since the single-click handler already runs on the
+   * way to a double-click.
+   */
+  private _stagedOrChangedDoubleClick(
+    action: Git.FileClickAction,
+    file: Git.IStatusFile,
+    diffButton: React.ReactNode
+  ): () => void {
+    switch (action) {
+      case 'open-on-double':
+        return () => this.openSelectedFiles(file);
+      case 'diff-on-double':
+        return diffButton
+          ? () => void this._openDiffViews([file])
+          : () => undefined;
+      case 'diff-on-single':
+      case 'select-only':
+      default:
+        return () => undefined;
+    }
+  }
+
+  /**
+   * Single-click handler for Untracked or Remote-Changed rows, where no
+   * diff is available; `diff-on-single` opens the file instead.
+   */
+  private _noDiffSingleClick(
+    action: Git.FileClickAction,
+    file: Git.IStatusFile
+  ): (() => void) | undefined {
+    if (action !== 'diff-on-single') {
+      return undefined;
+    }
+    return () => {
+      this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
+        files: [file]
+      } as CommandArguments.IGitContextAction as any);
+    };
+  }
+
+  /**
+   * Double-click handler for Untracked or Remote-Changed rows; only
+   * `open-on-double` opens the file, every other action is a no-op.
+   */
+  private _noDiffDoubleClick(
+    action: Git.FileClickAction,
+    file: Git.IStatusFile
+  ): () => void {
+    if (action !== 'open-on-double') {
+      return () => undefined;
+    }
+    return () => {
+      this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
+        files: [file]
+      } as CommandArguments.IGitContextAction as any);
+    };
   }
 
   /**

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -708,6 +708,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         model={this.props.model}
         selected={this._isSelectedFile(file)}
         setSelection={this.setSelection}
+        onClick={() => this._openDiffViews([file])}
         onDoubleClick={() => this._openDiffViews([file])}
         style={{ ...style }}
       />
@@ -776,6 +777,11 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         model={this.props.model}
         selected={this._isSelectedFile(file)}
         setSelection={this.setSelection}
+        onClick={
+          diffButton
+            ? () => this._openDiffViews([file])
+            : () => this.openSelectedFiles(file)
+        }
         onDoubleClick={
           doubleClickDiff
             ? diffButton
@@ -884,6 +890,11 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         model={this.props.model}
         selected={this._isSelectedFile(file)}
         setSelection={this.setSelection}
+        onClick={
+          diffButton
+            ? () => this._openDiffViews([file])
+            : () => this.openSelectedFiles(file)
+        }
         onDoubleClick={
           doubleClickDiff
             ? diffButton
@@ -988,6 +999,11 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         file={file}
         contextMenu={this.openContextMenu}
         model={this.props.model}
+        onClick={() =>
+          this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
+            files: [file]
+          } as CommandArguments.IGitContextAction as any)
+        }
         onDoubleClick={() => {
           if (!doubleClickDiff) {
             this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
@@ -1062,6 +1078,11 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
         file={file}
         contextMenu={this.openContextMenu}
         model={this.props.model}
+        onClick={() =>
+          this.props.commands.execute(ContextCommandIDs.gitFileOpen, {
+            files: [file]
+          } as CommandArguments.IGitContextAction as any)
+        }
         onDoubleClick={() => {
           if (!doubleClickDiff) {
             this.props.commands.execute(ContextCommandIDs.gitFileOpen, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,34 +161,6 @@ async function activate(
   translator = translator ?? nullTranslator;
   const trans = translator.load('jupyterlab_git');
 
-  // Map `doubleClickDiff` / `singleClickDiff` boolean keys to the
-  // `fileClickAction` enum in user settings. The schema sets
-  // `"jupyter.lab.transform": true`, so `settingRegistry.load` waits for
-  // this transform before resolving.
-  settingRegistry.transform(plugin.id, {
-    fetch: settingsPlugin => {
-      const user = settingsPlugin.data.user as
-        | { [key: string]: unknown }
-        | undefined;
-      if (!user) {
-        return settingsPlugin;
-      }
-      // Respect an explicit `fileClickAction` if one is set.
-      if (!('fileClickAction' in user)) {
-        if (user['singleClickDiff'] === true) {
-          user['fileClickAction'] = 'diff-on-single';
-        } else if (user['doubleClickDiff'] === true) {
-          user['fileClickAction'] = 'diff-on-double';
-        }
-      }
-      // Always drop the boolean keys so they don't shadow future writes
-      // or trigger schema-validation noise.
-      delete user['doubleClickDiff'];
-      delete user['singleClickDiff'];
-      return settingsPlugin;
-    }
-  });
-
   // Attempt to load application settings
   try {
     settings = await settingRegistry.load(plugin.id);
@@ -196,6 +168,22 @@ async function activate(
     console.error(
       trans.__('Failed to load settings for the Git Extension.\n%1', error)
     );
+  }
+
+  // One-shot migration of the legacy `doubleClickDiff` boolean to the
+  // `fileClickAction` enum. Only users upgrading from a prior version have
+  // `doubleClickDiff` saved.
+  if (settings) {
+    const legacyDoubleClick = settings.get('doubleClickDiff').user;
+    if (legacyDoubleClick !== undefined) {
+      if (
+        legacyDoubleClick === true &&
+        settings.get('fileClickAction').user === undefined
+      ) {
+        await settings.set('fileClickAction', 'diff-on-double');
+      }
+      await settings.remove('doubleClickDiff');
+    }
   }
   const serverSettings = app.serviceManager.serverSettings;
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,34 @@ async function activate(
   translator = translator ?? nullTranslator;
   const trans = translator.load('jupyterlab_git');
 
+  // Map `doubleClickDiff` / `singleClickDiff` boolean keys to the
+  // `fileClickAction` enum in user settings. The schema sets
+  // `"jupyter.lab.transform": true`, so `settingRegistry.load` waits for
+  // this transform before resolving.
+  settingRegistry.transform(plugin.id, {
+    fetch: settingsPlugin => {
+      const user = settingsPlugin.data.user as
+        | { [key: string]: unknown }
+        | undefined;
+      if (!user) {
+        return settingsPlugin;
+      }
+      // Respect an explicit `fileClickAction` if one is set.
+      if (!('fileClickAction' in user)) {
+        if (user['singleClickDiff'] === true) {
+          user['fileClickAction'] = 'diff-on-single';
+        } else if (user['doubleClickDiff'] === true) {
+          user['fileClickAction'] = 'diff-on-double';
+        }
+      }
+      // Always drop the boolean keys so they don't shadow future writes
+      // or trigger schema-validation noise.
+      delete user['doubleClickDiff'];
+      delete user['singleClickDiff'];
+      return settingsPlugin;
+    }
+  });
+
   // Attempt to load application settings
   try {
     settings = await settingRegistry.load(plugin.id);
@@ -287,7 +315,6 @@ async function activate(
       const category = 'Git Operations';
       [
         CommandIDs.gitToggleSimpleStaging,
-        CommandIDs.gitToggleDoubleClickDiff,
         CommandIDs.gitOpenGitignore,
         CommandIDs.gitInit,
         CommandIDs.gitMerge,

--- a/src/model.ts
+++ b/src/model.ts
@@ -2239,23 +2239,16 @@ export class GitExtension implements IGitExtension {
     }
 
     const matches = this._docRegistry?.getFileTypesForPath(path) ?? [];
-    // Prefer a file type whose `extensions` array actually contains the
-    // file's extension. Some extensions (e.g. jupytext) register a
-    // catch-all file type with an empty `extensions` array that matches
-    // by pattern; left to position alone it shadows the
-    // extension-keyed type (so `.csv` would render with the plain file
-    // icon instead of the spreadsheet icon the file browser uses).
-    const dot = path.lastIndexOf('.');
-    if (dot > -1) {
-      const ext = path.slice(dot).toLowerCase();
-      const byExt = matches.find(t =>
-        t.extensions?.some(e => e.toLowerCase() === ext)
-      );
-      if (byExt) {
-        return byExt;
-      }
-    }
-    return matches[0] ?? DocumentRegistry.getDefaultTextFileType();
+    // `getFileTypesForPath` returns pattern matches before extension matches,
+    // so a pattern-only catch-all (e.g. jupytext) can shadow the type
+    // registered against this file's extension. Prefer an extension match.
+    const ext = PathExt.extname(path).toLowerCase();
+    const byExtension = ext
+      ? matches.find(t => t.extensions?.some(e => e.toLowerCase() === ext))
+      : undefined;
+    return (
+      byExtension ?? matches[0] ?? DocumentRegistry.getDefaultTextFileType()
+    );
   }
 
   /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -2238,10 +2238,24 @@ export class GitExtension implements IGitExtension {
       return DocumentRegistry.getDefaultDirectoryFileType();
     }
 
-    return (
-      this._docRegistry?.getFileTypesForPath(path)[0] ??
-      DocumentRegistry.getDefaultTextFileType()
-    );
+    const matches = this._docRegistry?.getFileTypesForPath(path) ?? [];
+    // Prefer a file type whose `extensions` array actually contains the
+    // file's extension. Some extensions (e.g. jupytext) register a
+    // catch-all file type with an empty `extensions` array that matches
+    // by pattern; left to position alone it shadows the
+    // extension-keyed type (so `.csv` would render with the plain file
+    // icon instead of the spreadsheet icon the file browser uses).
+    const dot = path.lastIndexOf('.');
+    if (dot > -1) {
+      const ext = path.slice(dot).toLowerCase();
+      const byExt = matches.find(t =>
+        t.extensions?.some(e => e.toLowerCase() === ext)
+      );
+      if (byExt) {
+        return byExt;
+      }
+    }
+    return matches[0] ?? DocumentRegistry.getDefaultTextFileType();
   }
 
   /**

--- a/src/style/FileItemStyle.ts
+++ b/src/style/FileItemStyle.ts
@@ -45,7 +45,6 @@ export const fileStyle = style(
     alignItems: 'center',
     boxSizing: 'border-box',
     color: 'var(--jp-ui-font-color1)',
-    cursor: 'pointer',
     lineHeight: 'var(--jp-private-running-item-height)',
     padding: '0px 4px',
     listStyleType: 'none',
@@ -58,6 +57,12 @@ export const fileStyle = style(
   },
   showButtonOnHover
 );
+
+// Applied to rows whose single-click triggers a navigation action
+// (opening a diff or the file) so the cursor signals interactivity.
+export const fileClickableStyle = style({
+  cursor: 'pointer'
+});
 
 export const selectedFileStyle = style(
   (() => {

--- a/src/style/FileItemStyle.ts
+++ b/src/style/FileItemStyle.ts
@@ -2,11 +2,8 @@ import { style } from 'typestyle';
 import type { NestedCSSProperties } from 'typestyle/lib/types';
 import { actionButtonStyle, showButtonOnHover } from './ActionButtonStyle';
 
-// Status indicator: a colored, bold monospace letter showing the git
-// status code. The 10 + 18 + 6 = 34px total footprint matches the
-// section header count chip so row action buttons align with header
-// buttons; the 18px inline-flex slot keeps every letter in the same
-// vertical column regardless of glyph width.
+// 10 + 18 + 6 = 34px total width matches the section header count chip,
+// so row action buttons align with the header buttons.
 export const fileChangedLabelStyle = style({
   display: 'inline-flex',
   alignItems: 'center',
@@ -20,7 +17,6 @@ export const fileChangedLabelStyle = style({
   fontWeight: 600
 });
 
-// Semantic per-status color overrides applied on top of the base badge.
 export const fileChangedLabelAddedStyle = style({
   color: 'var(--jp-success-color1)'
 });

--- a/src/style/FileItemStyle.ts
+++ b/src/style/FileItemStyle.ts
@@ -2,6 +2,45 @@ import { style } from 'typestyle';
 import type { NestedCSSProperties } from 'typestyle/lib/types';
 import { actionButtonStyle, showButtonOnHover } from './ActionButtonStyle';
 
+// Status indicator: a colored, bold monospace letter showing the git
+// status code. The 10 + 18 + 6 = 34px total footprint matches the
+// section header count chip so row action buttons align with header
+// buttons; the 18px inline-flex slot keeps every letter in the same
+// vertical column regardless of glyph width.
+export const fileChangedLabelStyle = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '18px',
+  height: '18px',
+  marginLeft: '10px',
+  marginRight: '6px',
+  fontFamily: 'var(--jp-code-font-family)',
+  fontSize: 'var(--jp-ui-font-size0)',
+  fontWeight: 600
+});
+
+// Semantic per-status color overrides applied on top of the base badge.
+export const fileChangedLabelAddedStyle = style({
+  color: 'var(--jp-success-color1)'
+});
+
+export const fileChangedLabelDeletedStyle = style({
+  color: 'var(--jp-error-color1)'
+});
+
+export const fileChangedLabelModifiedStyle = style({
+  color: 'var(--jp-warn-color1)'
+});
+
+export const fileChangedLabelInfoStyle = style({
+  color: 'var(--jp-info-color1)'
+});
+
+export const selectedFileChangedLabelStyle = style({
+  color: 'white !important'
+});
+
 export const fileStyle = style(
   {
     userSelect: 'none',
@@ -10,6 +49,7 @@ export const fileStyle = style(
     alignItems: 'center',
     boxSizing: 'border-box',
     color: 'var(--jp-ui-font-color1)',
+    cursor: 'pointer',
     lineHeight: 'var(--jp-private-running-item-height)',
     padding: '0px 4px',
     listStyleType: 'none',
@@ -61,28 +101,6 @@ export const selectedFileStyle = style(
   })()
 );
 
-export const fileChangedLabelStyle = style({
-  fontSize: '10px',
-  marginLeft: '5px'
-});
-
-export const selectedFileChangedLabelStyle = style({
-  color: 'white !important'
-});
-
-export const fileChangedLabelBrandStyle = style({
-  color: 'var(--jp-brand-color0)'
-});
-
-export const fileChangedLabelWarnStyle = style({
-  color: 'var(--jp-warn-color0)',
-  fontWeight: 'bold'
-});
-
-export const fileChangedLabelInfoStyle = style({
-  color: 'var(--jp-info-color0)'
-});
-
 export const fileGitButtonStyle = style({
   display: 'none'
 });
@@ -108,5 +126,7 @@ export const checkboxLabelContainerStyle = style({
 export const checkboxLabelLastContainerStyle = style({
   display: 'flex',
   marginLeft: 'auto',
+  // Don't shrink so long file names truncate instead of clipping the status.
+  flexShrink: 0,
   overflow: 'hidden'
 });

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -697,6 +697,16 @@ export interface IGitExtension extends IDisposable {
 }
 
 export namespace Git {
+  /**
+   * Possible values of the `fileClickAction` setting controlling what
+   * happens when clicking or double-clicking a file in the Git panel.
+   */
+  export type FileClickAction =
+    | 'select-only'
+    | 'open-on-double'
+    | 'diff-on-double'
+    | 'diff-on-single';
+
   export namespace Diff {
     /**
      * Diff widget interface
@@ -1409,7 +1419,6 @@ export enum CommandIDs {
   gitInit = 'git:init',
   gitOpenUrl = 'git:open-url',
   gitToggleSimpleStaging = 'git:toggle-simple-staging',
-  gitToggleDoubleClickDiff = 'git:toggle-double-click-diff',
   gitManageRemote = 'git:manage-remote',
   gitClone = 'git:clone',
   gitMerge = 'git:merge',


### PR DESCRIPTION
Follow-up to #1474 

- [x] Improve the styling of the status markers: A, U, D, M
- [x] Align buttons
- [x] Clicking on the file opens the diff view, similar to other editors (configurable via the settings)

**Before**


https://github.com/user-attachments/assets/649b0504-4aba-497d-a928-4cd33d06a6dd



**After**


https://github.com/user-attachments/assets/052441dd-4b7d-4588-b867-e3346307c5eb

