### PR TITLE
Bump nodejs to 22 in the binder environment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - python >=3.10,<3.11.0a0
   - jupyterlab >=4.0.0,<5
   # labextension build dependencies
-  - nodejs >=18,<19
+  - nodejs >=22.12,<23
   - pip
   - wheel
   # additional packages for demos


### PR DESCRIPTION
This should help fix the failing Binder builds on PRs:

<img width="2238" height="1142" alt="image" src="https://github.com/user-attachments/assets/fcd795af-1033-4ec5-ba9b-4fcc6abce67c" />

