### PR TITLE
Fix Check Links on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,4 +171,4 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: "https://www.linkedin.com/.* https://fellowship.mlh.io/.* https://github.com/.* https://amazon.com/.*"
+          ignore_links: "https://www.linkedin.com/.* https://fellowship.mlh.io/.* https://github.com/.* https://amazon.com/.* https://stackoverflow.com/.*"


### PR DESCRIPTION
Getting 403s consistently:

<img width="1526" height="182" alt="image" src="https://github.com/user-attachments/assets/dd1d68e1-701d-4954-a628-ab28cd5cd306" />
