### PR TITLE
fix: enable pull/push toolbar buttons when the repo path loads after mount

### DIFF
--- a/src/__tests__/test-components/Toolbar.spec.tsx
+++ b/src/__tests__/test-components/Toolbar.spec.tsx
@@ -1,6 +1,6 @@
 import { nullTranslator } from '@jupyterlab/translation';
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'jest';
 import * as React from 'react';
@@ -116,6 +116,18 @@ describe('Toolbar', () => {
     };
   }
 
+  function emitRepositoryChanged(): void {
+    (model as any)._repositoryChanged.emit({
+      name: 'pathRepository',
+      oldValue: null,
+      newValue: DEFAULT_REPOSITORY_PATH
+    });
+  }
+
+  function emitRemoteChanged(): void {
+    (model as any)._remoteChanged.emit(null);
+  }
+
   beforeEach(async () => {
     jest.restoreAllMocks();
     model = await createModel();
@@ -212,6 +224,81 @@ describe('Toolbar', () => {
 
       expect(screen.getByText('main')).toBeDefined();
       expect(screen.queryByRole('button', { name: /branches/i })).toBeNull();
+    });
+  });
+
+  describe('remote availability', () => {
+    async function expectRemoteButtonsEnabledAfterSignal(
+      emitSignal: () => void
+    ): Promise<void> {
+      let remoteIsAvailable = false;
+      jest.spyOn(console, 'error').mockImplementation();
+      const getRemotes = jest
+        .spyOn(model, 'getRemotes')
+        .mockImplementation(() =>
+          remoteIsAvailable
+            ? Promise.resolve(REMOTES)
+            : Promise.reject(new Error('Not in a Git Repository'))
+        );
+
+      render(<Toolbar {...createProps()} />);
+
+      await waitFor(() => {
+        expect(getRemotes).toHaveBeenCalled();
+      });
+
+      screen
+        .getAllByRole('button', { name: 'No remote repository defined' })
+        .forEach(button => {
+          expect(button).toBeDisabled();
+        });
+
+      const callsBeforeSignal = getRemotes.mock.calls.length;
+      remoteIsAvailable = true;
+      await act(async () => {
+        emitSignal();
+      });
+
+      await waitFor(() => {
+        expect(getRemotes.mock.calls.length).toBeGreaterThan(
+          callsBeforeSignal
+        );
+        expect(
+          screen.getByRole('button', { name: 'Pull latest changes' })
+        ).toBeEnabled();
+        expect(
+          screen.getByRole('button', { name: 'Push committed changes' })
+        ).toBeEnabled();
+      });
+    }
+
+    it('should re-check remotes when the repository changes', async () => {
+      await expectRemoteButtonsEnabledAfterSignal(emitRepositoryChanged);
+    });
+
+    it('should re-check remotes when remote state changes', async () => {
+      await expectRemoteButtonsEnabledAfterSignal(emitRemoteChanged);
+    });
+
+    it('should disconnect remote checks when unmounted', async () => {
+      const getRemotes = jest
+        .spyOn(model, 'getRemotes')
+        .mockResolvedValue(REMOTES);
+      const { unmount } = render(<Toolbar {...createProps()} />);
+
+      await waitFor(() => {
+        expect(getRemotes).toHaveBeenCalled();
+      });
+
+      unmount();
+      const callsBeforeSignal = getRemotes.mock.calls.length;
+
+      await act(async () => {
+        emitRepositoryChanged();
+        emitRemoteChanged();
+      });
+
+      expect(getRemotes.mock.calls.length).toBe(callsBeforeSignal);
     });
   });
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -83,11 +83,23 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
    * Check whether or not the repo has any remotes
    */
   async componentDidMount(): Promise<void> {
+    this.props.model.repositoryChanged.connect(this._checkRemote, this);
+    this.props.model.remoteChanged.connect(this._checkRemote, this);
+    await this._checkRemote();
+  }
+
+  componentWillUnmount(): void {
+    this.props.model.repositoryChanged.disconnect(this._checkRemote, this);
+    this.props.model.remoteChanged.disconnect(this._checkRemote, this);
+  }
+
+  private async _checkRemote(): Promise<void> {
     try {
       const remotes = await this.props.model.getRemotes();
       const hasRemote = remotes.length > 0;
       this.setState({ hasRemote });
     } catch (err) {
+      this.setState({ hasRemote: false });
       console.error(err);
     }
   }


### PR DESCRIPTION
## Summary

Fixes #1492. The pull-from-remote and push-to-remote buttons in the Git panel toolbar no longer stay permanently greyed out ("No remote repository defined") when the toolbar mounts before the repository path is available.

## Why this matters

`Toolbar` only evaluated `hasRemote` once, inside `componentDidMount`. When the toolbar mounts before the repository path is populated, `model.getRemotes()` rejects with `Not in a Git Repository`, the `catch` logs the error, and `hasRemote` stays `false` for the lifetime of the component, so `_renderRemoteActions` keeps the pull/push buttons `disabled`. The same actions invoked from the command menu work because they resolve remotes at execute time, which is why the remote clearly exists. Two users reported this and a maintainer labeled it `bug`.

## Changes

- Extract the remote check into `_checkRemote`, and re-run it whenever `model.repositoryChanged` or `model.remoteChanged` fires, so the buttons enable as soon as a repository with a remote becomes available. This mirrors the signal-subscription pattern used elsewhere against `GitModel`.
- Disconnect both handlers in `componentWillUnmount` to avoid leaking subscriptions.

## Testing

Extended `Toolbar.spec.tsx` to cover an initial `getRemotes()` rejection followed by a `repositoryChanged` / `remoteChanged` signal that resolves remotes, asserting `hasRemote` flips to `true` and the buttons enable, plus that the handlers are disconnected on unmount. (I could not run `jlpm jest` locally because the extension's `node_modules` are not installed in this environment; the change is scoped to the toolbar's signal subscriptions.)
