### PR TITLE
Add support for Git worktrees

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ node_modules
 **/package.json
 !/package.json
 jupyterlab_git
+**/worktrees

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ For older versions of JupyterLab, go to:
 - Open the Git extension from the _Git_ tab on the left panel
 - [Set up authentication](#authentication-to-remote-repository-hosts)
 
+### Worktrees
+
+The extension supports [Git worktrees](https://git-scm.com/docs/git-worktree), which allow checking out more than one branch of the same repository at a time — for instance to follow the work of a coding agent on a separate branch.
+
+- The _Worktrees_ section of the Git panel lists the worktrees of the current repository whenever linked worktrees exist — including worktrees created outside of JupyterLab, e.g. by coding agents. Clicking a worktree opens it in the file browser, and the whole Git panel then operates on that worktree.
+- _Git > Add Worktree…_ (also available from the command palette) creates a new worktree for an existing branch, or for a new branch. By default worktrees are created in the `worktrees` folder of the repository, which is automatically excluded from the repository status.
+- Branches checked out in another worktree are flagged with a worktree icon in the branch list; selecting such a branch offers to open its worktree instead of failing the checkout.
+
+Note: worktrees located outside of the Jupyter server root folder are listed but cannot be opened.
+
 ## Install
 
 > **Note for users upgrading from a previous version:**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,11 @@ export default tseslint.config(
       '**/__tests__',
       'ui-tests',
       'packages',
-      'testutils'
+      'testutils',
+      // Nested Git worktrees hold their own copy of the sources
+      '**/worktrees',
+      '.venv',
+      '**/.ipynb_checkpoints'
     ]
   },
   { plugins: { jupyter } },

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,10 +30,13 @@ module.exports = {
     '<rootDir>/build',
     '<rootDir>/jupyterlab_git',
     '<rootDir>/jupyter-config',
-    '<rootDir>/ui-tests'
+    '<rootDir>/ui-tests',
+    // Nested Git worktrees hold their own copy of the sources
+    '/worktrees/'
   ],
   reporters: ['default', 'github-actions'],
   setupFiles: ['<rootDir>/testutils/jest-setup-files.js'],
+  testPathIgnorePatterns: ['/node_modules/', '/worktrees/'],
   testRegex: 'src/.*/.*.spec.ts[x]?$',
   transformIgnorePatterns: [`/node_modules/(?!${esModules}).+`]
 };

--- a/packages/core/jupyterlab_git_core/git.py
+++ b/packages/core/jupyterlab_git_core/git.py
@@ -2436,24 +2436,6 @@ class Git:
 
         path: str
             Git path repository
-
-        Returns:
-            dict: {
-                "code": int,
-                "worktrees": [
-                    {
-                        "path": str,  # absolute path as reported by Git
-                        "head": Optional[str],
-                        "branch": Optional[str],  # short branch name
-                        "detached": bool,
-                        "bare": bool,
-                        "locked": bool,
-                        "prunable": bool,
-                        "is_main": bool,
-                        "is_current": bool,
-                    }
-                ]
-            }
         """
         cmd = ["git", "worktree", "list", "--porcelain"]
 
@@ -2489,7 +2471,7 @@ class Git:
             elif key == "HEAD":
                 entry["head"] = value
             elif key == "branch":
-                entry["branch"] = value.split("refs/heads/", 1)[-1]
+                entry["branch"] = value.removeprefix("refs/heads/")
             elif key == "detached":
                 entry["detached"] = True
             elif key == "bare":
@@ -2502,15 +2484,19 @@ class Git:
         # Worktrees nested inside the current working tree would show up as
         # untracked files in its status; exclude them, including worktrees
         # created outside of JupyterLab (e.g. by coding agents).
-        for entry in worktrees:
-            if (
-                entry["is_main"]
-                or entry["is_current"]
-                or entry["bare"]
-                or entry["prunable"]
-            ):
-                continue
-            await self._ensure_worktree_excluded(path, entry["path"])
+        await self._ensure_worktrees_excluded(
+            path,
+            [
+                entry["path"]
+                for entry in worktrees
+                if not (
+                    entry["is_main"]
+                    or entry["is_current"]
+                    or entry["bare"]
+                    or entry["prunable"]
+                )
+            ],
+        )
 
         return {"code": code, "worktrees": worktrees}
 
@@ -2548,7 +2534,7 @@ class Git:
         if code != 0:
             return {"code": code, "command": " ".join(cmd), "message": error}
 
-        await self._ensure_worktree_excluded(path, worktree_path)
+        await self._ensure_worktrees_excluded(path, [worktree_path])
 
         return {"code": code, "message": output.strip() or error.strip()}
 
@@ -2563,12 +2549,11 @@ class Git:
         worktree_path: str
             Absolute path of the worktree to remove
         force: bool
-            Whether to remove the worktree even if it is dirty or locked;
-            passes --force twice as Git requires the double flag for locked
-            worktrees
+            Whether to remove the worktree even if it is dirty or locked
         """
         cmd = ["git", "worktree", "remove"]
         if force:
+            # Git requires the flag twice to remove locked worktrees
             cmd.extend(["--force", "--force"])
         cmd.append(worktree_path)
 
@@ -2579,23 +2564,25 @@ class Git:
 
         return {"code": code, "message": output.strip()}
 
-    async def _ensure_worktree_excluded(self, path: str, worktree_path: str) -> None:
-        """Exclude a worktree nested inside the working tree at ``path`` from
-        its Git status.
-
-        The exclude entry is written to ``info/exclude`` in the common git
-        directory so the nested worktree does not show up as untracked files.
-        Does nothing if the worktree lies outside of ``path``.
+    async def _ensure_worktrees_excluded(
+        self, path: str, worktree_paths: List[str]
+    ) -> None:
+        """Exclude the worktrees nested inside the working tree at ``path``
+        from its Git status, by adding entries to the ``info/exclude`` file.
         """
-        relative_path = os.path.relpath(worktree_path, path)
-        if (
-            relative_path in (".", "")
-            or relative_path.startswith("..")
-            or os.path.isabs(relative_path)
-        ):
-            return
+        patterns = []
+        for worktree_path in worktree_paths:
+            relative_path = os.path.relpath(worktree_path, path)
+            if (
+                relative_path in (".", "")
+                or relative_path.startswith("..")
+                or os.path.isabs(relative_path)
+            ):
+                continue
+            patterns.append("/" + Path(relative_path).as_posix() + "/")
 
-        pattern = "/" + Path(relative_path).as_posix() + "/"
+        if not patterns:
+            return
 
         cmd = ["git", "rev-parse", "--git-common-dir"]
         code, output, _ = await self.__execute(cmd, cwd=path)
@@ -2612,15 +2599,19 @@ class Git:
             if os.path.exists(exclude_path):
                 with open(exclude_path) as f:
                     content = f.read()
-            if pattern not in content.splitlines():
+            lines = content.splitlines()
+            missing = [pattern for pattern in patterns if pattern not in lines]
+            if missing:
                 os.makedirs(os.path.dirname(exclude_path), exist_ok=True)
                 with open(exclude_path, "a") as f:
                     if content and not content.endswith("\n"):
                         f.write("\n")
-                    f.write(pattern + "\n")
+                    f.write("\n".join(missing) + "\n")
         except OSError:
             get_logger().warning(
-                "Failed to exclude worktree {!s} from Git status".format(worktree_path),
+                "Failed to exclude worktrees {!s} from Git status".format(
+                    worktree_paths
+                ),
                 exc_info=True,
             )
 

--- a/packages/core/jupyterlab_git_core/git.py
+++ b/packages/core/jupyterlab_git_core/git.py
@@ -109,6 +109,29 @@ class RebaseAction(Enum):
     ABORT = 3
 
 
+def get_index_lock_path(cwd: str) -> str:
+    """Return the path of the ``index.lock`` file for the repository at ``cwd``.
+
+    In the main worktree, ``.git`` is a directory containing the lock file.
+    In linked worktrees and submodules, ``.git`` is a file with a
+    ``gitdir: <path>`` pointer to the actual git directory holding the lock;
+    that pointer may be relative to ``cwd``.
+    """
+    dot_git = os.path.join(cwd, ".git")
+    if os.path.isfile(dot_git):
+        try:
+            with open(dot_git) as f:
+                content = f.read().strip()
+        except OSError:
+            content = ""
+        if content.startswith("gitdir:"):
+            git_dir = content[len("gitdir:") :].strip()
+            if not os.path.isabs(git_dir):
+                git_dir = os.path.join(cwd, git_dir)
+            return os.path.join(git_dir, "index.lock")
+    return os.path.join(dot_git, "index.lock")
+
+
 async def execute(
     cmdline: "List[str]",
     cwd: "str",
@@ -193,7 +216,7 @@ async def execute(
     try:
         # Ensure our execution operation will succeed by first checking and waiting for the lock to be removed
         time_slept = 0
-        lockfile = os.path.join(cwd, ".git", "index.lock")
+        lockfile = get_index_lock_path(cwd)
         while os.path.exists(lockfile) and time_slept < MAX_WAIT_FOR_LOCK_S:
             await anyio.sleep(CHECK_LOCK_INTERVAL_S)
             time_slept += CHECK_LOCK_INTERVAL_S
@@ -869,7 +892,13 @@ class Git:
         Execute 'git for-each-ref' command on refs/heads & return the result.
         """
         # Format reference: https://git-scm.com/docs/git-for-each-ref#_field_names
-        formats = ["refname:short", "objectname", "upstream:short", "HEAD"]
+        formats = [
+            "refname:short",
+            "objectname",
+            "upstream:short",
+            "HEAD",
+            "worktreepath",
+        ]
         cmd = [
             "git",
             "for-each-ref",
@@ -884,7 +913,7 @@ class Git:
         current_branch = None
         results = []
         try:
-            for name, commit_sha, upstream_name, is_current_branch in (
+            for name, commit_sha, upstream_name, is_current_branch, worktree_path in (
                 line.split("\t") for line in output.splitlines()
             ):
                 is_current_branch = bool(is_current_branch.strip())
@@ -896,6 +925,9 @@ class Git:
                     "upstream": upstream_name if upstream_name else None,
                     "top_commit": commit_sha,
                     "tag": None,
+                    # Absolute path of the worktree where the branch is
+                    # checked out, or None if it is not checked out anywhere
+                    "worktree": worktree_path if worktree_path else None,
                 }
                 results.append(branch)
                 if is_current_branch:
@@ -913,6 +945,7 @@ class Git:
                     "upstream": None,
                     "top_commit": None,
                     "tag": None,
+                    "worktree": None,
                 }
                 results.append(branch)
                 current_branch = branch
@@ -2396,6 +2429,200 @@ class Git:
             results.append(submodule)
 
         return {"code": code, "submodules": results, "error": error}
+
+    async def worktree_list(self, path: str) -> dict:
+        """
+        Execute git worktree list --porcelain & parse the result.
+
+        path: str
+            Git path repository
+
+        Returns:
+            dict: {
+                "code": int,
+                "worktrees": [
+                    {
+                        "path": str,  # absolute path as reported by Git
+                        "head": Optional[str],
+                        "branch": Optional[str],  # short branch name
+                        "detached": bool,
+                        "bare": bool,
+                        "locked": bool,
+                        "prunable": bool,
+                        "is_main": bool,
+                        "is_current": bool,
+                    }
+                ]
+            }
+        """
+        cmd = ["git", "worktree", "list", "--porcelain"]
+
+        code, output, error = await self.__execute(cmd, cwd=path)
+
+        if code != 0:
+            return {"code": code, "command": " ".join(cmd), "message": error}
+
+        current_path = os.path.realpath(path)
+        worktrees = []
+        entry = None
+        for line in output.splitlines():
+            if not line.strip():
+                entry = None
+                continue
+            key, _, value = line.partition(" ")
+            if key == "worktree":
+                entry = {
+                    "path": value,
+                    "head": None,
+                    "branch": None,
+                    "detached": False,
+                    "bare": False,
+                    "locked": False,
+                    "prunable": False,
+                    # The main worktree (or bare repository) is always listed first
+                    "is_main": len(worktrees) == 0,
+                    "is_current": os.path.realpath(value) == current_path,
+                }
+                worktrees.append(entry)
+            elif entry is None:
+                continue
+            elif key == "HEAD":
+                entry["head"] = value
+            elif key == "branch":
+                entry["branch"] = value.split("refs/heads/", 1)[-1]
+            elif key == "detached":
+                entry["detached"] = True
+            elif key == "bare":
+                entry["bare"] = True
+            elif key == "locked":
+                entry["locked"] = True
+            elif key == "prunable":
+                entry["prunable"] = True
+
+        # Worktrees nested inside the current working tree would show up as
+        # untracked files in its status; exclude them, including worktrees
+        # created outside of JupyterLab (e.g. by coding agents).
+        for entry in worktrees:
+            if (
+                entry["is_main"]
+                or entry["is_current"]
+                or entry["bare"]
+                or entry["prunable"]
+            ):
+                continue
+            await self._ensure_worktree_excluded(path, entry["path"])
+
+        return {"code": code, "worktrees": worktrees}
+
+    async def worktree_add(
+        self,
+        path: str,
+        worktree_path: str,
+        branch: str,
+        new_branch: bool = False,
+        start_point: Optional[str] = None,
+    ) -> dict:
+        """
+        Execute git worktree add & return the result.
+
+        path: str
+            Git path repository
+        worktree_path: str
+            Absolute path at which the worktree is created
+        branch: str
+            Branch to check out in the new worktree; created if new_branch is True
+        new_branch: bool
+            Whether to create the branch
+        start_point: Optional[str]
+            Commit-ish the new branch starts from; defaults to HEAD
+        """
+        if new_branch:
+            cmd = ["git", "worktree", "add", "-b", branch, worktree_path]
+            if start_point:
+                cmd.append(start_point)
+        else:
+            cmd = ["git", "worktree", "add", worktree_path, branch]
+
+        code, output, error = await self.__execute(cmd, cwd=path)
+
+        if code != 0:
+            return {"code": code, "command": " ".join(cmd), "message": error}
+
+        await self._ensure_worktree_excluded(path, worktree_path)
+
+        return {"code": code, "message": output.strip() or error.strip()}
+
+    async def worktree_remove(
+        self, path: str, worktree_path: str, force: bool = False
+    ) -> dict:
+        """
+        Execute git worktree remove & return the result.
+
+        path: str
+            Git path repository
+        worktree_path: str
+            Absolute path of the worktree to remove
+        force: bool
+            Whether to remove the worktree even if it is dirty or locked;
+            passes --force twice as Git requires the double flag for locked
+            worktrees
+        """
+        cmd = ["git", "worktree", "remove"]
+        if force:
+            cmd.extend(["--force", "--force"])
+        cmd.append(worktree_path)
+
+        code, output, error = await self.__execute(cmd, cwd=path)
+
+        if code != 0:
+            return {"code": code, "command": " ".join(cmd), "message": error}
+
+        return {"code": code, "message": output.strip()}
+
+    async def _ensure_worktree_excluded(self, path: str, worktree_path: str) -> None:
+        """Exclude a worktree nested inside the working tree at ``path`` from
+        its Git status.
+
+        The exclude entry is written to ``info/exclude`` in the common git
+        directory so the nested worktree does not show up as untracked files.
+        Does nothing if the worktree lies outside of ``path``.
+        """
+        relative_path = os.path.relpath(worktree_path, path)
+        if (
+            relative_path in (".", "")
+            or relative_path.startswith("..")
+            or os.path.isabs(relative_path)
+        ):
+            return
+
+        pattern = "/" + Path(relative_path).as_posix() + "/"
+
+        cmd = ["git", "rev-parse", "--git-common-dir"]
+        code, output, _ = await self.__execute(cmd, cwd=path)
+        if code != 0:
+            return
+
+        common_dir = output.strip()
+        if not os.path.isabs(common_dir):
+            common_dir = os.path.join(path, common_dir)
+        exclude_path = os.path.join(common_dir, "info", "exclude")
+
+        try:
+            content = ""
+            if os.path.exists(exclude_path):
+                with open(exclude_path) as f:
+                    content = f.read()
+            if pattern not in content.splitlines():
+                os.makedirs(os.path.dirname(exclude_path), exist_ok=True)
+                with open(exclude_path, "a") as f:
+                    if content and not content.endswith("\n"):
+                        f.write("\n")
+                    f.write(pattern + "\n")
+        except OSError:
+            get_logger().warning(
+                "Failed to exclude worktree {!s} from Git status".format(worktree_path),
+                exc_info=True,
+            )
 
     @property
     def excluded_paths(self) -> List[str]:

--- a/packages/core/tests/test_branch.py
+++ b/packages/core/tests/test_branch.py
@@ -658,9 +658,9 @@ async def test_branch_success():
     with patch("jupyterlab_git_core.git.execute") as mock_execute:
         # Given
         process_output_heads = [
-            "feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/feature-foo\t*",
-            "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t ",
-            "feature-bar\t01234567899999abcdefghijklmnopqrstuvwxyz\t\t ",
+            "feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/feature-foo\t*\t/bin/test_curr_path",
+            "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t \t",
+            "feature-bar\t01234567899999abcdefghijklmnopqrstuvwxyz\t\t \t/bin/worktrees/feature-bar",
         ]
         process_output_remotes = [
             "origin/feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123",
@@ -684,6 +684,7 @@ async def test_branch_success():
                     "upstream": "origin/feature-foo",
                     "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
                     "tag": None,
+                    "worktree": "/bin/test_curr_path",
                 },
                 {
                     "is_current_branch": False,
@@ -692,6 +693,7 @@ async def test_branch_success():
                     "upstream": "origin/main",
                     "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
                     "tag": None,
+                    "worktree": None,
                 },
                 {
                     "is_current_branch": False,
@@ -700,6 +702,7 @@ async def test_branch_success():
                     "upstream": None,
                     "top_commit": "01234567899999abcdefghijklmnopqrstuvwxyz",
                     "tag": None,
+                    "worktree": "/bin/worktrees/feature-bar",
                 },
                 {
                     "is_current_branch": False,
@@ -725,6 +728,7 @@ async def test_branch_success():
                 "upstream": "origin/feature-foo",
                 "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
                 "tag": None,
+                "worktree": "/bin/test_curr_path",
             },
         }
 
@@ -739,7 +743,7 @@ async def test_branch_success():
                     [
                         "git",
                         "for-each-ref",
-                        "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)",
+                        "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)%09%(worktreepath)",
                         "refs/heads/",
                     ],
                     cwd=str(Path("/bin") / "test_curr_path"),
@@ -776,7 +780,7 @@ async def test_branch_failure():
         expected_cmd = [
             "git",
             "for-each-ref",
-            "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)",
+            "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)%09%(worktreepath)",
             "refs/heads/",
         ]
         mock_execute.return_value = (
@@ -811,7 +815,7 @@ async def test_branch_success_detached_head():
     with patch("jupyterlab_git_core.git.execute") as mock_execute:
         # Given
         process_output_heads = [
-            "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t "
+            "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t \t"
         ]
         process_output_remotes = [
             "origin/feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123"
@@ -843,6 +847,7 @@ async def test_branch_success_detached_head():
                     "upstream": "origin/main",
                     "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
                     "tag": None,
+                    "worktree": None,
                 },
                 {
                     "is_current_branch": True,
@@ -851,6 +856,7 @@ async def test_branch_success_detached_head():
                     "upstream": None,
                     "top_commit": None,
                     "tag": None,
+                    "worktree": None,
                 },
                 {
                     "is_current_branch": False,
@@ -868,6 +874,7 @@ async def test_branch_success_detached_head():
                 "upstream": None,
                 "top_commit": None,
                 "tag": None,
+                "worktree": None,
             },
         }
 
@@ -882,7 +889,7 @@ async def test_branch_success_detached_head():
                     [
                         "git",
                         "for-each-ref",
-                        "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)",
+                        "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)%09%(worktreepath)",
                         "refs/heads/",
                     ],
                     cwd=str(Path("/bin") / "test_curr_path"),
@@ -935,8 +942,8 @@ async def test_branch_success_rebasing():
     with patch("jupyterlab_git_core.git.execute") as mock_execute:
         # Given
         process_output_heads = [
-            "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t ",
-            "feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/feature-foo\t ",
+            "main\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/main\t \t",
+            "feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123\torigin/feature-foo\t \t",
         ]
         process_output_remotes = [
             "origin/feature-foo\tabcdefghijklmnopqrstuvwxyz01234567890123"
@@ -969,6 +976,7 @@ async def test_branch_success_rebasing():
                     "upstream": "origin/main",
                     "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
                     "tag": None,
+                    "worktree": None,
                 },
                 {
                     "is_current_branch": False,
@@ -977,6 +985,7 @@ async def test_branch_success_rebasing():
                     "upstream": "origin/feature-foo",
                     "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
                     "tag": None,
+                    "worktree": None,
                 },
                 {
                     "is_current_branch": True,
@@ -985,6 +994,7 @@ async def test_branch_success_rebasing():
                     "upstream": None,
                     "top_commit": None,
                     "tag": None,
+                    "worktree": None,
                 },
                 {
                     "is_current_branch": False,
@@ -1002,6 +1012,7 @@ async def test_branch_success_rebasing():
                 "upstream": None,
                 "top_commit": None,
                 "tag": None,
+                "worktree": None,
             },
         }
 
@@ -1016,7 +1027,7 @@ async def test_branch_success_rebasing():
                     [
                         "git",
                         "for-each-ref",
-                        "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)",
+                        "--format=%(refname:short)%09%(objectname)%09%(upstream:short)%09%(HEAD)%09%(worktreepath)",
                         "refs/heads/",
                     ],
                     cwd=str(Path("/bin") / "test_curr_path"),

--- a/packages/core/tests/test_worktree.py
+++ b/packages/core/tests/test_worktree.py
@@ -1,0 +1,522 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jupyterlab_git_core.git import Git, get_index_lock_path
+
+
+@pytest.mark.asyncio
+async def test_worktree_list_success(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        main_path = tmp_path / "repo"
+        main_path.mkdir()
+        linked_path = tmp_path / "repo" / ".worktrees" / "feature"
+        detached_path = tmp_path / "wt-detached"
+        locked_path = tmp_path / "wt-locked"
+        prunable_path = tmp_path / "wt-prunable"
+
+        process_output = [
+            "worktree {}".format(main_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/main",
+            "",
+            "worktree {}".format(linked_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/feature",
+            "",
+            "worktree {}".format(detached_path),
+            "HEAD 01234567899999abcdefghijklmnopqrstuvwxyz",
+            "detached",
+            "",
+            "worktree {}".format(locked_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/locked-branch",
+            "locked test lock reason",
+            "",
+            "worktree {}".format(prunable_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/prunable-branch",
+            "prunable gitdir file points to non-existent location",
+            "",
+        ]
+        mock_execute.side_effect = [
+            # Response for git worktree list
+            (0, "\n".join(process_output), ""),
+            # Response for git rev-parse --git-common-dir, triggered by the
+            # exclusion of the nested worktree
+            (0, ".git", ""),
+        ]
+
+        # When
+        actual_response = await Git().worktree_list(path=str(main_path))
+
+        # Then
+        assert mock_execute.call_args_list[0].args[0] == [
+            "git",
+            "worktree",
+            "list",
+            "--porcelain",
+        ]
+
+        # The worktree nested inside the working tree is excluded from its
+        # status, even though it was not created through the extension
+        exclude_file = main_path / ".git" / "info" / "exclude"
+        assert exclude_file.read_text() == "/.worktrees/feature/\n"
+        assert actual_response == {
+            "code": 0,
+            "worktrees": [
+                {
+                    "path": str(main_path),
+                    "head": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                    "branch": "main",
+                    "detached": False,
+                    "bare": False,
+                    "locked": False,
+                    "prunable": False,
+                    "is_main": True,
+                    "is_current": True,
+                },
+                {
+                    "path": str(linked_path),
+                    "head": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                    "branch": "feature",
+                    "detached": False,
+                    "bare": False,
+                    "locked": False,
+                    "prunable": False,
+                    "is_main": False,
+                    "is_current": False,
+                },
+                {
+                    "path": str(detached_path),
+                    "head": "01234567899999abcdefghijklmnopqrstuvwxyz",
+                    "branch": None,
+                    "detached": True,
+                    "bare": False,
+                    "locked": False,
+                    "prunable": False,
+                    "is_main": False,
+                    "is_current": False,
+                },
+                {
+                    "path": str(locked_path),
+                    "head": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                    "branch": "locked-branch",
+                    "detached": False,
+                    "bare": False,
+                    "locked": True,
+                    "prunable": False,
+                    "is_main": False,
+                    "is_current": False,
+                },
+                {
+                    "path": str(prunable_path),
+                    "head": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                    "branch": "prunable-branch",
+                    "detached": False,
+                    "bare": False,
+                    "locked": False,
+                    "prunable": True,
+                    "is_main": False,
+                    "is_current": False,
+                },
+            ],
+        }
+
+
+@pytest.mark.asyncio
+async def test_worktree_list_bare_repository(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        bare_path = tmp_path / "repo.git"
+        linked_path = tmp_path / "wt-main"
+
+        process_output = [
+            "worktree {}".format(bare_path),
+            "bare",
+            "",
+            "worktree {}".format(linked_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/main",
+            "",
+        ]
+        mock_execute.return_value = (0, "\n".join(process_output), "")
+
+        # When
+        actual_response = await Git().worktree_list(path=str(linked_path))
+
+        # Then
+        assert actual_response == {
+            "code": 0,
+            "worktrees": [
+                {
+                    "path": str(bare_path),
+                    "head": None,
+                    "branch": None,
+                    "detached": False,
+                    "bare": True,
+                    "locked": False,
+                    "prunable": False,
+                    "is_main": True,
+                    "is_current": False,
+                },
+                {
+                    "path": str(linked_path),
+                    "head": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                    "branch": "main",
+                    "detached": False,
+                    "bare": False,
+                    "locked": False,
+                    "prunable": False,
+                    "is_main": False,
+                    "is_current": True,
+                },
+            ],
+        }
+
+
+@pytest.mark.asyncio
+async def test_worktree_list_sibling_worktrees_write_no_exclude(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        main_path = tmp_path / "repo"
+        main_path.mkdir()
+        sibling_path = tmp_path / "repo-feature"
+
+        process_output = [
+            "worktree {}".format(main_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/main",
+            "",
+            "worktree {}".format(sibling_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/feature",
+            "",
+        ]
+        mock_execute.return_value = (0, "\n".join(process_output), "")
+
+        # When
+        actual_response = await Git().worktree_list(path=str(main_path))
+
+        # Then
+        assert actual_response["code"] == 0
+        # A single call: the sibling worktree needs no exclude entry
+        mock_execute.assert_called_once()
+        assert not (main_path / ".git" / "info" / "exclude").exists()
+
+
+@pytest.mark.asyncio
+async def test_worktree_list_failure():
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        error_message = (
+            "fatal: not a git repository (or any of the parent directories): .git"
+        )
+        mock_execute.return_value = (128, "", error_message)
+
+        # When
+        actual_response = await Git().worktree_list(
+            path=str(Path("/bin/test_curr_path"))
+        )
+
+        # Then
+        assert actual_response == {
+            "code": 128,
+            "command": "git worktree list --porcelain",
+            "message": error_message,
+        }
+
+
+@pytest.mark.asyncio
+async def test_worktree_add_existing_branch(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        repo_path = tmp_path / "repo"
+        worktree_path = tmp_path / "wt-feature"
+        mock_execute.side_effect = [
+            (0, "", "Preparing worktree (checking out 'feature')"),
+        ]
+
+        # When
+        actual_response = await Git().worktree_add(
+            path=str(repo_path),
+            worktree_path=str(worktree_path),
+            branch="feature",
+        )
+
+        # Then
+        mock_execute.assert_called_once_with(
+            ["git", "worktree", "add", str(worktree_path), "feature"],
+            cwd=str(repo_path),
+            env=None,
+            username=None,
+            password=None,
+            is_binary=False,
+        )
+        assert actual_response == {
+            "code": 0,
+            "message": "Preparing worktree (checking out 'feature')",
+        }
+
+
+@pytest.mark.asyncio
+async def test_worktree_add_new_branch_with_start_point(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        repo_path = tmp_path / "repo"
+        worktree_path = repo_path / ".worktrees" / "feature"
+        repo_path.mkdir()
+        mock_execute.side_effect = [
+            # Response for git worktree add
+            (0, "", "Preparing worktree (new branch 'feature')"),
+            # Response for git rev-parse --git-common-dir
+            (0, ".git", ""),
+        ]
+
+        # When
+        actual_response = await Git().worktree_add(
+            path=str(repo_path),
+            worktree_path=str(worktree_path),
+            branch="feature",
+            new_branch=True,
+            start_point="main",
+        )
+
+        # Then
+        assert mock_execute.call_args_list[0].args[0] == [
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            str(worktree_path),
+            "main",
+        ]
+        assert actual_response == {
+            "code": 0,
+            "message": "Preparing worktree (new branch 'feature')",
+        }
+
+        # The nested worktree is excluded from the repository status
+        exclude_file = repo_path / ".git" / "info" / "exclude"
+        assert exclude_file.read_text() == "/.worktrees/feature/\n"
+
+
+@pytest.mark.asyncio
+async def test_worktree_add_outside_repository_writes_no_exclude(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        repo_path = tmp_path / "repo"
+        worktree_path = tmp_path / "wt-feature"
+        repo_path.mkdir()
+        mock_execute.side_effect = [
+            (0, "", "Preparing worktree (checking out 'feature')"),
+        ]
+
+        # When
+        actual_response = await Git().worktree_add(
+            path=str(repo_path),
+            worktree_path=str(worktree_path),
+            branch="feature",
+        )
+
+        # Then
+        assert actual_response["code"] == 0
+        # A single call: the sibling worktree needs no exclude entry
+        mock_execute.assert_called_once()
+        assert not (repo_path / ".git" / "info" / "exclude").exists()
+
+
+@pytest.mark.asyncio
+async def test_worktree_add_appends_to_existing_exclude(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        repo_path = tmp_path / "repo"
+        worktree_path = repo_path / ".worktrees" / "feature"
+        exclude_file = repo_path / ".git" / "info" / "exclude"
+        exclude_file.parent.mkdir(parents=True)
+        exclude_file.write_text("*.log")
+        mock_execute.side_effect = [
+            (0, "", "Preparing worktree (checking out 'feature')"),
+            (0, str(repo_path / ".git"), ""),
+        ]
+
+        # When
+        await Git().worktree_add(
+            path=str(repo_path),
+            worktree_path=str(worktree_path),
+            branch="feature",
+        )
+
+        # Then
+        assert exclude_file.read_text() == "*.log\n/.worktrees/feature/\n"
+
+
+@pytest.mark.asyncio
+async def test_worktree_add_exclude_entry_not_duplicated(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        repo_path = tmp_path / "repo"
+        worktree_path = repo_path / ".worktrees" / "feature"
+        exclude_file = repo_path / ".git" / "info" / "exclude"
+        exclude_file.parent.mkdir(parents=True)
+        exclude_file.write_text("/.worktrees/feature/\n")
+        mock_execute.side_effect = [
+            (0, "", "Preparing worktree (checking out 'feature')"),
+            (0, str(repo_path / ".git"), ""),
+        ]
+
+        # When
+        await Git().worktree_add(
+            path=str(repo_path),
+            worktree_path=str(worktree_path),
+            branch="feature",
+        )
+
+        # Then
+        assert exclude_file.read_text() == "/.worktrees/feature/\n"
+
+
+@pytest.mark.asyncio
+async def test_worktree_add_failure(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        repo_path = tmp_path / "repo"
+        worktree_path = tmp_path / "wt-feature"
+        error_message = "fatal: 'feature' is already used by worktree at '/existing/wt'"
+        mock_execute.return_value = (128, "", error_message)
+
+        # When
+        actual_response = await Git().worktree_add(
+            path=str(repo_path),
+            worktree_path=str(worktree_path),
+            branch="feature",
+        )
+
+        # Then
+        assert actual_response == {
+            "code": 128,
+            "command": "git worktree add {} feature".format(worktree_path),
+            "message": error_message,
+        }
+
+
+@pytest.mark.asyncio
+async def test_worktree_remove_success():
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        mock_execute.return_value = (0, "", "")
+
+        # When
+        actual_response = await Git().worktree_remove(
+            path=str(Path("/bin/test_curr_path")),
+            worktree_path=str(Path("/bin/wt-feature")),
+        )
+
+        # Then
+        mock_execute.assert_called_once_with(
+            ["git", "worktree", "remove", str(Path("/bin/wt-feature"))],
+            cwd=str(Path("/bin/test_curr_path")),
+            env=None,
+            username=None,
+            password=None,
+            is_binary=False,
+        )
+        assert actual_response == {"code": 0, "message": ""}
+
+
+@pytest.mark.asyncio
+async def test_worktree_remove_force():
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        mock_execute.return_value = (0, "", "")
+
+        # When
+        actual_response = await Git().worktree_remove(
+            path=str(Path("/bin/test_curr_path")),
+            worktree_path=str(Path("/bin/wt-feature")),
+            force=True,
+        )
+
+        # Then
+        mock_execute.assert_called_once_with(
+            [
+                "git",
+                "worktree",
+                "remove",
+                "--force",
+                "--force",
+                str(Path("/bin/wt-feature")),
+            ],
+            cwd=str(Path("/bin/test_curr_path")),
+            env=None,
+            username=None,
+            password=None,
+            is_binary=False,
+        )
+        assert actual_response == {"code": 0, "message": ""}
+
+
+@pytest.mark.asyncio
+async def test_worktree_remove_failure():
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        error_message = (
+            "fatal: '/bin/wt-feature' contains modified or untracked files,"
+            " use --force to delete it"
+        )
+        mock_execute.return_value = (128, "", error_message)
+
+        # When
+        actual_response = await Git().worktree_remove(
+            path=str(Path("/bin/test_curr_path")),
+            worktree_path="/bin/wt-feature",
+        )
+
+        # Then
+        assert actual_response == {
+            "code": 128,
+            "command": "git worktree remove /bin/wt-feature",
+            "message": error_message,
+        }
+
+
+def test_get_index_lock_path_main_worktree(tmp_path):
+    # Given a repository whose .git is a directory
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+
+    # Then
+    assert get_index_lock_path(str(tmp_path)) == str(git_dir / "index.lock")
+
+
+def test_get_index_lock_path_linked_worktree_absolute(tmp_path):
+    # Given a linked worktree whose .git is a file with an absolute gitdir
+    main_git_dir = tmp_path / "repo" / ".git" / "worktrees" / "wt"
+    main_git_dir.mkdir(parents=True)
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: {}\n".format(main_git_dir))
+
+    # Then
+    assert get_index_lock_path(str(worktree)) == str(main_git_dir / "index.lock")
+
+
+def test_get_index_lock_path_linked_worktree_relative(tmp_path):
+    # Given a submodule-style .git file with a relative gitdir
+    worktree = tmp_path / "sub"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: ../.git/modules/sub\n")
+
+    # Then
+    assert get_index_lock_path(str(worktree)) == os.path.join(
+        str(worktree), "../.git/modules/sub", "index.lock"
+    )
+
+
+def test_get_index_lock_path_no_repository(tmp_path):
+    # Given a folder without any .git entry
+    assert get_index_lock_path(str(tmp_path)) == str(tmp_path / ".git" / "index.lock")

--- a/packages/core/tests/test_worktree.py
+++ b/packages/core/tests/test_worktree.py
@@ -209,6 +209,47 @@ async def test_worktree_list_sibling_worktrees_write_no_exclude(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_worktree_list_excludes_nested_worktrees_in_one_write(tmp_path):
+    with patch("jupyterlab_git_core.git.execute") as mock_execute:
+        # Given
+        main_path = tmp_path / "repo"
+        main_path.mkdir()
+        first_path = main_path / "worktrees" / "first"
+        second_path = main_path / "worktrees" / "second"
+
+        process_output = [
+            "worktree {}".format(main_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/main",
+            "",
+            "worktree {}".format(first_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/first",
+            "",
+            "worktree {}".format(second_path),
+            "HEAD abcdefghijklmnopqrstuvwxyz01234567890123",
+            "branch refs/heads/second",
+            "",
+        ]
+        mock_execute.side_effect = [
+            # Response for git worktree list
+            (0, "\n".join(process_output), ""),
+            # Response for git rev-parse --git-common-dir; a single call
+            # covers the exclusion of all nested worktrees
+            (0, ".git", ""),
+        ]
+
+        # When
+        actual_response = await Git().worktree_list(path=str(main_path))
+
+        # Then
+        assert actual_response["code"] == 0
+        assert mock_execute.call_count == 2
+        exclude_file = main_path / ".git" / "info" / "exclude"
+        assert exclude_file.read_text() == "/worktrees/first/\n/worktrees/second/\n"
+
+
+@pytest.mark.asyncio
 async def test_worktree_list_failure():
     with patch("jupyterlab_git_core.git.execute") as mock_execute:
         # Given

--- a/packages/jupyterlab/jupyterlab_git/handlers.py
+++ b/packages/jupyterlab/jupyterlab_git/handlers.py
@@ -57,6 +57,19 @@ def to_server_path(local_path: str, root_dir: str) -> str:
     return Path(relative).as_posix()
 
 
+def is_inside_root(local_path: str, root_dir: str) -> bool:
+    """Whether an absolute local path is inside the server root directory.
+
+    Args:
+        local_path: absolute local path
+        root_dir: resolved (``os.path.realpath``) server root directory
+    """
+    try:
+        return os.path.commonpath([local_path, root_dir]) == root_dir
+    except ValueError:
+        return False
+
+
 class SSHHandler(APIHandler):
     """
     Top-level parent class for SSH actions
@@ -1103,6 +1116,18 @@ class GitWorktreeHandler(GitHandler):
     Handler for 'git worktree'. Lists, adds and removes worktrees.
     """
 
+    def _finish_outside_root_error(self) -> None:
+        """Reject a worktree path outside of the server root directory."""
+        self.set_status(400)
+        self.finish(
+            json.dumps(
+                {
+                    "code": 400,
+                    "message": "The worktree path must be inside the Jupyter server root directory",
+                }
+            )
+        )
+
     @tornado.web.authenticated
     async def get(self, path: str = ""):
         """
@@ -1160,20 +1185,8 @@ class GitWorktreeHandler(GitHandler):
         root_dir = os.path.realpath(os.path.expanduser(contents_manager.root_dir))
         destination = os.path.realpath(os.path.join(local_path, worktree_path))
 
-        try:
-            inside_root = os.path.commonpath([destination, root_dir]) == root_dir
-        except ValueError:
-            inside_root = False
-        if not inside_root:
-            self.set_status(400)
-            self.finish(
-                json.dumps(
-                    {
-                        "code": 400,
-                        "message": "The worktree path must be inside the Jupyter server root directory",
-                    }
-                )
-            )
+        if not is_inside_root(destination, root_dir):
+            self._finish_outside_root_error()
             return
 
         result = await self.git.worktree_add(
@@ -1210,20 +1223,8 @@ class GitWorktreeHandler(GitHandler):
         root_dir = os.path.realpath(os.path.expanduser(contents_manager.root_dir))
         target = os.path.realpath(os.path.join(root_dir, worktree_path))
 
-        try:
-            inside_root = os.path.commonpath([target, root_dir]) == root_dir
-        except ValueError:
-            inside_root = False
-        if not inside_root:
-            self.set_status(400)
-            self.finish(
-                json.dumps(
-                    {
-                        "code": 400,
-                        "message": "The worktree path must be inside the Jupyter server root directory",
-                    }
-                )
-            )
+        if not is_inside_root(target, root_dir):
+            self._finish_outside_root_error()
             return
 
         response = await self.git.worktree_remove(local_path, target, force)

--- a/packages/jupyterlab/jupyterlab_git/handlers.py
+++ b/packages/jupyterlab/jupyterlab_git/handlers.py
@@ -40,6 +40,23 @@ NAMESPACE = "/git"
 SSH_AUTH_RESOURCE = "ssh"
 
 
+def to_server_path(local_path: str, root_dir: str) -> str:
+    """Convert an absolute local path into a POSIX path relative to the
+    server root directory.
+
+    The returned path starts with ``..`` when the path is outside of the
+    server root; the frontend uses that marker to flag entries it cannot open.
+
+    Args:
+        local_path: absolute local path
+        root_dir: resolved (``os.path.realpath``) server root directory
+    """
+    relative = os.path.relpath(os.path.realpath(local_path), root_dir)
+    if relative == ".":
+        return ""
+    return Path(relative).as_posix()
+
+
 class SSHHandler(APIHandler):
     """
     Top-level parent class for SSH actions
@@ -305,10 +322,20 @@ class GitBranchHandler(GitHandler):
         """
         POST request handler, fetches all branches in current repository.
         """
-        result = await self.git.branch(self.url2localpath(path))
+        local_path, contents_manager = self.url2localpath(
+            path, with_contents_manager=True
+        )
+        result = await self.git.branch(local_path)
 
         if result["code"] != 0:
             self.set_status(500)
+        else:
+            # Convert the absolute worktree paths reported by Git into paths
+            # relative to the server root, as expected by the frontend.
+            root_dir = os.path.realpath(os.path.expanduser(contents_manager.root_dir))
+            for branch in result.get("branches", []):
+                if branch.get("worktree"):
+                    branch["worktree"] = to_server_path(branch["worktree"], root_dir)
         self.finish(json.dumps(result))
 
 
@@ -1071,6 +1098,144 @@ class GitSubmodulesHandler(GitHandler):
         self.finish(json.dumps(result))
 
 
+class GitWorktreeHandler(GitHandler):
+    """
+    Handler for 'git worktree'. Lists, adds and removes worktrees.
+    """
+
+    @tornado.web.authenticated
+    async def get(self, path: str = ""):
+        """
+        GET request handler, lists all worktrees of the current repository.
+
+        Worktree paths are returned relative to the server root; paths
+        starting with ``..`` denote worktrees outside of the server root.
+        """
+        local_path, contents_manager = self.url2localpath(
+            path, with_contents_manager=True
+        )
+        result = await self.git.worktree_list(local_path)
+
+        if result["code"] != 0:
+            self.set_status(500)
+        else:
+            root_dir = os.path.realpath(os.path.expanduser(contents_manager.root_dir))
+            for worktree in result.get("worktrees", []):
+                worktree["path"] = to_server_path(worktree["path"], root_dir)
+        self.finish(json.dumps(result))
+
+    @tornado.web.authenticated
+    async def post(self, path: str = ""):
+        """
+        POST request handler, adds a worktree to the current repository.
+
+        Args:
+            path: Git repository path relatively to the server root
+        Body: {
+            "worktree_path": Worktree path relatively to the repository root,
+            "branch": Branch to check out in the new worktree,
+            "new_branch": Whether to create the branch (default False),
+            "start_point": Commit-ish a new branch starts from (optional)
+        }
+        """
+        local_path, contents_manager = self.url2localpath(
+            path, with_contents_manager=True
+        )
+        data = self.get_json_body()
+        worktree_path = data.get("worktree_path")
+        branch = data.get("branch")
+
+        if not worktree_path or not branch:
+            self.set_status(400)
+            self.finish(
+                json.dumps(
+                    {
+                        "code": 400,
+                        "message": "worktree_path and branch are required",
+                    }
+                )
+            )
+            return
+
+        root_dir = os.path.realpath(os.path.expanduser(contents_manager.root_dir))
+        destination = os.path.realpath(os.path.join(local_path, worktree_path))
+
+        try:
+            inside_root = os.path.commonpath([destination, root_dir]) == root_dir
+        except ValueError:
+            inside_root = False
+        if not inside_root:
+            self.set_status(400)
+            self.finish(
+                json.dumps(
+                    {
+                        "code": 400,
+                        "message": "The worktree path must be inside the Jupyter server root directory",
+                    }
+                )
+            )
+            return
+
+        result = await self.git.worktree_add(
+            local_path,
+            destination,
+            branch,
+            new_branch=data.get("new_branch", False),
+            start_point=data.get("start_point"),
+        )
+
+        if result["code"] != 0:
+            self.set_status(500)
+        else:
+            self.set_status(201)
+            result["worktree_path"] = to_server_path(destination, root_dir)
+        self.finish(json.dumps(result))
+
+    @tornado.web.authenticated
+    async def delete(self, path: str = ""):
+        """
+        DELETE request handler, removes a worktree from the current repository.
+
+        Query arguments:
+            worktree_path: Worktree path relatively to the server root
+            force: Whether to remove the worktree even if it is dirty or
+                locked ("true"/"false", default "false")
+        """
+        local_path, contents_manager = self.url2localpath(
+            path, with_contents_manager=True
+        )
+        worktree_path = self.get_query_argument("worktree_path")
+        force = self.get_query_argument("force", "false").lower() == "true"
+
+        root_dir = os.path.realpath(os.path.expanduser(contents_manager.root_dir))
+        target = os.path.realpath(os.path.join(root_dir, worktree_path))
+
+        try:
+            inside_root = os.path.commonpath([target, root_dir]) == root_dir
+        except ValueError:
+            inside_root = False
+        if not inside_root:
+            self.set_status(400)
+            self.finish(
+                json.dumps(
+                    {
+                        "code": 400,
+                        "message": "The worktree path must be inside the Jupyter server root directory",
+                    }
+                )
+            )
+            return
+
+        response = await self.git.worktree_remove(local_path, target, force)
+
+        if response["code"] == 0:
+            self.set_status(204)
+            self.finish()
+        else:
+            self.set_status(500)
+            self.finish(json.dumps(response))
+
+
 class SshHostHandler(SSHHandler):
     """
     Handler for checking if a host is known by SSH
@@ -1139,6 +1304,7 @@ def setup_handlers(web_app):
         ("/stash_pop", GitStashPopHandler),
         ("/stash_apply", GitStashApplyHandler),
         ("/submodules", GitSubmodulesHandler),
+        ("/worktrees", GitWorktreeHandler),
         ("/check_notebooks", GitCheckNotebooksHandler),
         ("/strip_notebooks", GitStripNotebooksHandler),
     ]

--- a/packages/jupyterlab/tests/test_handlers.py
+++ b/packages/jupyterlab/tests/test_handlers.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
@@ -282,6 +283,75 @@ async def test_branch_handler_localbranch(mock_git, jp_fetch, jp_root_dir):
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload == {"code": 0, "branches": branch["branches"]}
+
+
+@patch("jupyterlab_git.handlers.GitBranchHandler.git", spec=Git)
+async def test_branch_handler_relativize_worktree_paths(
+    mock_git, jp_fetch, jp_root_dir
+):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    root_real = os.path.realpath(str(jp_root_dir))
+    branch = {
+        "code": 0,
+        "branches": [
+            {
+                "is_current_branch": True,
+                "is_remote_branch": False,
+                "name": "main",
+                "upstream": None,
+                "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                "tag": None,
+                "worktree": os.path.join(root_real, "test_path"),
+            },
+            {
+                "is_current_branch": False,
+                "is_remote_branch": False,
+                "name": "feature-foo",
+                "upstream": None,
+                "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                "tag": None,
+                "worktree": os.path.join(
+                    root_real, "test_path", ".worktrees", "feature-foo"
+                ),
+            },
+            {
+                "is_current_branch": False,
+                "is_remote_branch": False,
+                "name": "feature-bar",
+                "upstream": None,
+                "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                "tag": None,
+                "worktree": None,
+            },
+            {
+                "is_current_branch": False,
+                "is_remote_branch": False,
+                "name": "feature-baz",
+                "upstream": None,
+                "top_commit": "abcdefghijklmnopqrstuvwxyz01234567890123",
+                "tag": None,
+                "worktree": os.path.join(os.path.dirname(root_real), "outside-wt"),
+            },
+        ],
+    }
+
+    mock_git.branch.return_value = branch
+
+    # When
+    response = await jp_fetch(
+        NAMESPACE, local_path.name, "branch", body="{}", method="POST"
+    )
+
+    # Then
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert [entry["worktree"] for entry in payload["branches"]] == [
+        "test_path",
+        "test_path/.worktrees/feature-foo",
+        None,
+        "../outside-wt",
+    ]
 
 
 @patch("jupyterlab_git.handlers.GitLogHandler.git", spec=Git)

--- a/packages/jupyterlab/tests/test_worktrees.py
+++ b/packages/jupyterlab/tests/test_worktrees.py
@@ -1,0 +1,272 @@
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from jupyterlab_git_core.git import Git
+from jupyterlab_git.handlers import NAMESPACE
+
+from .testutils import assert_http_error
+from tornado.httpclient import HTTPClientError
+
+
+def worktree(path, **kwargs):
+    """Build a worktree entry as returned by ``Git.worktree_list``."""
+    entry = {
+        "path": path,
+        "head": "abcdefghijklmnopqrstuvwxyz01234567890123",
+        "branch": "main",
+        "detached": False,
+        "bare": False,
+        "locked": False,
+        "prunable": False,
+        "is_main": False,
+        "is_current": False,
+    }
+    entry.update(kwargs)
+    return entry
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_get(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    root_real = os.path.realpath(str(jp_root_dir))
+    main_abs = os.path.join(root_real, "test_path")
+    linked_abs = os.path.join(root_real, "test_path", ".worktrees", "feature")
+    outside_abs = os.path.join(os.path.dirname(root_real), "outside-wt")
+
+    mock_git.worktree_list.return_value = {
+        "code": 0,
+        "worktrees": [
+            worktree(main_abs, is_main=True, is_current=True),
+            worktree(linked_abs, branch="feature"),
+            worktree(outside_abs, branch="outside"),
+        ],
+    }
+
+    # When
+    response = await jp_fetch(NAMESPACE, local_path.name, "worktrees", method="GET")
+
+    # Then
+    mock_git.worktree_list.assert_called_with(str(local_path))
+
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert [entry["path"] for entry in payload["worktrees"]] == [
+        "test_path",
+        "test_path/.worktrees/feature",
+        "../outside-wt",
+    ]
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_get_failure(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    mock_git.worktree_list.return_value = {
+        "code": 128,
+        "command": "git worktree list --porcelain",
+        "message": "fatal: not a git repository",
+    }
+
+    # When
+    with pytest.raises(HTTPClientError) as error:
+        await jp_fetch(NAMESPACE, local_path.name, "worktrees", method="GET")
+
+    # Then
+    assert_http_error(error, 500)
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_post(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    mock_git.worktree_add.return_value = {"code": 0, "message": ""}
+
+    body = {
+        "worktree_path": ".worktrees/feature",
+        "branch": "feature",
+        "new_branch": True,
+        "start_point": "main",
+    }
+
+    # When
+    response = await jp_fetch(
+        NAMESPACE,
+        local_path.name,
+        "worktrees",
+        body=json.dumps(body),
+        method="POST",
+    )
+
+    # Then
+    expected_destination = os.path.realpath(str(local_path / ".worktrees" / "feature"))
+    mock_git.worktree_add.assert_called_with(
+        str(local_path),
+        expected_destination,
+        "feature",
+        new_branch=True,
+        start_point="main",
+    )
+
+    assert response.code == 201
+    payload = json.loads(response.body)
+    assert payload["worktree_path"] == "test_path/.worktrees/feature"
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_post_outside_root_rejected(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    body = {"worktree_path": "../../outside", "branch": "feature"}
+
+    # When
+    with pytest.raises(HTTPClientError) as error:
+        await jp_fetch(
+            NAMESPACE,
+            local_path.name,
+            "worktrees",
+            body=json.dumps(body),
+            method="POST",
+        )
+
+    # Then
+    assert_http_error(error, 400)
+    mock_git.worktree_add.assert_not_called()
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_post_missing_branch_rejected(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    body = {"worktree_path": ".worktrees/feature"}
+
+    # When
+    with pytest.raises(HTTPClientError) as error:
+        await jp_fetch(
+            NAMESPACE,
+            local_path.name,
+            "worktrees",
+            body=json.dumps(body),
+            method="POST",
+        )
+
+    # Then
+    assert_http_error(error, 400)
+    mock_git.worktree_add.assert_not_called()
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_post_failure(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    mock_git.worktree_add.return_value = {
+        "code": 128,
+        "command": "git worktree add",
+        "message": "fatal: 'feature' is already used by worktree at '/wt'",
+    }
+    body = {"worktree_path": ".worktrees/feature", "branch": "feature"}
+
+    # When
+    with pytest.raises(HTTPClientError) as error:
+        await jp_fetch(
+            NAMESPACE,
+            local_path.name,
+            "worktrees",
+            body=json.dumps(body),
+            method="POST",
+        )
+
+    # Then
+    assert_http_error(error, 500)
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_delete(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    mock_git.worktree_remove.return_value = {"code": 0, "message": ""}
+
+    # When
+    response = await jp_fetch(
+        NAMESPACE,
+        local_path.name,
+        "worktrees",
+        method="DELETE",
+        params={"worktree_path": "test_path/.worktrees/feature"},
+    )
+
+    # Then
+    expected_target = os.path.realpath(str(local_path / ".worktrees" / "feature"))
+    mock_git.worktree_remove.assert_called_with(str(local_path), expected_target, False)
+    assert response.code == 204
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_delete_force(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    mock_git.worktree_remove.return_value = {"code": 0, "message": ""}
+
+    # When
+    response = await jp_fetch(
+        NAMESPACE,
+        local_path.name,
+        "worktrees",
+        method="DELETE",
+        params={
+            "worktree_path": "test_path/.worktrees/feature",
+            "force": "true",
+        },
+    )
+
+    # Then
+    expected_target = os.path.realpath(str(local_path / ".worktrees" / "feature"))
+    mock_git.worktree_remove.assert_called_with(str(local_path), expected_target, True)
+    assert response.code == 204
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_delete_outside_root_rejected(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+
+    # When
+    with pytest.raises(HTTPClientError) as error:
+        await jp_fetch(
+            NAMESPACE,
+            local_path.name,
+            "worktrees",
+            method="DELETE",
+            params={"worktree_path": "../outside-wt"},
+        )
+
+    # Then
+    assert_http_error(error, 400)
+    mock_git.worktree_remove.assert_not_called()
+
+
+@patch("jupyterlab_git.handlers.GitWorktreeHandler.git", spec=Git)
+async def test_worktrees_delete_failure(mock_git, jp_fetch, jp_root_dir):
+    # Given
+    local_path = jp_root_dir / "test_path"
+    mock_git.worktree_remove.return_value = {
+        "code": 128,
+        "command": "git worktree remove",
+        "message": "fatal: validation failed",
+    }
+
+    # When
+    with pytest.raises(HTTPClientError) as error:
+        await jp_fetch(
+            NAMESPACE,
+            local_path.name,
+            "worktrees",
+            method="DELETE",
+            params={"worktree_path": "test_path/.worktrees/feature"},
+        )
+
+    # Then
+    assert_http_error(error, 500)

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -152,6 +152,9 @@
             "command": "git:manage-remote"
           },
           {
+            "command": "git:add-worktree"
+          },
+          {
             "command": "git:terminal-command"
           },
           {

--- a/specification/Git_REST_API.yml
+++ b/specification/Git_REST_API.yml
@@ -246,6 +246,38 @@ paths:
             in: path
             required: true
             type: string
+  /{path}/worktrees:
+    get:
+      parameters:
+          - name: path
+            description: Git repository path
+            in: path
+            required: true
+            type: string
+    post:
+      parameters:
+          - name: path
+            description: Git repository path
+            in: path
+            required: true
+            type: string
+    delete:
+      parameters:
+          - name: path
+            description: Git repository path
+            in: path
+            required: true
+            type: string
+          - name: worktree_path
+            description: Worktree path relative to the server root
+            in: query
+            required: true
+            type: string
+          - name: force
+            description: Whether to remove the worktree even if it is dirty or locked
+            in: query
+            required: false
+            type: string
   /diffnotebook:
     post:
   /settings:

--- a/src/__tests__/model.spec.tsx
+++ b/src/__tests__/model.spec.tsx
@@ -455,4 +455,146 @@ describe('IGitExtension', () => {
       spy.mockRestore();
     });
   });
+
+  describe('#refreshWorktrees', () => {
+    const WORKTREES: Git.IWorktree[] = [
+      {
+        path: DEFAULT_REPOSITORY_PATH,
+        head: 'abcdefghijklmnopqrstuvwxyz01234567890123',
+        branch: 'main',
+        detached: false,
+        bare: false,
+        locked: false,
+        prunable: false,
+        is_main: true,
+        is_current: true
+      },
+      {
+        path: DEFAULT_REPOSITORY_PATH + '/.worktrees/feature',
+        head: 'abcdefghijklmnopqrstuvwxyz01234567890123',
+        branch: 'feature',
+        detached: false,
+        bare: false,
+        locked: false,
+        prunable: false,
+        is_main: false,
+        is_current: false
+      }
+    ];
+
+    it('should fetch the worktree list and emit worktreesChanged', async () => {
+      model.pathRepository = DEFAULT_REPOSITORY_PATH;
+      await model.ready;
+      // Settle the initial refresh, which sees an empty worktree list
+      await model.refresh();
+
+      mockResponses.responses['worktrees'] = {
+        body: () => ({ code: 0, worktrees: WORKTREES })
+      };
+
+      const testSignal = testEmission(model.worktreesChanged, {
+        test: model => {
+          expect(model.worktrees).toEqual(WORKTREES);
+        }
+      });
+
+      await model.refreshWorktrees();
+      await testSignal;
+
+      expect(model.worktrees).toEqual(WORKTREES);
+    });
+
+    it('should not emit worktreesChanged when the list is unchanged', async () => {
+      mockResponses.responses['worktrees'] = {
+        body: () => ({ code: 0, worktrees: WORKTREES })
+      };
+
+      model.pathRepository = DEFAULT_REPOSITORY_PATH;
+      await model.ready;
+
+      await model.refreshWorktrees();
+      expect(model.worktrees).toEqual(WORKTREES);
+
+      let emissions = 0;
+      model.worktreesChanged.connect(() => {
+        emissions += 1;
+      });
+
+      await model.refreshWorktrees();
+      expect(emissions).toEqual(0);
+    });
+  });
+
+  describe('#addWorktree', () => {
+    it('should request the server to add a worktree and refresh', async () => {
+      const spy = jest.spyOn(GitExtension.prototype, 'refreshBranch');
+      mockResponses.responses['worktreesPOST'] = {
+        body: () => ({
+          code: 0,
+          message: '',
+          worktree_path: DEFAULT_REPOSITORY_PATH + '/.worktrees/feature'
+        })
+      };
+
+      model.pathRepository = DEFAULT_REPOSITORY_PATH;
+      await model.ready;
+      spy.mockClear();
+
+      const response = await model.addWorktree({
+        worktreePath: '.worktrees/feature',
+        branch: 'feature',
+        newBranch: true,
+        startPoint: 'main'
+      });
+
+      expect(response.worktree_path).toEqual(
+        DEFAULT_REPOSITORY_PATH + '/.worktrees/feature'
+      );
+      expect(mockGit.requestAPI).toHaveBeenCalledWith(
+        DEFAULT_REPOSITORY_PATH + '/worktrees',
+        'POST',
+        {
+          worktree_path: '.worktrees/feature',
+          branch: 'feature',
+          new_branch: true,
+          start_point: 'main'
+        },
+        'git',
+        undefined
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      spy.mockRestore();
+    });
+  });
+
+  describe('#removeWorktree', () => {
+    it('should request the server to remove a worktree and refresh', async () => {
+      const spy = jest.spyOn(GitExtension.prototype, 'refreshBranch');
+      const worktreePath = DEFAULT_REPOSITORY_PATH + '/.worktrees/feature';
+      const query = `?worktree_path=${encodeURIComponent(
+        worktreePath
+      )}&force=false`;
+      mockResponses.responses['worktrees' + query + 'DELETE'] = {
+        body: () => null
+      };
+
+      model.pathRepository = DEFAULT_REPOSITORY_PATH;
+      await model.ready;
+      spy.mockClear();
+
+      await model.removeWorktree(worktreePath);
+
+      expect(mockGit.requestAPI).toHaveBeenCalledWith(
+        DEFAULT_REPOSITORY_PATH + '/worktrees' + query,
+        'DELETE',
+        null,
+        'git',
+        undefined
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      spy.mockRestore();
+    });
+  });
 });

--- a/src/__tests__/test-components/BranchMenu.spec.tsx
+++ b/src/__tests__/test-components/BranchMenu.spec.tsx
@@ -313,6 +313,83 @@ describe('BranchMenu', () => {
     });
   });
 
+  describe('worktrees', () => {
+    const WORKTREE_BRANCH = {
+      is_current_branch: false,
+      is_remote_branch: false,
+      name: 'feature-wt',
+      upstream: '',
+      top_commit: '',
+      tag: '',
+      worktree: 'path/to/wt-feature'
+    };
+
+    it('should display a worktree marker for branches checked out in another worktree', () => {
+      render(
+        <BranchMenu
+          {...createProps({
+            currentBranch: 'current',
+            branches: [WORKTREE_BRANCH]
+          })}
+        />
+      );
+
+      expect(
+        screen.getByTitle('Checked out in worktree: path/to/wt-feature')
+      ).toBeDefined();
+    });
+
+    it('should show a dialog instead of switching to a branch checked out in another worktree', async () => {
+      const mockDialog = showDialog as jest.MockedFunction<typeof showDialog>;
+      mockDialog.mockClear();
+      mockDialog.mockResolvedValue({
+        button: { accept: false },
+        isChecked: null,
+        value: undefined
+      } as any);
+
+      // Make the model aware of the branch and its worktree
+      const mock = git as jest.Mocked<typeof git>;
+      mock.requestAPI.mockImplementation(
+        mockedRequestAPI({
+          responses: {
+            ...defaultMockedResponses,
+            branch: {
+              body: () => ({
+                code: 0,
+                branches: [WORKTREE_BRANCH],
+                current_branch: { name: 'current' }
+              })
+            }
+          }
+        }) as any
+      );
+      await model.refreshBranch();
+
+      const spy = jest.spyOn(GitExtension.prototype, 'checkout');
+
+      render(
+        <BranchMenu
+          {...createProps({
+            currentBranch: 'current',
+            branches: [WORKTREE_BRANCH],
+            branching: true
+          })}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('listitem', {
+          name: `Switch to branch: ${WORKTREE_BRANCH.name}`
+        })
+      );
+
+      expect(mockDialog).toHaveBeenCalledTimes(1);
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
   describe('switch branch', () => {
     it('should not switch to a specified branch upon clicking its corresponding element when branching is disabled', async () => {
       const spy = jest.spyOn(GitExtension.prototype, 'checkout');

--- a/src/__tests__/test-components/WorktreeMenu.spec.tsx
+++ b/src/__tests__/test-components/WorktreeMenu.spec.tsx
@@ -1,0 +1,333 @@
+import { showDialog } from '@jupyterlab/apputils';
+import { nullTranslator } from '@jupyterlab/translation';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import 'jest';
+import * as React from 'react';
+import {
+  WorktreeMenu,
+  IWorktreeMenuProps
+} from '../../components/WorktreeMenu';
+import * as git from '../../git';
+import { GitExtension } from '../../model';
+import { CommandIDs, Git } from '../../tokens';
+import {
+  DEFAULT_REPOSITORY_PATH,
+  defaultMockedResponses,
+  mockedRequestAPI
+} from '../utils';
+
+jest.mock('../../git');
+jest.mock('@jupyterlab/apputils');
+
+const WORKTREES: Git.IWorktree[] = [
+  {
+    path: DEFAULT_REPOSITORY_PATH,
+    head: 'abcdefghijklmnopqrstuvwxyz01234567890123',
+    branch: 'main',
+    detached: false,
+    bare: false,
+    locked: false,
+    prunable: false,
+    is_main: true,
+    is_current: true
+  },
+  {
+    path: DEFAULT_REPOSITORY_PATH + '/.worktrees/feature',
+    head: 'abcdefghijklmnopqrstuvwxyz01234567890123',
+    branch: 'feature',
+    detached: false,
+    bare: false,
+    locked: false,
+    prunable: false,
+    is_main: false,
+    is_current: false
+  },
+  {
+    path: 'stale-wt',
+    head: 'abcdefghijklmnopqrstuvwxyz01234567890123',
+    branch: 'stale-branch',
+    detached: false,
+    bare: false,
+    locked: false,
+    prunable: true,
+    is_main: false,
+    is_current: false
+  },
+  {
+    path: '../outside-wt',
+    head: 'abcdefghijklmnopqrstuvwxyz01234567890123',
+    branch: 'outside-branch',
+    detached: false,
+    bare: false,
+    locked: false,
+    prunable: false,
+    is_main: false,
+    is_current: false
+  }
+];
+
+async function createModel() {
+  const model = new GitExtension();
+  model.pathRepository = DEFAULT_REPOSITORY_PATH;
+
+  await model.ready;
+  return model;
+}
+
+describe('WorktreeMenu', () => {
+  let model: GitExtension;
+  const trans = nullTranslator.load('jupyterlab_git');
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+
+    const mock = git as jest.Mocked<typeof git>;
+    mock.requestAPI.mockImplementation(
+      mockedRequestAPI({
+        responses: {
+          ...defaultMockedResponses
+        }
+      }) as any
+    );
+
+    model = await createModel();
+  });
+
+  function createProps(
+    props?: Partial<IWorktreeMenuProps>
+  ): IWorktreeMenuProps {
+    return {
+      commands: {
+        execute: jest.fn()
+      } as any,
+      model: model,
+      worktrees: WORKTREES,
+      trans: trans,
+      ...props
+    };
+  }
+
+  describe('render', () => {
+    it('should display a button to create a new worktree', () => {
+      render(<WorktreeMenu {...createProps()} />);
+      expect(
+        screen.getByRole('button', { name: 'New Worktree' })
+      ).toHaveAttribute('title', 'Create a new worktree');
+    });
+
+    it('should display a list of worktrees', () => {
+      render(<WorktreeMenu {...createProps()} />);
+      expect(screen.getAllByRole('listitem').length).toEqual(WORKTREES.length);
+      expect(screen.getByText('main')).toBeDefined();
+      expect(screen.getByText('feature')).toBeDefined();
+    });
+
+    it('should not display bare repository entries', () => {
+      const bare: Git.IWorktree = {
+        path: 'repo.git',
+        head: null,
+        branch: null,
+        detached: false,
+        bare: true,
+        locked: false,
+        prunable: false,
+        is_main: true,
+        is_current: false
+      };
+      render(
+        <WorktreeMenu {...createProps({ worktrees: [bare, WORKTREES[1]] })} />
+      );
+      expect(screen.getAllByRole('listitem').length).toEqual(1);
+    });
+
+    it('should mark stale worktrees', () => {
+      render(<WorktreeMenu {...createProps()} />);
+      expect(screen.getByText('(stale)')).toBeDefined();
+    });
+
+    it('should display a remove button for linked worktrees only', () => {
+      render(<WorktreeMenu {...createProps()} />);
+      // All rows but the current/main one have a remove action
+      expect(screen.getAllByTitle('Remove this worktree').length).toEqual(
+        WORKTREES.length - 1
+      );
+    });
+  });
+
+  describe('new worktree', () => {
+    it('should execute the add worktree command upon clicking the New Worktree button', async () => {
+      const fakeExecutioner = jest.fn();
+      render(
+        <WorktreeMenu
+          {...createProps({
+            commands: { execute: fakeExecutioner } as any
+          })}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'New Worktree' })
+      );
+
+      expect(fakeExecutioner).toHaveBeenCalledWith(CommandIDs.gitAddWorktree);
+    });
+  });
+
+  describe('open worktree', () => {
+    it('should execute the open worktree command upon clicking a worktree', async () => {
+      const fakeExecutioner = jest.fn();
+      render(
+        <WorktreeMenu
+          {...createProps({
+            commands: { execute: fakeExecutioner } as any
+          })}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('listitem', {
+          name: `Open worktree: ${WORKTREES[1].path}`
+        })
+      );
+
+      expect(fakeExecutioner).toHaveBeenCalledWith(CommandIDs.gitOpenWorktree, {
+        path: WORKTREES[1].path
+      });
+    });
+
+    it('should not open the current worktree', async () => {
+      const fakeExecutioner = jest.fn();
+      render(
+        <WorktreeMenu
+          {...createProps({
+            commands: { execute: fakeExecutioner } as any
+          })}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('listitem', {
+          name: `Current worktree: ${WORKTREES[0].path}`
+        })
+      );
+
+      expect(fakeExecutioner).not.toHaveBeenCalled();
+    });
+
+    it('should not open a stale worktree', async () => {
+      const fakeExecutioner = jest.fn();
+      render(
+        <WorktreeMenu
+          {...createProps({
+            commands: { execute: fakeExecutioner } as any
+          })}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('listitem', {
+          name: 'The folder of this worktree is missing; it can be removed'
+        })
+      );
+
+      expect(fakeExecutioner).not.toHaveBeenCalled();
+    });
+
+    it('should not open a worktree outside of the server root', async () => {
+      const fakeExecutioner = jest.fn();
+      render(
+        <WorktreeMenu
+          {...createProps({
+            commands: { execute: fakeExecutioner } as any
+          })}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('listitem', {
+          name: 'This worktree is outside of the Jupyter server root and cannot be opened'
+        })
+      );
+
+      expect(fakeExecutioner).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove worktree', () => {
+    function acceptDialog() {
+      const mockDialog = showDialog as jest.MockedFunction<typeof showDialog>;
+      mockDialog.mockResolvedValue({
+        button: {
+          accept: true,
+          actions: [],
+          caption: '',
+          className: '',
+          displayType: 'default',
+          iconClass: '',
+          iconLabel: '',
+          label: ''
+        },
+        isChecked: null,
+        value: undefined
+      } as any);
+      return mockDialog;
+    }
+
+    it('should remove the worktree upon accepting the confirmation dialog', async () => {
+      acceptDialog();
+      const spy = jest
+        .spyOn(GitExtension.prototype, 'removeWorktree')
+        .mockResolvedValue();
+
+      render(<WorktreeMenu {...createProps()} />);
+
+      await userEvent.click(screen.getAllByTitle('Remove this worktree')[0]);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(WORKTREES[1].path);
+      spy.mockRestore();
+    });
+
+    it('should not remove the worktree when the confirmation dialog is cancelled', async () => {
+      const mockDialog = showDialog as jest.MockedFunction<typeof showDialog>;
+      mockDialog.mockResolvedValue({
+        button: { accept: false },
+        isChecked: null,
+        value: undefined
+      } as any);
+      const spy = jest
+        .spyOn(GitExtension.prototype, 'removeWorktree')
+        .mockResolvedValue();
+
+      render(<WorktreeMenu {...createProps()} />);
+
+      await userEvent.click(screen.getAllByTitle('Remove this worktree')[0]);
+
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should force the removal upon accepting the force dialog for a dirty worktree', async () => {
+      acceptDialog();
+      const spy = jest
+        .spyOn(GitExtension.prototype, 'removeWorktree')
+        .mockRejectedValueOnce(
+          new Error(
+            "fatal: 'wt' contains modified or untracked files, use --force to delete it"
+          )
+        )
+        .mockResolvedValueOnce();
+
+      render(<WorktreeMenu {...createProps()} />);
+
+      await userEvent.click(screen.getAllByTitle('Remove this worktree')[0]);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenNthCalledWith(1, WORKTREES[1].path);
+      expect(spy).toHaveBeenNthCalledWith(2, WORKTREES[1].path, true);
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/__tests__/test-components/WorktreeMenu.spec.tsx
+++ b/src/__tests__/test-components/WorktreeMenu.spec.tsx
@@ -110,13 +110,6 @@ describe('WorktreeMenu', () => {
   }
 
   describe('render', () => {
-    it('should display a button to create a new worktree', () => {
-      render(<WorktreeMenu {...createProps()} />);
-      expect(
-        screen.getByRole('button', { name: 'New Worktree' })
-      ).toHaveAttribute('title', 'Create a new worktree');
-    });
-
     it('should display a list of worktrees', () => {
       render(<WorktreeMenu {...createProps()} />);
       expect(screen.getAllByRole('listitem').length).toEqual(WORKTREES.length);
@@ -153,25 +146,6 @@ describe('WorktreeMenu', () => {
       expect(screen.getAllByTitle('Remove this worktree').length).toEqual(
         WORKTREES.length - 1
       );
-    });
-  });
-
-  describe('new worktree', () => {
-    it('should execute the add worktree command upon clicking the New Worktree button', async () => {
-      const fakeExecutioner = jest.fn();
-      render(
-        <WorktreeMenu
-          {...createProps({
-            commands: { execute: fakeExecutioner } as any
-          })}
-        />
-      );
-
-      await userEvent.click(
-        screen.getByRole('button', { name: 'New Worktree' })
-      );
-
-      expect(fakeExecutioner).toHaveBeenCalledWith(CommandIDs.gitAddWorktree);
     });
   });
 

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -59,6 +59,12 @@ export const defaultMockedResponses: {
       code: 0,
       tags: []
     })
+  },
+  worktrees: {
+    body: () => ({
+      code: 0,
+      worktrees: []
+    })
   }
 };
 

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -37,6 +37,7 @@ import { BranchPicker } from './components/BranchPicker';
 import { CONTEXT_COMMANDS } from './components/FileList';
 import { ManageRemoteDialogue } from './components/ManageRemoteDialogue';
 import { NewTagDialogBox } from './components/NewTagDialog';
+import { NewWorktreeDialog } from './components/NewWorktreeDialog';
 import { PreviewMainAreaWidget } from './components/diff/PreviewMainAreaWidget';
 import { DiffModel } from './components/diff/model';
 import { AUTH_ERROR_MESSAGES, requestAPI } from './git';
@@ -50,7 +51,8 @@ import {
   historyIcon,
   openIcon,
   removeIcon,
-  tagIcon
+  tagIcon,
+  worktreeIcon
 } from './style/icons';
 import { CommandIDs, ContextCommandIDs, Git, IGitExtension } from './tokens';
 import { AdvancedPushForm } from './widgets/AdvancedPushForm';
@@ -1145,6 +1147,116 @@ export function addCommands(
           trans.__('Failed to get the stash'),
           showError(err as Error, trans)
         );
+      }
+    }
+  });
+
+  /** Add git worktree command */
+  commands.addCommand(CommandIDs.gitAddWorktree, {
+    label: trans.__('Add Worktree…'),
+    caption: trans.__(
+      'Create a new worktree to check out a second branch of the current repository'
+    ),
+    icon: worktreeIcon.bindprops({ stylesheet: 'menuItem' }),
+    isEnabled: () => gitModel.pathRepository !== null,
+    execute: async () => {
+      const localBranches = gitModel.branches.filter(
+        branch => !branch.is_remote_branch
+      );
+
+      const widgetId = 'git-dialog-AddWorktree';
+      let anchor = document.querySelector<HTMLDivElement>(`#${widgetId}`);
+      if (!anchor) {
+        anchor = document.createElement('div');
+        anchor.id = widgetId;
+        document.body.appendChild(anchor);
+      }
+
+      const waitForDialog =
+        new PromiseDelegate<Git.IAddWorktreeOptions | null>();
+      const dialog = ReactWidget.create(
+        <NewWorktreeDialog
+          currentBranch={gitModel.currentBranch?.name ?? ''}
+          branches={localBranches}
+          onClose={(options?: Git.IAddWorktreeOptions) => {
+            dialog.dispose();
+            waitForDialog.resolve(options ?? null);
+          }}
+          trans={trans}
+        />
+      );
+
+      Widget.attach(dialog, anchor);
+
+      const options = await waitForDialog.promise;
+      if (!options) {
+        return;
+      }
+
+      const id = Notification.emit(
+        trans.__('Adding worktree…'),
+        'in-progress',
+        { autoClose: false }
+      );
+      try {
+        const response = await gitModel.addWorktree(options);
+        const worktreePath = response.worktree_path ?? options.worktreePath;
+        Notification.update({
+          id,
+          type: 'success',
+          message: trans.__("Worktree '%1' added.", worktreePath),
+          autoClose: 5000,
+          actions:
+            response.worktree_path && !response.worktree_path.startsWith('..')
+              ? [
+                  {
+                    label: trans.__('Open Worktree'),
+                    callback: () => {
+                      void commands.execute(CommandIDs.gitOpenWorktree, {
+                        path: response.worktree_path
+                      });
+                    }
+                  }
+                ]
+              : undefined
+        });
+      } catch (error) {
+        Notification.update({
+          id,
+          type: 'error',
+          message: trans.__('Failed to add worktree.'),
+          ...showError(error as Error, trans)
+        });
+      }
+    }
+  });
+
+  /** Open worktree in the file browser command */
+  commands.addCommand(CommandIDs.gitOpenWorktree, {
+    label: trans.__('Open Worktree'),
+    caption: trans.__(
+      'Open a worktree of the current repository in the file browser'
+    ),
+    isEnabled: () => gitModel.pathRepository !== null,
+    execute: async args => {
+      const path = args?.path as string | undefined;
+      if (typeof path !== 'string' || path.startsWith('..')) {
+        return;
+      }
+      try {
+        await fileBrowserModel.cd('/' + path);
+      } catch (error) {
+        // The contents API does not serve hidden folders by default
+        const isHidden = path
+          .split('/')
+          .some(part => part.startsWith('.') && part !== '.');
+        const message = isHidden
+          ? trans.__(
+              "Failed to open the worktree '%1'. It is inside a hidden folder; start the Jupyter server with 'ContentsManager.allow_hidden=True' to open it.",
+              path
+            )
+          : trans.__("Failed to open the worktree '%1'.", path);
+        Notification.error(message, showError(error as Error, trans));
       }
     }
   });

--- a/src/components/BranchMenu.tsx
+++ b/src/components/BranchMenu.tsx
@@ -26,7 +26,7 @@ import {
   newBranchButtonClass,
   wrapperClass
 } from '../style/BranchMenu';
-import { branchIcon, mergeIcon, trashIcon } from '../style/icons';
+import { branchIcon, mergeIcon, trashIcon, worktreeIcon } from '../style/icons';
 import { CommandIDs, Git, IGitExtension } from '../tokens';
 import { ActionButton } from './ActionButton';
 import { NewBranchDialog } from './NewBranchDialog';
@@ -283,6 +283,16 @@ export class BranchMenu extends React.Component<
       >
         <branchIcon.react className={listItemIconClass} tag="span" />
         <span className={nameClass}>{branch.name}</span>
+        {!branch.is_remote_branch && !isActive && branch.worktree && (
+          <worktreeIcon.react
+            className={listItemIconClass}
+            tag="span"
+            title={this.props.trans.__(
+              'Checked out in worktree: %1',
+              branch.worktree
+            )}
+          />
+        )}
         {!branch.is_remote_branch && !isActive && (
           <>
             <ActionButton
@@ -359,6 +369,21 @@ export class BranchMenu extends React.Component<
    * @param branchName Branch name
    */
   private _onDeleteBranch = async (branchName: string): Promise<void> => {
+    // A branch checked out in another worktree cannot be deleted; show a
+    // helpful dialog instead of attempting the deletion.
+    const branchData = this.props.model.branches.find(
+      candidate => !candidate.is_remote_branch && candidate.name === branchName
+    );
+    if (branchData && !branchData.is_current_branch && branchData.worktree) {
+      const becameAvailable = await this._onCheckedOutElsewhere(
+        branchData,
+        'delete'
+      );
+      if (!becameAvailable) {
+        return;
+      }
+    }
+
     const acknowledgement = await showDialog<void>({
       title: this.props.trans.__('Delete branch'),
       body: (
@@ -393,6 +418,98 @@ export class BranchMenu extends React.Component<
    */
   private _onMergeBranch = async (branch: string): Promise<void> => {
     await this.props.commands.execute(CommandIDs.gitMerge, { branch });
+  };
+
+  /**
+   * Shows a dialog for a branch which is checked out in another worktree,
+   * offering to open that worktree, or to remove it when it is stale.
+   *
+   * @param branch - branch data
+   * @param action - user action having triggered the dialog
+   * @returns whether the branch became available because its stale worktree
+   *   was removed
+   */
+  private _onCheckedOutElsewhere = async (
+    branch: Git.IBranch,
+    action: 'switch' | 'delete'
+  ): Promise<boolean> => {
+    const trans = this.props.trans;
+    const worktreePath = branch.worktree!;
+    const worktree = this.props.model.worktrees.find(
+      candidate => candidate.path === worktreePath
+    );
+    const isOutsideRoot = worktreePath.startsWith('..');
+
+    if (worktree?.prunable) {
+      const result = await showDialog<void>({
+        title: trans.__('Branch used by a stale worktree'),
+        body: (
+          <p>
+            {trans.__('The branch ')}
+            <b>{branch.name}</b>
+            {trans.__(' is used by the worktree ')}
+            <b>{worktreePath}</b>
+            {trans.__(
+              ', whose folder is missing. Remove the stale worktree to make the branch available again.'
+            )}
+          </p>
+        ),
+        buttons: [
+          Dialog.cancelButton({ label: trans.__('Cancel') }),
+          Dialog.warnButton({ label: trans.__('Remove Stale Worktree') })
+        ]
+      });
+      if (!result.button.accept) {
+        return false;
+      }
+      try {
+        await this.props.model.removeWorktree(worktreePath);
+        return true;
+      } catch (error) {
+        Notification.error(
+          trans.__('Failed to remove worktree.'),
+          showError(error as Error, trans)
+        );
+        return false;
+      }
+    }
+
+    const result = await showDialog<void>({
+      title: trans.__('Branch checked out in another worktree'),
+      body: (
+        <p>
+          {trans.__('The branch ')}
+          <b>{branch.name}</b>
+          {trans.__(' is checked out in the worktree ')}
+          <b>{worktreePath}</b>
+          {'. '}
+          {action === 'delete'
+            ? trans.__('Remove that worktree before deleting the branch.')
+            : trans.__(
+                'A branch can be active in only one worktree at a time.'
+              )}
+          {isOutsideRoot
+            ? ' ' +
+              trans.__(
+                'That worktree is outside of the Jupyter server root and cannot be opened here.'
+              )
+            : ''}
+        </p>
+      ),
+      buttons: isOutsideRoot
+        ? [Dialog.okButton({ label: trans.__('Dismiss') })]
+        : [
+            Dialog.cancelButton({ label: trans.__('Dismiss') }),
+            Dialog.okButton({ label: trans.__('Open Worktree') })
+          ]
+    });
+
+    if (!isOutsideRoot && result.button.accept) {
+      await this.props.commands.execute(CommandIDs.gitOpenWorktree, {
+        path: worktreePath
+      });
+    }
+    return false;
   };
 
   /**
@@ -443,6 +560,29 @@ export class BranchMenu extends React.Component<
           this.CHANGES_ERR_MSG
         );
         return;
+      }
+
+      // Switching to a branch which is active in another worktree always
+      // fails; show a helpful dialog instead of attempting the checkout.
+      const checkedOutBranchName = isRemote
+        ? branch.split('/').slice(-1)[0]
+        : branch;
+      const checkedOutBranch = this.props.model.branches.find(
+        candidate =>
+          !candidate.is_remote_branch && candidate.name === checkedOutBranchName
+      );
+      if (
+        checkedOutBranch &&
+        !checkedOutBranch.is_current_branch &&
+        checkedOutBranch.worktree
+      ) {
+        const becameAvailable = await this._onCheckedOutElsewhere(
+          checkedOutBranch,
+          'switch'
+        );
+        if (!becameAvailable) {
+          return;
+        }
       }
 
       let message = 'Switched branch.';

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -31,6 +31,7 @@ import { BranchMenu } from './BranchMenu';
 import { RebaseAction } from './RebaseAction';
 import { WarningBox } from './WarningBox';
 import { TagMenu } from './TagMenu';
+import { WorktreeMenu } from './WorktreeMenu';
 
 /**
  * Interface describing component properties.
@@ -64,7 +65,7 @@ export interface IGitPanelProps {
   /**
    * Which body to render.
    */
-  contentMode: 'changes' | 'history' | 'branches';
+  contentMode: 'changes' | 'history' | 'branches' | 'worktrees';
 
   /**
    * Whether to render the "not a git repository" warning when no repository
@@ -162,6 +163,11 @@ export interface IGitPanelState {
    * List of submodules.
    */
   submodules: Git.ISubmodule[];
+
+  /**
+   * List of worktrees.
+   */
+  worktrees: Git.IWorktree[];
 }
 
 /**
@@ -183,7 +189,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       hasDirtyFiles: hasDirtyStagedFiles,
       stash,
       tagsList,
-      submodules: submodules
+      submodules: submodules,
+      worktrees
     } = props.model;
 
     this.state = {
@@ -203,7 +210,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       challengerCommit: null,
       stash: stash,
       tagsList: tagsList,
-      submodules: submodules
+      submodules: submodules,
+      worktrees: worktrees
     };
   }
 
@@ -284,6 +292,14 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       model.headChanged.connect(async () => {
         await this.refreshCurrentBranch();
         await this.refreshHistory();
+      }, this);
+    }
+
+    if (contentMode === 'worktrees') {
+      model.worktreesChanged.connect(() => {
+        this.setState({
+          worktrees: model.worktrees
+        });
       }, this);
     }
 
@@ -381,6 +397,10 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       this.forceUpdate();
       return;
     }
+    if (this.props.contentMode === 'worktrees') {
+      this.setState({ worktrees: this.props.model.worktrees });
+      return;
+    }
     await this.refreshBranches();
     await this.refreshHistory();
     await this.refreshTags();
@@ -465,7 +485,21 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
     if (contentMode === 'history') {
       return <div className={panelMainClass}>{this._renderHistory()}</div>;
     }
+    if (contentMode === 'worktrees') {
+      return <div className={panelMainClass}>{this._renderWorktrees()}</div>;
+    }
     return <div className={panelMainClass}>{this._renderBranches()}</div>;
+  }
+
+  private _renderWorktrees(): React.ReactElement {
+    return (
+      <WorktreeMenu
+        commands={this.props.commands}
+        model={this.props.model}
+        worktrees={this.state.worktrees}
+        trans={this.props.trans}
+      />
+    );
   }
 
   private _renderBranches(): React.ReactElement {

--- a/src/components/NewWorktreeDialog.tsx
+++ b/src/components/NewWorktreeDialog.tsx
@@ -1,0 +1,296 @@
+import { TranslationBundle } from '@jupyterlab/translation';
+import ClearIcon from '@mui/icons-material/Clear';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import ListItem from '@mui/material/ListItem';
+import React from 'react';
+import { FixedSizeList, ListChildComponentProps } from 'react-window';
+import { classes } from 'typestyle';
+import {
+  actionsWrapperClass,
+  activeListItemClass,
+  branchDialogClass,
+  buttonClass,
+  cancelButtonClass,
+  closeButtonClass,
+  contentWrapperClass,
+  createButtonClass,
+  filterClass,
+  filterClearClass,
+  filterInputClass,
+  filterWrapperClass,
+  listItemClass,
+  listItemContentClass,
+  listItemIconClass,
+  listItemTitleClass,
+  listWrapperClass,
+  nameInputClass,
+  titleClass,
+  titleWrapperClass
+} from '../style/NewBranchDialog';
+import { disabledListItemClass } from '../style/WorktreeMenuStyle';
+import { branchIcon, worktreeIcon } from '../style/icons';
+import { Git } from '../tokens';
+
+const ITEM_HEIGHT = 27.5; // HTML element height for a single branch
+const HEIGHT = 200; // HTML element height for the branches list
+
+/**
+ * The default folder, relative to the repository root, in which new
+ * worktrees are created.
+ *
+ * A visible folder is used on purpose: the Jupyter contents API does not
+ * serve hidden folders by default, which would prevent opening the
+ * worktrees in the file browser.
+ */
+export const DEFAULT_WORKTREE_FOLDER = 'worktrees';
+
+/**
+ * NewWorktreeDialog component properties
+ */
+export interface INewWorktreeDialogProps {
+  /**
+   * Current branch name.
+   */
+  currentBranch: string;
+
+  /**
+   * Current list of local branches.
+   */
+  branches: Git.IBranch[];
+
+  /**
+   * Callback to invoke upon closing the dialog.
+   *
+   * Called without options if the dialog is cancelled.
+   */
+  onClose(options?: Git.IAddWorktreeOptions): void;
+
+  /**
+   * The application language translator.
+   */
+  trans: TranslationBundle;
+}
+
+/**
+ * Returns the default worktree path for a branch.
+ *
+ * @param branch - branch name
+ * @returns worktree path relative to the repository root
+ */
+function defaultWorktreePath(branch: string): string {
+  return branch ? `${DEFAULT_WORKTREE_FOLDER}/${branch}` : '';
+}
+
+/**
+ * NewWorktreeDialog React component
+ *
+ * A dialog to create a new worktree, either for an existing branch which is
+ * not checked out in any worktree, or for a new branch started from the
+ * selected branch.
+ *
+ * @param props Component properties
+ * @returns React element
+ */
+export function NewWorktreeDialog(props: INewWorktreeDialogProps): JSX.Element {
+  const [filter, setFilter] = React.useState<string>('');
+  const [selectedBranch, setSelectedBranch] = React.useState<string>(
+    props.currentBranch
+  );
+  const [newBranchName, setNewBranchName] = React.useState<string>('');
+  const [worktreePath, setWorktreePath] = React.useState<string>('');
+  const [pathEdited, setPathEdited] = React.useState<boolean>(false);
+
+  const { trans } = props;
+
+  // A non-empty new branch name switches the dialog to "new branch" mode,
+  // in which the selected branch is used as the start point.
+  const newBranchMode = newBranchName.trim() !== '';
+
+  const branches = props.branches.filter(
+    branch => !filter || branch.name.includes(filter)
+  );
+
+  const selectedBranchData = props.branches.find(
+    branch => branch.name === selectedBranch
+  );
+  const selectionValid =
+    !!selectedBranchData && (newBranchMode || !selectedBranchData.worktree);
+
+  const canCreate =
+    worktreePath.trim() !== '' &&
+    (newBranchMode ? newBranchName.trim() !== '' : selectionValid);
+
+  function renderItem(rowProps: ListChildComponentProps): JSX.Element {
+    const { data, index, style } = rowProps;
+    const branch = data[index] as Git.IBranch;
+    const isSelected = branch.name === selectedBranch;
+    // Branches already checked out in a worktree cannot be checked out
+    // again, but they can be used as the start point of a new branch.
+    const unavailable = !newBranchMode && !!branch.worktree;
+
+    return (
+      <ListItem
+        button
+        title={
+          unavailable
+            ? trans.__(
+                "The branch '%1' is already checked out in the worktree '%2'",
+                branch.name,
+                branch.worktree ?? ''
+              )
+            : newBranchMode
+            ? trans.__('Start the new branch from %1', branch.name)
+            : trans.__('Create a worktree for branch %1', branch.name)
+        }
+        className={classes(
+          listItemClass,
+          isSelected ? activeListItemClass : null,
+          unavailable ? disabledListItemClass : null
+        )}
+        onClick={() => {
+          if (unavailable) {
+            return;
+          }
+          setSelectedBranch(branch.name);
+          if (!newBranchMode && !pathEdited) {
+            setWorktreePath(defaultWorktreePath(branch.name));
+          }
+        }}
+        style={style}
+      >
+        <branchIcon.react className={listItemIconClass} tag="span" />
+        <div className={listItemContentClass}>
+          <p className={listItemTitleClass}>{branch.name}</p>
+        </div>
+        {branch.worktree ? (
+          <worktreeIcon.react className={listItemIconClass} tag="span" />
+        ) : null}
+      </ListItem>
+    );
+  }
+
+  return (
+    <Dialog
+      classes={{
+        paper: branchDialogClass
+      }}
+      open={true}
+      onClose={() => {
+        props.onClose();
+      }}
+    >
+      <div className={titleWrapperClass}>
+        <p className={titleClass}>{trans.__('Add Worktree')}</p>
+        <button className={closeButtonClass}>
+          <ClearIcon
+            titleAccess={trans.__('Close this dialog')}
+            fontSize="small"
+            onClick={() => {
+              props.onClose();
+            }}
+          />
+        </button>
+      </div>
+      <div className={contentWrapperClass}>
+        <p>
+          {newBranchMode
+            ? trans.__('Start the new branch from…')
+            : trans.__('Branch to check out in the new worktree')}
+        </p>
+        <div className={filterWrapperClass}>
+          <div className={filterClass}>
+            <input
+              className={filterInputClass}
+              type="text"
+              onChange={event => {
+                setFilter(event.target.value);
+              }}
+              value={filter}
+              placeholder={trans.__('Filter')}
+              title={trans.__('Filter branch list')}
+            />
+            {filter ? (
+              <button className={filterClearClass}>
+                <ClearIcon
+                  titleAccess={trans.__('Clear the current filter')}
+                  fontSize="small"
+                  onClick={() => {
+                    setFilter('');
+                  }}
+                />
+              </button>
+            ) : null}
+          </div>
+        </div>
+        <FixedSizeList
+          className={listWrapperClass}
+          height={HEIGHT}
+          itemSize={ITEM_HEIGHT}
+          itemCount={branches.length}
+          itemData={branches}
+          itemKey={(index, data) => data[index].name}
+          style={{ overflowX: 'hidden' }}
+          width={'auto'}
+        >
+          {renderItem}
+        </FixedSizeList>
+        <p>{trans.__('Or create a new branch named…')}</p>
+        <input
+          className={nameInputClass}
+          type="text"
+          onChange={event => {
+            const name = event.target.value;
+            setNewBranchName(name);
+            if (!pathEdited) {
+              setWorktreePath(
+                defaultWorktreePath(name.trim() || selectedBranch)
+              );
+            }
+          }}
+          value={newBranchName}
+          placeholder={trans.__('Leave empty to use an existing branch')}
+          title={trans.__('Enter a new branch name')}
+        />
+        <p>{trans.__('Worktree path (relative to the repository)')}</p>
+        <input
+          className={nameInputClass}
+          type="text"
+          onChange={event => {
+            setWorktreePath(event.target.value);
+            setPathEdited(true);
+          }}
+          value={worktreePath}
+          placeholder={defaultWorktreePath(trans.__('branch'))}
+          title={trans.__('Enter the new worktree path')}
+        />
+      </div>
+      <DialogActions className={actionsWrapperClass}>
+        <input
+          className={classes(buttonClass, cancelButtonClass)}
+          type="button"
+          title={trans.__('Close this dialog without adding a worktree')}
+          value={trans.__('Cancel')}
+          onClick={() => {
+            props.onClose();
+          }}
+        />
+        <input
+          className={classes(buttonClass, createButtonClass)}
+          type="button"
+          title={trans.__('Add a new worktree')}
+          value={trans.__('Add Worktree')}
+          onClick={() => {
+            props.onClose({
+              worktreePath: worktreePath.trim(),
+              branch: newBranchMode ? newBranchName.trim() : selectedBranch,
+              newBranch: newBranchMode,
+              startPoint: newBranchMode ? selectedBranch : undefined
+            });
+          }}
+          disabled={!canCreate}
+        />
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -24,7 +24,13 @@ import {
   toolbarMenuWrapperClass,
   toolbarNavClass
 } from '../style/Toolbar';
-import { branchIcon, desktopIcon, pullIcon, pushIcon } from '../style/icons';
+import {
+  branchIcon,
+  desktopIcon,
+  pullIcon,
+  pushIcon,
+  worktreeIcon
+} from '../style/icons';
 import { CommandIDs, Git, IGitExtension } from '../tokens';
 import { ActionButton } from './ActionButton';
 import { SubmoduleMenu } from './SubmoduleMenu';
@@ -108,12 +114,18 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
                       {() => (
                         <UseSignal signal={this.props.model.submodulesChanged}>
                           {() => (
-                            <div className={toolbarClass}>
-                              {this._renderToolbarRow()}
-                              {this.state.repoMenu
-                                ? this._renderSubmodules()
-                                : null}
-                            </div>
+                            <UseSignal
+                              signal={this.props.model.worktreesChanged}
+                            >
+                              {() => (
+                                <div className={toolbarClass}>
+                                  {this._renderToolbarRow()}
+                                  {this.state.repoMenu
+                                    ? this._renderSubmodules()
+                                    : null}
+                                </div>
+                              )}
+                            </UseSignal>
                           )}
                         </UseSignal>
                       )}
@@ -144,42 +156,75 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
 
   private _renderRepoLabel(): React.ReactElement {
     const repositoryName = this._getRepositoryName();
+    const linkedWorktree = this._getLinkedWorktree();
     return (
       <span
         className={repoLabelClass}
-        title={this.props.trans.__(
-          'Current repository: %1',
-          this._getFullRepositoryPath()
-        )}
+        title={
+          linkedWorktree
+            ? this.props.trans.__(
+                'Current repository: %1 — linked worktree',
+                this._getFullRepositoryPath()
+              )
+            : this.props.trans.__(
+                'Current repository: %1',
+                this._getFullRepositoryPath()
+              )
+        }
       >
         <desktopIcon.react tag="span" className="jp-Icon" />
         <span className={repoButtonLabelClass}>{repositoryName}</span>
+        {linkedWorktree && (
+          <worktreeIcon.react tag="span" className="jp-Icon" />
+        )}
       </span>
     );
   }
 
   private _renderRepoButton(): React.ReactElement {
     const repositoryName = this._getRepositoryName();
+    const linkedWorktree = this._getLinkedWorktree();
     return (
       <button
         type="button"
         className={repoButtonClass}
-        title={this.props.trans.__(
-          'Current repository: %1 — click to switch submodule',
-          this._getFullRepositoryPath()
-        )}
+        title={
+          linkedWorktree
+            ? this.props.trans.__(
+                'Current repository: %1 — linked worktree — click to switch submodule',
+                this._getFullRepositoryPath()
+              )
+            : this.props.trans.__(
+                'Current repository: %1 — click to switch submodule',
+                this._getFullRepositoryPath()
+              )
+        }
         aria-haspopup="menu"
         aria-expanded={this.state.repoMenu}
         onClick={this._onRepoClick}
       >
         <desktopIcon.react tag="span" className="jp-Icon" />
         <span className={repoButtonLabelClass}>{repositoryName}</span>
+        {linkedWorktree && (
+          <worktreeIcon.react tag="span" className="jp-Icon" />
+        )}
         {this.state.repoMenu ? (
           <caretUpIcon.react tag="span" className="jp-Icon" />
         ) : (
           <caretDownIcon.react tag="span" className="jp-Icon" />
         )}
       </button>
+    );
+  }
+
+  /**
+   * Returns the current worktree if it is a linked worktree, `null` otherwise.
+   */
+  private _getLinkedWorktree(): Git.IWorktree | null {
+    return (
+      this.props.model.worktrees.find(
+        worktree => worktree.is_current && !worktree.is_main
+      ) ?? null
     );
   }
 

--- a/src/components/WorktreeMenu.tsx
+++ b/src/components/WorktreeMenu.tsx
@@ -11,16 +11,14 @@ import {
   activeListItemClass,
   listItemClass,
   listItemIconClass,
-  nameClass,
-  wrapperClass
+  nameClass
 } from '../style/BranchMenu';
 import {
   activeWorktreeDetailClass,
   disabledListItemClass,
-  newWorktreeButtonClass,
-  worktreeButtonWrapperClass,
   worktreePathClass,
-  worktreeStateClass
+  worktreeStateClass,
+  worktreeWrapperClass
 } from '../style/WorktreeMenuStyle';
 import { trashIcon, worktreeIcon } from '../style/icons';
 import { CommandIDs, Git, IGitExtension } from '../tokens';
@@ -65,29 +63,7 @@ export class WorktreeMenu extends React.Component<IWorktreeMenuProps> {
    */
   render(): React.ReactElement {
     return (
-      <div className={wrapperClass}>
-        {this._renderNewWorktreeButton()}
-        {this._renderWorktreeList()}
-      </div>
-    );
-  }
-
-  /**
-   * Renders a button to create a new worktree.
-   *
-   * @returns React element
-   */
-  private _renderNewWorktreeButton(): React.ReactElement {
-    return (
-      <div className={worktreeButtonWrapperClass}>
-        <input
-          className={newWorktreeButtonClass}
-          type="button"
-          title={this.props.trans.__('Create a new worktree')}
-          value={this.props.trans.__('New Worktree')}
-          onClick={this._onNewWorktreeClick}
-        />
-      </div>
+      <div className={worktreeWrapperClass}>{this._renderWorktreeList()}</div>
     );
   }
 
@@ -207,13 +183,6 @@ export class WorktreeMenu extends React.Component<IWorktreeMenuProps> {
         )}
       </ListItem>
     );
-  };
-
-  /**
-   * Callback invoked upon clicking a button to create a new worktree.
-   */
-  private _onNewWorktreeClick = (): void => {
-    this.props.commands.execute(CommandIDs.gitAddWorktree);
   };
 
   /**

--- a/src/components/WorktreeMenu.tsx
+++ b/src/components/WorktreeMenu.tsx
@@ -1,0 +1,311 @@
+import { Dialog, Notification, showDialog } from '@jupyterlab/apputils';
+import { TranslationBundle } from '@jupyterlab/translation';
+import { CommandRegistry } from '@lumino/commands';
+import ListItem from '@mui/material/ListItem';
+import * as React from 'react';
+import { FixedSizeList, ListChildComponentProps } from 'react-window';
+import { classes } from 'typestyle';
+import { showError } from '../notifications';
+import { hiddenButtonStyle } from '../style/ActionButtonStyle';
+import {
+  activeListItemClass,
+  listItemClass,
+  listItemIconClass,
+  nameClass,
+  wrapperClass
+} from '../style/BranchMenu';
+import {
+  activeWorktreeDetailClass,
+  disabledListItemClass,
+  newWorktreeButtonClass,
+  worktreeButtonWrapperClass,
+  worktreePathClass,
+  worktreeStateClass
+} from '../style/WorktreeMenuStyle';
+import { trashIcon, worktreeIcon } from '../style/icons';
+import { CommandIDs, Git, IGitExtension } from '../tokens';
+import { ActionButton } from './ActionButton';
+
+const ITEM_HEIGHT = 24.8; // HTML element height for a single worktree
+const MAX_HEIGHT = 400; // Maximal HTML element height for the worktrees list
+
+/**
+ * Interface describing component properties.
+ */
+export interface IWorktreeMenuProps {
+  /**
+   * Jupyter App commands registry
+   */
+  commands: CommandRegistry;
+
+  /**
+   * Git extension data model.
+   */
+  model: IGitExtension;
+
+  /**
+   * The list of worktrees of the repo.
+   */
+  worktrees: Git.IWorktree[];
+
+  /**
+   * The application language translator.
+   */
+  trans: TranslationBundle;
+}
+
+/**
+ * React component for rendering a worktree menu.
+ */
+export class WorktreeMenu extends React.Component<IWorktreeMenuProps> {
+  /**
+   * Renders the component.
+   *
+   * @returns React element
+   */
+  render(): React.ReactElement {
+    return (
+      <div className={wrapperClass}>
+        {this._renderNewWorktreeButton()}
+        {this._renderWorktreeList()}
+      </div>
+    );
+  }
+
+  /**
+   * Renders a button to create a new worktree.
+   *
+   * @returns React element
+   */
+  private _renderNewWorktreeButton(): React.ReactElement {
+    return (
+      <div className={worktreeButtonWrapperClass}>
+        <input
+          className={newWorktreeButtonClass}
+          type="button"
+          title={this.props.trans.__('Create a new worktree')}
+          value={this.props.trans.__('New Worktree')}
+          onClick={this._onNewWorktreeClick}
+        />
+      </div>
+    );
+  }
+
+  /**
+   * Renders the list of worktrees.
+   *
+   * @returns React element
+   */
+  private _renderWorktreeList(): React.ReactElement {
+    // A bare repository entry is not a working tree that can be opened
+    const worktrees = this.props.worktrees.filter(worktree => !worktree.bare);
+
+    return (
+      <FixedSizeList
+        height={Math.min(
+          Math.max(1, worktrees.length) * ITEM_HEIGHT,
+          MAX_HEIGHT
+        )}
+        itemCount={worktrees.length}
+        itemData={worktrees}
+        itemKey={(index, data) => data[index].path}
+        itemSize={ITEM_HEIGHT}
+        style={{ overflowX: 'hidden', paddingTop: 0, paddingBottom: 0 }}
+        width={'auto'}
+      >
+        {this._renderItem}
+      </FixedSizeList>
+    );
+  }
+
+  /**
+   * Renders a menu item.
+   *
+   * @param props Row properties
+   * @returns React element
+   */
+  private _renderItem = (props: ListChildComponentProps): JSX.Element => {
+    const { data, index, style } = props;
+    const worktree = data[index] as Git.IWorktree;
+    const trans = this.props.trans;
+
+    const isOutsideRoot = worktree.path.startsWith('..');
+    const openable =
+      !worktree.is_current && !worktree.prunable && !isOutsideRoot;
+    const label =
+      worktree.branch ?? (worktree.head ? worktree.head.slice(0, 7) : '');
+
+    let stateHint = '';
+    if (worktree.prunable) {
+      stateHint = trans.__('(stale)');
+    } else if (worktree.locked) {
+      stateHint = trans.__('(locked)');
+    } else if (worktree.detached) {
+      stateHint = trans.__('(detached)');
+    }
+
+    let title: string;
+    if (worktree.is_current) {
+      title = trans.__('Current worktree: %1', worktree.path);
+    } else if (worktree.prunable) {
+      title = trans.__(
+        'The folder of this worktree is missing; it can be removed'
+      );
+    } else if (isOutsideRoot) {
+      title = trans.__(
+        'This worktree is outside of the Jupyter server root and cannot be opened'
+      );
+    } else {
+      title = trans.__('Open worktree: %1', worktree.path);
+    }
+
+    return (
+      <ListItem
+        button
+        title={title}
+        className={classes(
+          listItemClass,
+          worktree.is_current ? activeListItemClass : null,
+          !openable && !worktree.is_current ? disabledListItemClass : null
+        )}
+        onClick={this._onWorktreeClickFactory(worktree)}
+        role="listitem"
+        style={style}
+      >
+        <worktreeIcon.react className={listItemIconClass} tag="span" />
+        <span className={nameClass}>{label}</span>
+        {stateHint && (
+          <span
+            className={classes(
+              worktreeStateClass,
+              worktree.is_current ? activeWorktreeDetailClass : null
+            )}
+          >
+            {stateHint}
+          </span>
+        )}
+        <span
+          className={classes(
+            worktreePathClass,
+            worktree.is_current ? activeWorktreeDetailClass : null
+          )}
+        >
+          {worktree.path}
+        </span>
+        {!worktree.is_main && !worktree.is_current && (
+          <ActionButton
+            className={hiddenButtonStyle}
+            icon={trashIcon}
+            title={trans.__('Remove this worktree')}
+            onClick={async (
+              event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+            ) => {
+              event?.stopPropagation();
+              await this._onRemoveWorktree(worktree);
+            }}
+          />
+        )}
+      </ListItem>
+    );
+  };
+
+  /**
+   * Callback invoked upon clicking a button to create a new worktree.
+   */
+  private _onNewWorktreeClick = (): void => {
+    this.props.commands.execute(CommandIDs.gitAddWorktree);
+  };
+
+  /**
+   * Returns a callback which is invoked upon clicking a worktree.
+   *
+   * @param worktree - worktree
+   * @returns callback
+   */
+  private _onWorktreeClickFactory(worktree: Git.IWorktree) {
+    return async (): Promise<void> => {
+      const isOutsideRoot = worktree.path.startsWith('..');
+      if (worktree.is_current || worktree.prunable || isOutsideRoot) {
+        return;
+      }
+      await this.props.commands.execute(CommandIDs.gitOpenWorktree, {
+        path: worktree.path
+      });
+    };
+  }
+
+  /**
+   * Callback on remove worktree button
+   *
+   * @param worktree Worktree to remove
+   */
+  private _onRemoveWorktree = async (
+    worktree: Git.IWorktree
+  ): Promise<void> => {
+    const trans = this.props.trans;
+    const acknowledgement = await showDialog<void>({
+      title: trans.__('Remove worktree'),
+      body: (
+        <p>
+          {trans.__(
+            'Are you sure you want to permanently remove the worktree '
+          )}
+          <b>{worktree.path}</b>?
+          <br />
+          {trans.__('This deletes its folder and cannot be undone.')}
+        </p>
+      ),
+      buttons: [
+        Dialog.cancelButton({ label: trans.__('Cancel') }),
+        Dialog.warnButton({ label: trans.__('Remove') })
+      ]
+    });
+    if (!acknowledgement.button.accept) {
+      return;
+    }
+
+    try {
+      await this.props.model.removeWorktree(worktree.path);
+    } catch (error: any) {
+      const message: string = error?.message ?? '';
+      const isDirty = message.includes('modified or untracked files');
+      const isLocked = message.includes('locked working tree');
+      if (!isDirty && !isLocked) {
+        Notification.error(
+          trans.__('Failed to remove worktree.'),
+          showError(error, trans)
+        );
+        return;
+      }
+
+      const confirmForce = await showDialog<void>({
+        title: trans.__('Force remove worktree'),
+        body: isLocked
+          ? trans.__(
+              'The worktree %1 is locked. Do you want to force its removal?',
+              worktree.path
+            )
+          : trans.__(
+              'The worktree %1 contains modified or untracked files that will be lost. Do you want to force its removal?',
+              worktree.path
+            ),
+        buttons: [
+          Dialog.cancelButton({ label: trans.__('Cancel') }),
+          Dialog.warnButton({ label: trans.__('Force Remove') })
+        ]
+      });
+      if (!confirmForce.button.accept) {
+        return;
+      }
+
+      try {
+        await this.props.model.removeWorktree(worktree.path, true);
+      } catch (forceError: any) {
+        Notification.error(
+          trans.__('Failed to remove worktree.'),
+          showError(forceError, trans)
+        );
+      }
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,6 +312,7 @@ async function activate(
         CommandIDs.gitPull,
         CommandIDs.gitResetToRemote,
         CommandIDs.gitManageRemote,
+        CommandIDs.gitAddWorktree,
         CommandIDs.gitTerminalCommand
       ].forEach(command => palette.addItem({ command, category }));
     }

--- a/src/model.ts
+++ b/src/model.ts
@@ -122,6 +122,13 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
+   * Worktree list for the current repository.
+   */
+  get worktrees(): Git.IWorktree[] {
+    return this._worktrees;
+  }
+
+  /**
    * Tags list for the current repository.
    */
   get tagsList(): Git.ITag[] {
@@ -284,6 +291,13 @@ export class GitExtension implements IGitExtension {
    */
   get submodulesChanged(): ISignal<IGitExtension, void> {
     return this._submodulesChanged;
+  }
+
+  /**
+   * A signal emitted when the worktrees of the Git repository change.
+   */
+  get worktreesChanged(): ISignal<IGitExtension, void> {
+    return this._worktreesChanged;
   }
 
   /**
@@ -1343,6 +1357,114 @@ export class GitExtension implements IGitExtension {
   }
 
   /**
+   * Refresh the list of repository worktrees.
+   *
+   * Emit worktreesChanged if the worktree list changes.
+   *
+   * @returns promise which resolves upon refreshing repository worktrees
+   */
+  async refreshWorktrees(): Promise<void> {
+    try {
+      const path = await this._getPathRepository();
+      const data = await this._taskHandler.execute<Git.IWorktreeResult>(
+        'git:refresh:worktrees',
+        async () => {
+          return await this._requestAPI<Git.IWorktreeResult>(
+            URLExt.join(path, 'worktrees'),
+            'GET'
+          );
+        }
+      );
+
+      const worktrees = data.worktrees ?? [];
+      const worktreesChanged = !JSONExt.deepEqual(
+        this._worktrees as any,
+        worktrees as any
+      );
+
+      this._worktrees = worktrees;
+
+      if (worktreesChanged) {
+        this._worktreesChanged.emit();
+      }
+    } catch (error) {
+      const worktreesChanged = this._worktrees.length > 0;
+      this._worktrees = [];
+      if (worktreesChanged) {
+        this._worktreesChanged.emit();
+      }
+
+      if (!(error instanceof Git.NotInRepository)) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Add a new worktree to the current repository.
+   *
+   * @param options - worktree options
+   * @returns promise which resolves upon adding a worktree
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  async addWorktree(
+    options: Git.IAddWorktreeOptions
+  ): Promise<Git.IWorktreeAddResult> {
+    const path = await this._getPathRepository();
+    const data = await this._taskHandler.execute<Git.IWorktreeAddResult>(
+      'git:worktree:add',
+      async () => {
+        return await this._requestAPI<Git.IWorktreeAddResult>(
+          URLExt.join(path, 'worktrees'),
+          'POST',
+          {
+            worktree_path: options.worktreePath,
+            branch: options.branch,
+            new_branch: options.newBranch ?? false,
+            start_point: options.startPoint ?? null
+          }
+        );
+      }
+    );
+
+    await this.refreshWorktrees();
+    await this.refreshBranch();
+
+    return data;
+  }
+
+  /**
+   * Remove a worktree from the current repository.
+   *
+   * @param worktreePath - worktree path relative to the server root
+   * @param force - whether to remove the worktree even if it is dirty or locked
+   * @returns promise which resolves upon removing the worktree
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  async removeWorktree(worktreePath: string, force = false): Promise<void> {
+    const path = await this._getPathRepository();
+    await this._taskHandler.execute<void>('git:worktree:remove', async () => {
+      await this._requestAPI(
+        URLExt.join(path, 'worktrees') +
+          URLExt.objectToQueryString({
+            worktree_path: worktreePath,
+            force: String(force)
+          }),
+        'DELETE'
+      );
+    });
+
+    await this.refreshWorktrees();
+    await this.refreshBranch();
+  }
+
+  /**
    * Refresh the repository status.
    *
    * Emit statusChanged if required.
@@ -2353,6 +2475,7 @@ export class GitExtension implements IGitExtension {
       try {
         await this.refreshBranch();
         await this.refreshTag();
+        await this.refreshWorktrees();
         await this.refreshStatus();
         await this.refreshStash();
         await this.checkRemoteChangeNotified();
@@ -2437,6 +2560,7 @@ export class GitExtension implements IGitExtension {
   private _credentialsRequired = false;
   private _lastAuthor: Git.IIdentity | null = null;
   private _submodules: Git.ISubmodule[] = [];
+  private _worktrees: Git.IWorktree[] = [];
 
   // Configurable
   private _statusForDirtyState: Git.Status[] = ['staged', 'partially-staged'];
@@ -2444,6 +2568,7 @@ export class GitExtension implements IGitExtension {
   private _branchesChanged = new Signal<IGitExtension, void>(this);
   private _tagsChanged = new Signal<IGitExtension, void>(this);
   private _submodulesChanged = new Signal<IGitExtension, void>(this);
+  private _worktreesChanged = new Signal<IGitExtension, void>(this);
   private _headChanged = new Signal<IGitExtension, void>(this);
   private _markChanged = new Signal<IGitExtension, void>(this);
   private _selectedHistoryFileChanged = new Signal<

--- a/src/style/WorktreeMenuStyle.ts
+++ b/src/style/WorktreeMenuStyle.ts
@@ -1,0 +1,60 @@
+import { style } from 'typestyle';
+
+export const worktreeButtonWrapperClass = style({
+  padding: '4px 11px 4px',
+  display: 'flex',
+  justifyContent: 'flex-end'
+});
+
+export const newWorktreeButtonClass = style({
+  boxSizing: 'border-box',
+
+  height: '2em',
+  flex: '0 0 auto',
+
+  padding: '0 8px',
+
+  color: 'white',
+  fontSize: 'var(--jp-ui-font-size1)',
+
+  backgroundColor: 'var(--md-blue-500)',
+  border: '0',
+  borderRadius: '3px',
+
+  $nest: {
+    '&:hover': {
+      backgroundColor: 'var(--md-blue-600)'
+    },
+    '&:active': {
+      backgroundColor: 'var(--md-blue-700)'
+    }
+  }
+});
+
+export const worktreePathClass = style({
+  flex: '10 1 auto',
+  fontSize: 'var(--jp-ui-font-size0)',
+  color: 'var(--jp-ui-font-color2)',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  marginLeft: '4px'
+});
+
+export const worktreeStateClass = style({
+  flex: '0 0 auto',
+  fontSize: 'var(--jp-ui-font-size0)',
+  color: 'var(--jp-ui-font-color2)',
+  fontStyle: 'italic',
+  marginLeft: '4px'
+});
+
+export const activeWorktreeDetailClass = style({
+  color: 'inherit',
+  opacity: 0.8
+});
+
+export const disabledListItemClass = style({
+  opacity: 0.5,
+  cursor: 'default'
+});

--- a/src/style/WorktreeMenuStyle.ts
+++ b/src/style/WorktreeMenuStyle.ts
@@ -1,34 +1,7 @@
 import { style } from 'typestyle';
 
-export const worktreeButtonWrapperClass = style({
-  padding: '4px 11px 4px',
-  display: 'flex',
-  justifyContent: 'flex-end'
-});
-
-export const newWorktreeButtonClass = style({
-  boxSizing: 'border-box',
-
-  height: '2em',
-  flex: '0 0 auto',
-
-  padding: '0 8px',
-
-  color: 'white',
-  fontSize: 'var(--jp-ui-font-size1)',
-
-  backgroundColor: 'var(--md-blue-500)',
-  border: '0',
-  borderRadius: '3px',
-
-  $nest: {
-    '&:hover': {
-      backgroundColor: 'var(--md-blue-600)'
-    },
-    '&:active': {
-      backgroundColor: 'var(--md-blue-700)'
-    }
-  }
+export const worktreeWrapperClass = style({
+  borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)'
 });
 
 export const worktreePathClass = style({

--- a/src/style/icons.ts
+++ b/src/style/icons.ts
@@ -22,6 +22,7 @@ import selectForCompareSvg from '../../style/icons/select-for-compare.svg';
 import tagSvg from '../../style/icons/tag.svg';
 import trashSvg from '../../style/icons/trash.svg';
 import verticalMoreSvg from '../../style/icons/vertical-more.svg';
+import worktreeSvg from '../../style/icons/worktree.svg';
 
 export const gitIcon = new LabIcon({ name: 'git', svgstr: gitSvg });
 export const addIcon = new LabIcon({
@@ -103,4 +104,8 @@ export const trashIcon = new LabIcon({
 export const verticalMoreIcon = new LabIcon({
   name: 'git:vertical-more',
   svgstr: verticalMoreSvg
+});
+export const worktreeIcon = new LabIcon({
+  name: 'git:worktree',
+  svgstr: worktreeSvg
 });

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -35,6 +35,11 @@ export interface IGitExtension extends IDisposable {
   submodules: Git.ISubmodule[];
 
   /**
+   * The list of worktrees of the current repo
+   */
+  worktrees: Git.IWorktree[];
+
+  /**
    * A signal emitted when the branches of the Git repository changes.
    */
   readonly branchesChanged: ISignal<IGitExtension, void>;
@@ -53,6 +58,11 @@ export interface IGitExtension extends IDisposable {
    * A signal emitted when the submodules of the Git repository change.
    */
   readonly submodulesChanged: ISignal<IGitExtension, void>;
+
+  /**
+   * A signal emitted when the worktrees of the Git repository change.
+   */
+  readonly worktreesChanged: ISignal<IGitExtension, void>;
 
   /**
    * Top level path of the current Git repository
@@ -201,6 +211,20 @@ export interface IGitExtension extends IDisposable {
    * @throws {ServerConnection.NetworkError} If the request cannot be made
    */
   addRemote(url: string, name?: string): Promise<void>;
+
+  /**
+   * Add a new worktree to the current repository.
+   *
+   * @param options - worktree options
+   * @returns promise which resolves upon adding a worktree
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  addWorktree(
+    options: Git.IAddWorktreeOptions
+  ): Promise<Git.IWorktreeAddResult>;
 
   /**
    * Apply a given stash
@@ -535,6 +559,24 @@ export interface IGitExtension extends IDisposable {
    * Make request for a list of all Git tags
    */
   refreshTag(): Promise<void>;
+
+  /**
+   * Make request for a list of all Git worktrees
+   */
+  refreshWorktrees(): Promise<void>;
+
+  /**
+   * Remove a worktree from the current repository.
+   *
+   * @param worktreePath - worktree path relative to the server root
+   * @param force - whether to remove the worktree even if it is dirty or locked
+   * @returns promise which resolves upon removing the worktree
+   *
+   * @throws {Git.NotInRepository} If the current path is not a Git repository
+   * @throws {Git.GitResponseError} If the server response is not ok
+   * @throws {ServerConnection.NetworkError} If the request cannot be made
+   */
+  removeWorktree(worktreePath: string, force?: boolean): Promise<void>;
 
   /**
    * Determines whether there are unsaved changes on staged files,
@@ -987,6 +1029,13 @@ export namespace Git {
     upstream: string | null;
     top_commit: string;
     tag: string | null;
+    /**
+     * Path of the worktree where the branch is checked out, relative to the
+     * server root; starts with '..' if outside of the server root. `null` if
+     * the branch is not checked out in any worktree. Only set for local
+     * branches.
+     */
+    worktree?: string | null;
   }
 
   /** Interface for GitBranch request result,
@@ -1012,6 +1061,92 @@ export namespace Git {
   export interface ISubmoduleResult {
     code: number;
     submodules: ISubmodule[];
+  }
+
+  /**
+   * Worktree description interface
+   */
+  export interface IWorktree {
+    /**
+     * Worktree path relative to the server root; starts with '..' if the
+     * worktree is outside of the server root and cannot be opened.
+     */
+    path: string;
+    /**
+     * Commit the worktree HEAD points to.
+     */
+    head: string | null;
+    /**
+     * Branch checked out in the worktree; `null` if detached or bare.
+     */
+    branch: string | null;
+    /**
+     * Whether the worktree HEAD is detached.
+     */
+    detached: boolean;
+    /**
+     * Whether the entry is a bare repository.
+     */
+    bare: boolean;
+    /**
+     * Whether the worktree is locked.
+     */
+    locked: boolean;
+    /**
+     * Whether the worktree is stale and can be pruned (e.g. its folder was
+     * deleted manually).
+     */
+    prunable: boolean;
+    /**
+     * Whether the entry is the main worktree.
+     */
+    is_main: boolean;
+    /**
+     * Whether the entry is the current repository.
+     */
+    is_current: boolean;
+  }
+
+  /**
+   * Interface for worktree list request result
+   */
+  export interface IWorktreeResult {
+    code: number;
+    worktrees?: IWorktree[];
+  }
+
+  /**
+   * Options to add a new worktree
+   */
+  export interface IAddWorktreeOptions {
+    /**
+     * Worktree path relative to the repository root.
+     */
+    worktreePath: string;
+    /**
+     * Branch to check out in the new worktree.
+     */
+    branch: string;
+    /**
+     * Whether to create the branch.
+     */
+    newBranch?: boolean;
+    /**
+     * Commit-ish a new branch starts from; defaults to HEAD.
+     */
+    startPoint?: string;
+  }
+
+  /**
+   * Interface for worktree add request result
+   */
+  export interface IWorktreeAddResult {
+    code: number;
+    message?: string;
+    /**
+     * Path of the created worktree relative to the server root.
+     */
+    worktree_path?: string;
   }
 
   /**
@@ -1432,5 +1567,7 @@ export enum CommandIDs {
   gitShowDiff = 'git:show-diff',
   gitStash = 'git:stash',
   gitStashPop = 'git:stash-pop',
-  gitStashList = 'git:stash-list'
+  gitStashList = 'git:stash-list',
+  gitAddWorktree = 'git:add-worktree',
+  gitOpenWorktree = 'git:open-worktree'
 }

--- a/src/widgets/GitWidget.tsx
+++ b/src/widgets/GitWidget.tsx
@@ -6,7 +6,12 @@ import { CommandRegistry } from '@lumino/commands';
 import { Message } from '@lumino/messaging';
 import { PanelLayout, Widget } from '@lumino/widgets';
 import * as React from 'react';
-import { PanelWithToolbar, SidePanel } from '@jupyterlab/ui-components';
+import {
+  PanelWithToolbar,
+  SidePanel,
+  ToolbarButton,
+  addIcon
+} from '@jupyterlab/ui-components';
 import { GitPanel } from '../components/GitPanel';
 import { Toolbar } from '../components/Toolbar';
 import { GitExtension } from '../model';
@@ -15,6 +20,7 @@ import {
   sectionBodyStyle,
   sectionStyle
 } from '../style/GitWidgetStyle';
+import { CommandIDs } from '../tokens';
 
 /**
  * The Git extension's main side-bar widget.
@@ -59,6 +65,16 @@ export class GitWidget extends SidePanel {
     this._worktreesSection = this._createSection(
       'Worktrees',
       this._createWorktreesSection()
+    );
+    this._worktreesSection.toolbar.addItem(
+      'new-worktree',
+      new ToolbarButton({
+        icon: addIcon,
+        onClick: () => {
+          void this._commands.execute(CommandIDs.gitAddWorktree);
+        },
+        tooltip: trans.__('Create a new worktree')
+      })
     );
     this._updateWorktreesSection();
     model.worktreesChanged.connect(this._updateWorktreesSection, this);

--- a/src/widgets/GitWidget.tsx
+++ b/src/widgets/GitWidget.tsx
@@ -54,9 +54,29 @@ export class GitWidget extends SidePanel {
       this._createSection('Branches and Tags', this._createBranchesSection())
     );
 
+    // The worktrees section is only shown when the repository has linked
+    // worktrees.
+    this._worktreesSection = this._createSection(
+      'Worktrees',
+      this._createWorktreesSection()
+    );
+    this._updateWorktreesSection();
+    model.worktreesChanged.connect(this._updateWorktreesSection, this);
+
     // Add refresh standby condition if this widget is hidden
     model.refreshStandbyCondition = (): boolean =>
       !this._settings.composite['refreshIfHidden'] && this.isHidden;
+  }
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._model.worktreesChanged.disconnect(this._updateWorktreesSection, this);
+    if (this._worktreesSection.parent === null) {
+      this._worktreesSection.dispose();
+    }
+    super.dispose();
   }
 
   /**
@@ -123,6 +143,34 @@ export class GitWidget extends SidePanel {
     );
   }
 
+  private _createWorktreesSection(): React.ReactElement {
+    return (
+      <GitPanel
+        commands={this._commands}
+        filebrowser={this._fileBrowserModel}
+        model={this._model}
+        settings={this._settings}
+        trans={this._gitTrans}
+        contentMode="worktrees"
+      />
+    );
+  }
+
+  /**
+   * Attach or detach the worktrees section depending on whether the current
+   * repository has linked worktrees.
+   */
+  private _updateWorktreesSection(): void {
+    const hasLinkedWorktrees = this._model.worktrees.some(
+      worktree => !worktree.is_main
+    );
+    if (hasLinkedWorktrees && this._worktreesSection.parent === null) {
+      this.addWidget(this._worktreesSection);
+    } else if (!hasLinkedWorktrees && this._worktreesSection.parent !== null) {
+      this._worktreesSection.parent = null;
+    }
+  }
+
   private _renderTopToolbar(): React.ReactElement {
     return (
       <Toolbar
@@ -138,4 +186,5 @@ export class GitWidget extends SidePanel {
   private _fileBrowserModel: FileBrowserModel;
   private _model: GitExtension;
   private _settings: ISettingRegistry.ISettings;
+  private _worktreesSection: PanelWithToolbar;
 }

--- a/style/icons/worktree.svg
+++ b/style/icons/worktree.svg
@@ -1,0 +1,6 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" viewBox="0 0 24 24">
+  <g class="jp-icon3 jp-icon-selectable" fill="#4F4F4F">
+    <path d="M3 6H1v13c0 1.1.9 2 2 2h17v-2H3V6z"/>
+    <path d="M23 4h-9l-2-2H7c-1.1 0-2 .9-2 2v11c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2z"/>
+  </g>
+</svg>

--- a/ui-tests/tests/worktree.spec.ts
+++ b/ui-tests/tests/worktree.spec.ts
@@ -54,6 +54,11 @@ test.describe('Git Worktrees', () => {
     });
     await worktreeItem.waitFor();
 
+    // The worktrees section toolbar offers to create another worktree
+    await page.getByRole('button', { name: 'Create a new worktree' }).click();
+    await dialog.waitFor();
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+
     // Open the worktree; the whole panel now targets it
     await worktreeItem.click();
 

--- a/ui-tests/tests/worktree.spec.ts
+++ b/ui-tests/tests/worktree.spec.ts
@@ -1,0 +1,107 @@
+import { expect, galata, test } from '@jupyterlab/galata';
+import path from 'path';
+import { extractFile } from './utils';
+
+const baseRepositoryPath = 'test-repository.tar.gz';
+test.use({ autoGoto: false, mockSettings: galata.DEFAULT_SETTINGS });
+
+test.describe('Git Worktrees', () => {
+  test.beforeEach(async ({ page, request, tmpPath }) => {
+    await extractFile(
+      request,
+      path.resolve(__dirname, 'data', baseRepositoryPath),
+      path.join(tmpPath, 'repository.tar.gz')
+    );
+
+    await page.goto(`tree/${tmpPath}/test-repository`);
+
+    await page.sidebar.openTab('jp-git-sessions');
+    // Wait for the panel to load the repository
+    await page.getByTitle('Current branch: master').waitFor();
+  });
+
+  test('should not show the worktrees section without linked worktrees', async ({
+    page
+  }) => {
+    await expect(page.getByText('Worktrees', { exact: true })).toHaveCount(0);
+  });
+
+  test('should add a worktree for a new branch and open it', async ({
+    page,
+    tmpPath
+  }) => {
+    // Open the add worktree dialog from the main menu
+    await page.menu.clickMenuItem('Git>Add Worktree…');
+
+    const dialog = page.getByRole('dialog');
+    await dialog.waitFor();
+
+    await dialog
+      .getByRole('textbox', { name: 'Enter a new branch name' })
+      .fill('my-worktree');
+
+    // The worktree path is derived from the branch name
+    await expect(
+      dialog.getByRole('textbox', { name: 'Enter the new worktree path' })
+    ).toHaveValue('worktrees/my-worktree');
+
+    await dialog.getByRole('button', { name: 'Add Worktree' }).click();
+
+    // The worktrees section appears with the new worktree
+    await page.getByText('Worktrees', { exact: true }).waitFor();
+    const worktreeItem = page.getByRole('listitem', {
+      name: `Open worktree: ${tmpPath}/test-repository/worktrees/my-worktree`
+    });
+    await worktreeItem.waitFor();
+
+    // Open the worktree; the whole panel now targets it
+    await worktreeItem.click();
+
+    await page
+      .getByRole('listitem', {
+        name: `Current worktree: ${tmpPath}/test-repository/worktrees/my-worktree`
+      })
+      .waitFor();
+    await expect(page.getByTitle('Current branch: my-worktree')).toHaveCount(1);
+  });
+
+  test('should show a dialog when switching to a branch checked out in another worktree', async ({
+    page
+  }) => {
+    // Create a worktree for a new branch
+    await page.menu.clickMenuItem('Git>Add Worktree…');
+    const dialog = page.getByRole('dialog');
+    await dialog.waitFor();
+    await dialog
+      .getByRole('textbox', { name: 'Enter a new branch name' })
+      .fill('busy-branch');
+    await dialog.getByRole('button', { name: 'Add Worktree' }).click();
+    await page.getByText('Worktrees', { exact: true }).waitFor();
+
+    // Open the branches section and try to switch to the branch of the worktree
+    const branchesRegion = page.getByRole('region', {
+      name: 'Branches and Tags Section'
+    });
+    if (!(await branchesRegion.isVisible())) {
+      await page.getByText('Branches and Tags', { exact: true }).click();
+    }
+    const branchItem = page.getByRole('listitem', {
+      name: 'Switch to branch: busy-branch'
+    });
+    await branchItem.waitFor();
+
+    // The branch is flagged with its worktree
+    await expect(branchItem.getByTitle(/Checked out in worktree:/)).toHaveCount(
+      1
+    );
+
+    await branchItem.click();
+
+    // A dialog offers to open the worktree instead of failing the checkout
+    await page.getByText('Branch checked out in another worktree').waitFor();
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+
+    // Still on the original branch
+    await expect(page.getByTitle('Current branch: master')).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
Fixes #1504 

This will make it easier to discover worktrees (often used with coding agents) and switch between them to diff the changed files, all from the same running JupyterLab instance. 

https://github.com/user-attachments/assets/6a6a4970-3915-4697-8542-15b7cfd0a0a9

Fable 5 helped with this PR.