### PR TITLE
Improve Git panel UX

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -106,6 +106,71 @@
       "title": "Clear outputs before commit",
       "description": "If true, notebook outputs will be cleared before committing. If false, outputs are kept. If null, ask each time.",
       "default": null
+    },
+    "toolbar": {
+      "title": "Git panel toolbar items",
+      "description": "Note: To disable a toolbar item,\ncopy it to User Preferences and add the\n\"disabled\" key. The following example will disable the refresh button:\n{\n  \"toolbar\": [\n    {\n      \"name\": \"refresh\",\n      \"disabled\": true\n    }\n  ]\n}\n\nToolbar description:",
+      "items": {
+        "$ref": "#/definitions/toolbarItem"
+      },
+      "type": "array",
+      "default": []
+    }
+  },
+  "definitions": {
+    "toolbarItem": {
+      "properties": {
+        "name": {
+          "title": "Unique name",
+          "type": "string"
+        },
+        "args": {
+          "title": "Command arguments",
+          "type": "object"
+        },
+        "command": {
+          "title": "Command id",
+          "type": "string",
+          "default": ""
+        },
+        "disabled": {
+          "title": "Whether the item is ignored or not",
+          "type": "boolean",
+          "default": false
+        },
+        "icon": {
+          "title": "Item icon id",
+          "description": "If defined, it will override the command icon",
+          "type": "string"
+        },
+        "label": {
+          "title": "Item label",
+          "description": "If defined, it will override the command label",
+          "type": "string"
+        },
+        "caption": {
+          "title": "Item caption",
+          "description": "If defined, it will override the command caption",
+          "type": "string"
+        },
+        "type": {
+          "title": "Item type",
+          "type": "string",
+          "oneOf": [
+            { "const": "command", "title": "Command" },
+            { "const": "spacer", "title": "Spacer" }
+          ]
+        },
+        "rank": {
+          "title": "Item rank",
+          "type": "number",
+          "minimum": 0,
+          "default": 50
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false,
+      "type": "object"
     }
   },
   "jupyter.lab.shortcuts": [
@@ -219,6 +284,15 @@
     "domain": "jupyterlab_git"
   },
   "jupyter.lab.toolbars": {
-    "FileBrowser": [{ "name": "gitClone", "rank": 31 }]
-  }
+    "FileBrowser": [{ "name": "gitClone", "rank": 31 }],
+    "Git": [
+      { "name": "repository", "rank": 10 },
+      { "name": "branch", "rank": 20 },
+      { "name": "spacer", "type": "spacer", "rank": 50 },
+      { "name": "pull", "rank": 60 },
+      { "name": "push", "rank": 70 },
+      { "name": "refresh", "rank": 80 }
+    ]
+  },
+  "jupyter.lab.transform": true
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -77,6 +77,22 @@
       "description": "If true, use a simplified concept of staging. Only files with changes are shown (instead of showing staged/changed/untracked), and all files with changes will be automatically staged",
       "default": false
     },
+    "commitBoxPosition": {
+      "type": "string",
+      "title": "Commit box position",
+      "description": "Where the commit message box appears in the Git panel.",
+      "oneOf": [
+        {
+          "const": "top",
+          "title": "Above the list of changed files"
+        },
+        {
+          "const": "bottom",
+          "title": "Below the list of changed files"
+        }
+      ],
+      "default": "top"
+    },
     "commitAndPush": {
       "type": "boolean",
       "title": "Trigger push on commit",

--- a/src/__tests__/plugin.spec.ts
+++ b/src/__tests__/plugin.spec.ts
@@ -13,7 +13,7 @@ import {
   IMockedResponses,
   mockedRequestAPI
 } from './utils';
-import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
+import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 
 jest.mock('../git');
 jest.mock('@jupyterlab/application');
@@ -25,7 +25,7 @@ const plugin = plugins[0];
 describe('plugin', () => {
   const mockGit = git as jest.Mocked<typeof git>;
   let app: jest.Mocked<JupyterLab>;
-  let browserFactory: jest.Mocked<IFileBrowserFactory>;
+  let fileBrowser: jest.Mocked<IDefaultFileBrowser>;
   let mockResponses: IMockedResponses = {};
   let settingRegistry: jest.Mocked<ISettingRegistry>;
 
@@ -35,11 +35,9 @@ describe('plugin', () => {
     (app as any).serviceManager = {
       serverSettings: ServerConnection.makeSettings()
     };
-    browserFactory = {
-      defaultBrowser: {
-        model: { pathChanged: new Signal(null), restored: Promise.resolve() }
-      }
-    } as unknown as jest.Mocked<IFileBrowserFactory>;
+    fileBrowser = {
+      model: { pathChanged: new Signal(null), restored: Promise.resolve() }
+    } as unknown as jest.Mocked<IDefaultFileBrowser>;
     settingRegistry = new SettingRegistry({
       connector: null as any
     }) as any;
@@ -73,11 +71,12 @@ describe('plugin', () => {
       // When
       const extension = await plugin.activate(
         app,
-        null,
-        browserFactory,
-        { tracker: { currentWidget: null } },
-        null,
-        settingRegistry
+        null, // restorer
+        null, // editorServices
+        fileBrowser,
+        settingRegistry,
+        null, // docmanager
+        null // toolbarRegistry
       );
 
       // Then
@@ -108,11 +107,12 @@ describe('plugin', () => {
       // When
       const extension = await plugin.activate(
         app,
-        null,
-        browserFactory,
-        { tracker: { currentWidget: null } },
-        null,
-        settingRegistry
+        null, // restorer
+        null, // editorServices
+        fileBrowser,
+        settingRegistry,
+        null, // docmanager
+        null // toolbarRegistry
       );
 
       // Then
@@ -142,11 +142,12 @@ describe('plugin', () => {
       // When
       const extension = await plugin.activate(
         app,
-        null,
-        browserFactory,
-        { tracker: { currentWidget: null } },
-        null,
-        settingRegistry
+        null, // restorer
+        null, // editorServices
+        fileBrowser,
+        settingRegistry,
+        null, // docmanager
+        null // toolbarRegistry
       );
 
       // Then
@@ -173,11 +174,12 @@ describe('plugin', () => {
       // When
       const extension = await plugin.activate(
         app,
-        null,
-        browserFactory,
-        { tracker: { currentWidget: null } },
-        null,
-        settingRegistry
+        null, // restorer
+        null, // editorServices
+        fileBrowser,
+        settingRegistry,
+        null, // docmanager
+        null // toolbarRegistry
       );
 
       // Then

--- a/src/__tests__/test-components/CommitBox.spec.tsx
+++ b/src/__tests__/test-components/CommitBox.spec.tsx
@@ -101,6 +101,41 @@ describe('CommitBox', () => {
       );
     });
 
+    it('should display a dedicated message when the first line of the message is empty', () => {
+      const props = {
+        ...defaultProps,
+        message: '\nLonger description of the fix',
+        hasFiles: true
+      };
+      render(<CommitBox {...props} />);
+
+      expect(
+        screen.getByText(
+          'The first line is used as the commit summary and cannot be empty.'
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'The first line is used as the commit summary; the following lines as the description.'
+        )
+      ).toBeNull();
+    });
+
+    it('should explain in the commit button title that the first line is empty', () => {
+      const props = {
+        ...defaultProps,
+        message: '\nLonger description of the fix',
+        hasFiles: true
+      };
+      render(<CommitBox {...props} />);
+
+      expect(screen.getAllByRole('button')[0]).toHaveAttribute(
+        'title',
+        'Disabled: The first line of the commit message is empty'
+      );
+      expect(screen.getAllByRole('button')[0]).toHaveAttribute('disabled');
+    });
+
     it('should display a button to commit changes', () => {
       const props = defaultProps;
       render(<CommitBox {...props} />);

--- a/src/__tests__/test-components/CommitBox.spec.tsx
+++ b/src/__tests__/test-components/CommitBox.spec.tsx
@@ -69,6 +69,38 @@ describe('CommitBox', () => {
       );
     });
 
+    it('should not display the summary hint for a single-line message', () => {
+      const props = {
+        ...defaultProps,
+        message: 'Fix a bug'
+      };
+      render(<CommitBox {...props} />);
+
+      expect(
+        screen.queryByText(
+          'The first line is used as the commit summary; the following lines as the description.'
+        )
+      ).toBeNull();
+    });
+
+    it('should display the summary hint when the message spans multiple lines', () => {
+      const props = {
+        ...defaultProps,
+        message: 'Fix a bug\n\nLonger description of the fix'
+      };
+      render(<CommitBox {...props} />);
+
+      expect(
+        screen.getByText(
+          'The first line is used as the commit summary; the following lines as the description.'
+        )
+      ).toBeInTheDocument();
+      expect(screen.getAllByRole('textbox')[0]).toHaveAttribute(
+        'aria-describedby',
+        'jp-git-commit-message-hint'
+      );
+    });
+
     it('should display a button to commit changes', () => {
       const props = defaultProps;
       render(<CommitBox {...props} />);

--- a/src/__tests__/test-components/CommitBox.spec.tsx
+++ b/src/__tests__/test-components/CommitBox.spec.tsx
@@ -21,11 +21,9 @@ describe('CommitBox', () => {
 
   const defaultProps: ICommitBoxProps = {
     onCommit: async () => {},
-    setSummary: () => {},
-    setDescription: () => {},
+    setMessage: () => {},
     setAmend: () => {},
-    summary: '',
-    description: '',
+    message: '',
     amend: false,
     hasFiles: false,
     commands: defaultCommands,
@@ -41,17 +39,17 @@ describe('CommitBox', () => {
   });
 
   describe('#render()', () => {
-    it('should display placeholder text for the commit message summary', () => {
+    it('should display placeholder text for the commit message', () => {
       const props = defaultProps;
       render(<CommitBox {...props} />);
 
       expect(screen.getAllByRole('textbox')[0]).toHaveAttribute(
         'placeholder',
-        'Summary (Ctrl+Enter to commit)'
+        'Commit message (Ctrl+Enter to commit)'
       );
     });
 
-    it('should adjust placeholder text for the commit message summary when keybinding changes', () => {
+    it('should adjust placeholder text for the commit message when keybinding changes', () => {
       const adjustedCommands = new CommandRegistry();
       adjustedCommands.addKeyBinding({
         keys: ['Shift Enter'],
@@ -67,7 +65,7 @@ describe('CommitBox', () => {
 
       expect(screen.getAllByRole('textbox')[0]).toHaveAttribute(
         'placeholder',
-        'Summary (Shift+Enter to commit)'
+        'Commit message (Shift+Enter to commit)'
       );
     });
 
@@ -102,10 +100,10 @@ describe('CommitBox', () => {
       expect(screen.getAllByRole('button')[0]).toHaveAttribute('disabled');
     });
 
-    it('should not apply a class to disable the commit button when files have changes to commit and the user has entered a commit message summary', () => {
+    it('should not apply a class to disable the commit button when files have changes to commit and the user has entered a commit message', () => {
       const props = {
         ...defaultProps,
-        summary: 'beep boop',
+        message: 'beep boop',
         hasFiles: true
       };
 
@@ -117,7 +115,7 @@ describe('CommitBox', () => {
     it('should apply a class to disable the commit input fields in amend mode', () => {
       const props = {
         ...defaultProps,
-        summary: 'beep boop',
+        message: 'beep boop',
         amend: true
       };
 

--- a/src/__tests__/test-components/GitPanel.spec.tsx
+++ b/src/__tests__/test-components/GitPanel.spec.tsx
@@ -95,14 +95,9 @@ describe('GitPanel', () => {
       expect(panel).toBeInstanceOf(GitPanel);
     });
 
-    it('should set the default commit message summary to an empty string', () => {
+    it('should set the default commit message to an empty string', () => {
       const panel = new GitPanel(props);
-      expect(panel.state.commitSummary).toEqual('');
-    });
-
-    it('should set the default commit message description to an empty string', () => {
-      const panel = new GitPanel(props);
-      expect(panel.state.commitDescription).toEqual('');
+      expect(panel.state.commitMessage).toEqual('');
     });
   });
 
@@ -191,10 +186,9 @@ describe('GitPanel', () => {
 
       props.model.checkNotebooksForOutputs = jest.fn().mockResolvedValue([]);
 
-      await userEvent.type(screen.getAllByRole('textbox')[0], commitSummary);
       await userEvent.type(
-        screen.getAllByRole('textbox')[1],
-        commitDescription
+        screen.getAllByRole('textbox')[0],
+        commitSummary + '\n' + commitDescription
       );
 
       await userEvent.click(screen.getByRole('button', { name: 'Commit' }));
@@ -215,7 +209,30 @@ describe('GitPanel', () => {
 
       // Only erase commit message upon success
       expect(screen.getAllByRole('textbox')[0]).toHaveValue('');
-      expect(screen.getAllByRole('textbox')[1]).toHaveValue('');
+    });
+
+    it('should not add another blank line when the message already has one', async () => {
+      configSpy.mockResolvedValue({ options: commitUser });
+
+      props.model.checkNotebooksForOutputs = jest.fn().mockResolvedValue([]);
+
+      await userEvent.type(
+        screen.getAllByRole('textbox')[0],
+        commitSummary + '\n\n' + commitDescription
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Commit' }));
+
+      await waitFor(() => {
+        expect(configSpy).toHaveBeenCalledTimes(1);
+      });
+
+      expect(commitSpy).toHaveBeenCalledTimes(1);
+      expect(commitSpy).toHaveBeenCalledWith(
+        commitSummary + '\n\n' + commitDescription + '\n',
+        false,
+        null
+      );
     });
 
     it('should not commit without a commit message', async () => {
@@ -332,10 +349,9 @@ describe('GitPanel', () => {
         value: null
       });
 
-      await userEvent.type(screen.getAllByRole('textbox')[0], commitSummary);
       await userEvent.type(
-        screen.getAllByRole('textbox')[1],
-        commitDescription
+        screen.getAllByRole('textbox')[0],
+        commitSummary + '\n' + commitDescription
       );
       await userEvent.click(screen.getByRole('button', { name: 'Commit' }));
 
@@ -344,8 +360,9 @@ describe('GitPanel', () => {
       expect(commitSpy).not.toHaveBeenCalled();
 
       // Should not erase commit message
-      expect(screen.getAllByRole('textbox')[0]).toHaveValue(commitSummary);
-      expect(screen.getAllByRole('textbox')[1]).toHaveValue(commitDescription);
+      expect(screen.getAllByRole('textbox')[0]).toHaveValue(
+        commitSummary + '\n' + commitDescription
+      );
     });
 
     it('should not commit if no user identity is set and the user rejects the dialog', async () => {
@@ -359,10 +376,9 @@ describe('GitPanel', () => {
         value: null
       });
 
-      await userEvent.type(screen.getAllByRole('textbox')[0], commitSummary);
       await userEvent.type(
-        screen.getAllByRole('textbox')[1],
-        commitDescription
+        screen.getAllByRole('textbox')[0],
+        commitSummary + '\n' + commitDescription
       );
       await userEvent.click(screen.getByRole('button', { name: 'Commit' }));
 
@@ -371,8 +387,9 @@ describe('GitPanel', () => {
       expect(commitSpy).not.toHaveBeenCalled();
 
       // Should not erase commit message
-      expect(screen.getAllByRole('textbox')[0]).toHaveValue(commitSummary);
-      expect(screen.getAllByRole('textbox')[1]).toHaveValue(commitDescription);
+      expect(screen.getAllByRole('textbox')[0]).toHaveValue(
+        commitSummary + '\n' + commitDescription
+      );
     });
   });
 

--- a/src/__tests__/test-components/Toolbar.spec.tsx
+++ b/src/__tests__/test-components/Toolbar.spec.tsx
@@ -114,7 +114,7 @@ async function createModel(options: IModelOptions = {}): Promise<GitExtension> {
   if (options.repository !== null) {
     model.pathRepository = options.repository ?? DEFAULT_REPOSITORY_PATH;
     await model.ready;
-    // Manually fetch branch/submodule/remote data; model.ready does not await these.
+    // `model.ready` does not await branch/submodule/remote data.
     await model.refreshBranch();
     await model.listSubmodules();
     await model.refreshRemotes();
@@ -340,7 +340,6 @@ describe('Toolbar items', () => {
       model = await createModel({ repository: null });
       render(<RemoteActions />);
 
-      // No item is rendered as long as no repository is detected
       expect(screen.queryAllByRole('button')).toHaveLength(0);
 
       model.pathRepository = DEFAULT_REPOSITORY_PATH;

--- a/src/__tests__/test-components/Toolbar.spec.tsx
+++ b/src/__tests__/test-components/Toolbar.spec.tsx
@@ -1,14 +1,24 @@
 import { nullTranslator } from '@jupyterlab/translation';
+import { Signal } from '@lumino/signaling';
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'jest';
 import * as React from 'react';
-import { IToolbarProps, Toolbar } from '../../components/Toolbar';
+import {
+  BranchItem,
+  IRemoteActionItemProps,
+  IToolbarItemProps,
+  PullItem,
+  PushItem,
+  RefreshItem,
+  RepositoryItem
+} from '../../components/Toolbar';
 import * as git from '../../git';
 import { GitExtension } from '../../model';
 import { badgeClass } from '../../style/Toolbar';
 import { CommandIDs, Git } from '../../tokens';
+import type { GitWidget } from '../../widgets/GitWidget';
 import {
   DEFAULT_REPOSITORY_PATH,
   defaultMockedResponses,
@@ -112,11 +122,36 @@ async function createModel(options: IModelOptions = {}): Promise<GitExtension> {
   return model;
 }
 
-describe('Toolbar', () => {
+interface IPanelMock {
+  panel: GitWidget;
+  toggleSubmoduleMenu: jest.Mock;
+}
+
+function createPanelMock(): IPanelMock {
+  const toggleSubmoduleMenu = jest.fn();
+  const panel: any = {
+    submoduleMenuShown: false,
+    toggleSubmoduleMenu
+  };
+  panel.submoduleMenuShownChanged = new Signal<unknown, boolean>(panel);
+  return { panel: panel as GitWidget, toggleSubmoduleMenu };
+}
+
+describe('Toolbar items', () => {
   let model: GitExtension;
   const trans = nullTranslator.load('jupyterlab_git');
 
-  function createProps(props?: Partial<IToolbarProps>): IToolbarProps {
+  function createProps(props?: Partial<IToolbarItemProps>): IToolbarItemProps {
+    return {
+      model: model,
+      trans: trans,
+      ...props
+    };
+  }
+
+  function createActionProps(
+    props?: Partial<IRemoteActionItemProps>
+  ): IRemoteActionItemProps {
     return {
       model: model,
       commands: {
@@ -127,18 +162,28 @@ describe('Toolbar', () => {
     };
   }
 
+  // The pull and push items share the remote state; render both to assert on it.
+  function RemoteActions(): JSX.Element {
+    return (
+      <>
+        <PullItem {...createActionProps()} />
+        <PushItem {...createActionProps()} />
+      </>
+    );
+  }
+
   beforeEach(async () => {
     jest.restoreAllMocks();
     model = await createModel();
   });
 
-  describe('render', () => {
+  describe('PullItem', () => {
     it('should display a button to pull the latest changes', async () => {
-      render(<Toolbar {...createProps()} />);
+      render(<PullItem {...createActionProps()} />);
 
       await waitFor(() => {
         expect(
-          screen.getAllByRole('button', { name: 'Pull latest changes' })
+          screen.getByRole('button', { name: 'Pull latest changes' })
         ).toBeDefined();
       });
 
@@ -151,7 +196,7 @@ describe('Toolbar', () => {
 
     it('should display a badge on pull icon if behind', async () => {
       model = await createModel({ status: { behind: 1 } });
-      render(<Toolbar {...createProps()} />);
+      render(<PullItem {...createActionProps()} />);
 
       await waitFor(() => {
         expect(
@@ -162,76 +207,11 @@ describe('Toolbar', () => {
       });
     });
 
-    it('should display a button to push the latest changes', async () => {
-      render(<Toolbar {...createProps()} />);
-
-      await waitFor(() => {
-        expect(
-          screen.getAllByRole('button', { name: 'Push committed changes' })
-        ).toBeDefined();
-      });
-
-      expect(
-        screen
-          .getByRole('button', { name: 'Push committed changes' })
-          .parentElement?.querySelector(`.${badgeClass} > .MuiBadge-badge`)
-      ).toHaveClass('MuiBadge-invisible');
-    });
-
-    it('should display a badge on push icon if ahead', async () => {
-      model = await createModel({ status: { ahead: 1 } });
-      render(<Toolbar {...createProps()} />);
-
-      await waitFor(() => {
-        expect(
-          screen
-            .getByRole('button', { name: /^Push committed changes/ })
-            .parentElement?.querySelector(`.${badgeClass} > .MuiBadge-badge`)
-        ).not.toHaveClass('MuiBadge-invisible');
-      });
-    });
-
-    it('should display a button to refresh the current repository', () => {
-      render(<Toolbar {...createProps()} />);
-
-      expect(
-        screen.getAllByRole('button', {
-          name: 'Refresh the repository to detect local and remote changes'
-        })
-      ).toBeDefined();
-    });
-
-    it('should display a non-interactive repository label when there are no submodules', () => {
-      render(<Toolbar {...createProps()} />);
-
-      // DEFAULT_REPOSITORY_PATH basename is 'repo'.
-      expect(screen.getByText('repo')).toBeDefined();
-      expect(screen.queryByRole('button', { name: 'repo' })).toBeNull();
-    });
-
-    it('should display a repository menu button when submodules are present', async () => {
-      model = await createModel({
-        submodules: [{ name: 'sub' }]
-      });
-      render(<Toolbar {...createProps()} />);
-
-      expect(screen.getByRole('button', { name: 'repo' })).toBeDefined();
-    });
-
-    it('should display the current branch as a static label', () => {
-      render(<Toolbar {...createProps()} />);
-
-      expect(screen.getByText('main')).toBeDefined();
-      expect(screen.queryByRole('button', { name: /branches/i })).toBeNull();
-    });
-  });
-
-  describe('push/pull changes with remote', () => {
     it('should pull changes when the button to pull the latest changes is clicked', async () => {
       const mockedExecute = jest.fn();
       render(
-        <Toolbar
-          {...createProps({
+        <PullItem
+          {...createActionProps({
             commands: {
               execute: mockedExecute
             } as any
@@ -253,11 +233,64 @@ describe('Toolbar', () => {
       expect(mockedExecute).toHaveBeenCalledWith(CommandIDs.gitPull);
     });
 
+    it('should not pull changes when the pull button is clicked but there is no remote branch', async () => {
+      model = await createModel({ remotes: [] });
+      const mockedExecute = jest.fn();
+      render(
+        <PullItem
+          {...createActionProps({
+            commands: {
+              execute: mockedExecute
+            } as any
+          })}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: 'No remote repository defined'
+        })
+      );
+
+      expect(mockedExecute).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('PushItem', () => {
+    it('should display a button to push the latest changes', async () => {
+      render(<PushItem {...createActionProps()} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Push committed changes' })
+        ).toBeDefined();
+      });
+
+      expect(
+        screen
+          .getByRole('button', { name: 'Push committed changes' })
+          .parentElement?.querySelector(`.${badgeClass} > .MuiBadge-badge`)
+      ).toHaveClass('MuiBadge-invisible');
+    });
+
+    it('should display a badge on push icon if ahead', async () => {
+      model = await createModel({ status: { ahead: 1 } });
+      render(<PushItem {...createActionProps()} />);
+
+      await waitFor(() => {
+        expect(
+          screen
+            .getByRole('button', { name: /^Push committed changes/ })
+            .parentElement?.querySelector(`.${badgeClass} > .MuiBadge-badge`)
+        ).not.toHaveClass('MuiBadge-invisible');
+      });
+    });
+
     it('should push changes when the button to push the latest changes is clicked', async () => {
       const mockedExecute = jest.fn();
       render(
-        <Toolbar
-          {...createProps({
+        <PushItem
+          {...createActionProps({
             commands: {
               execute: mockedExecute
             } as any
@@ -278,50 +311,26 @@ describe('Toolbar', () => {
       expect(mockedExecute).toHaveBeenCalledTimes(1);
       expect(mockedExecute).toHaveBeenCalledWith(CommandIDs.gitPush);
     });
-  });
-
-  describe('push/pull changes without remote', () => {
-    beforeEach(async () => {
-      model = await createModel({ remotes: [] });
-    });
-
-    it('should not pull changes when the pull button is clicked but there is no remote branch', async () => {
-      const mockedExecute = jest.fn();
-      render(
-        <Toolbar
-          {...createProps({
-            commands: {
-              execute: mockedExecute
-            } as any
-          })}
-        />
-      );
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'No remote repository defined'
-        })[0]
-      );
-
-      expect(mockedExecute).toHaveBeenCalledTimes(0);
-    });
 
     it('should not push changes when the push button is clicked but there is no remote branch', async () => {
+      model = await createModel({ remotes: [] });
       const mockedExecute = jest.fn();
       render(
-        <Toolbar
-          {...createProps({
+        <PushItem
+          {...createActionProps({
             commands: {
               execute: mockedExecute
             } as any
           })}
         />
       );
+
       await userEvent.click(
-        screen.getAllByRole('button', {
+        screen.getByRole('button', {
           name: 'No remote repository defined'
-        })[1]
+        })
       );
+
       expect(mockedExecute).toHaveBeenCalledTimes(0);
     });
   });
@@ -329,9 +338,9 @@ describe('Toolbar', () => {
   describe('repository discovery', () => {
     it('should enable the pull and push buttons when the repository is discovered after mount', async () => {
       model = await createModel({ repository: null });
-      render(<Toolbar {...createProps()} />);
+      render(<RemoteActions />);
 
-      // The toolbar is empty as long as no repository is detected
+      // No item is rendered as long as no repository is detected
       expect(screen.queryAllByRole('button')).toHaveLength(0);
 
       model.pathRepository = DEFAULT_REPOSITORY_PATH;
@@ -352,7 +361,7 @@ describe('Toolbar', () => {
     it('should enable the pull and push buttons when a remote is added', async () => {
       const remotes: Git.IGitRemote[] = [];
       model = await createModel({ remotes });
-      render(<Toolbar {...createProps()} />);
+      render(<RemoteActions />);
 
       expect(
         await screen.findAllByRole('button', {
@@ -376,7 +385,7 @@ describe('Toolbar', () => {
     it('should disable the pull and push buttons when the last remote is removed', async () => {
       const remotes: Git.IGitRemote[] = [...REMOTES];
       model = await createModel({ remotes });
-      render(<Toolbar {...createProps()} />);
+      render(<RemoteActions />);
 
       expect(
         await screen.findByRole('button', { name: 'Pull latest changes' })
@@ -395,10 +404,20 @@ describe('Toolbar', () => {
     });
   });
 
-  describe('refresh repository', () => {
+  describe('RefreshItem', () => {
+    it('should display a button to refresh the current repository', () => {
+      render(<RefreshItem {...createProps()} />);
+
+      expect(
+        screen.getByRole('button', {
+          name: 'Refresh the repository to detect local and remote changes'
+        })
+      ).toBeDefined();
+    });
+
     it('should refresh the repository when the button to refresh the repository is clicked', async () => {
       const spy = jest.spyOn(model, 'refresh');
-      render(<Toolbar {...createProps()} />);
+      render(<RefreshItem {...createProps()} />);
       await userEvent.click(
         screen.getByRole('button', {
           name: 'Refresh the repository to detect local and remote changes'
@@ -408,6 +427,48 @@ describe('Toolbar', () => {
 
       spy.mockReset();
       spy.mockRestore();
+    });
+  });
+
+  describe('RepositoryItem', () => {
+    it('should display a non-interactive repository label when there are no submodules', () => {
+      const { panel } = createPanelMock();
+      render(<RepositoryItem {...createProps()} panel={panel} />);
+
+      // DEFAULT_REPOSITORY_PATH basename is 'repo'.
+      expect(screen.getByText('repo')).toBeDefined();
+      expect(screen.queryByRole('button', { name: 'repo' })).toBeNull();
+    });
+
+    it('should display a repository menu button when submodules are present', async () => {
+      model = await createModel({
+        submodules: [{ name: 'sub' }]
+      });
+      const { panel } = createPanelMock();
+      render(<RepositoryItem {...createProps()} panel={panel} />);
+
+      expect(screen.getByRole('button', { name: 'repo' })).toBeDefined();
+    });
+
+    it('should toggle the submodule menu when the repository menu button is clicked', async () => {
+      model = await createModel({
+        submodules: [{ name: 'sub' }]
+      });
+      const { panel, toggleSubmoduleMenu } = createPanelMock();
+      render(<RepositoryItem {...createProps()} panel={panel} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'repo' }));
+
+      expect(toggleSubmoduleMenu).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('BranchItem', () => {
+    it('should display the current branch as a static label', () => {
+      render(<BranchItem {...createProps()} />);
+
+      expect(screen.getByText('main')).toBeDefined();
+      expect(screen.queryByRole('button', { name: /branches/i })).toBeNull();
     });
   });
 });

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -5,6 +5,7 @@ import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import Grow from '@mui/material/Grow';
+import Input from '@mui/material/Input';
 import MenuItem from '@mui/material/MenuItem';
 import MenuList from '@mui/material/MenuList';
 import Paper from '@mui/material/Paper';
@@ -13,8 +14,10 @@ import * as React from 'react';
 import { classes } from 'typestyle';
 import { listItemIconClass } from '../style/BranchMenu';
 import {
+  activeStyle,
   commitButtonClass,
   commitFormClass,
+  commitMessageClass,
   commitPaperClass,
   commitRoot,
   commitVariantSelector,
@@ -27,7 +30,6 @@ import {
   listItemDescClass
 } from '../style/NewBranchDialog';
 import { CommandIDs } from '../tokens';
-import { CommitMessage } from './CommitMessage';
 
 /**
  * Commit action
@@ -68,14 +70,10 @@ export interface ICommitBoxProps {
   trans: TranslationBundle;
 
   /**
-   * Commit message summary.
+   * Commit message. The first line is used as the commit summary and the
+   * remaining lines as the commit description.
    */
-  summary: string;
-
-  /**
-   * Commit message description.
-   */
-  description: string;
+  message: string;
 
   /**
    * Whether commit is amending the previous one or not
@@ -88,18 +86,11 @@ export interface ICommitBoxProps {
   warning?: JSX.Element | null;
 
   /**
-   * Updates the commit message summary.
+   * Updates the commit message.
    *
-   * @param summary - commit message summary
+   * @param message - commit message
    */
-  setSummary: (summary: string) => void;
-
-  /**
-   * Updates the commit message description.
-   *
-   * @param description - commit message description
-   */
-  setDescription: (description: string) => void;
+  setMessage: (message: string) => void;
 
   /**
    * Updates the amend checkbox state
@@ -179,15 +170,15 @@ export class CommitBox extends React.Component<
     const disabled = !this._canCommit();
     const title = !this.props.hasFiles
       ? this.props.trans.__('Disabled: No files are staged for commit')
-      : !this.props.summary && !this.props.amend
-      ? this.props.trans.__('Disabled: No commit message summary')
+      : !this._summary && !this.props.amend
+      ? this.props.trans.__('Disabled: No commit message')
       : this.props.label;
 
     const shortcutHint = CommandRegistry.formatKeystroke(
       this._getSubmitKeystroke()
     );
-    const summaryPlaceholder = this.props.trans.__(
-      'Summary (%1 to commit)',
+    const messagePlaceholder = this.props.trans.__(
+      'Commit message (%1 to commit)',
       shortcutHint
     );
 
@@ -195,18 +186,24 @@ export class CommitBox extends React.Component<
       <div className={classes(commitFormClass, 'jp-git-CommitBox')}>
         {this.props.warning ?? null}
         {!this.props.amend && (
-          <CommitMessage
-            error={
-              this.props.hasFiles &&
-              !this.props.amend &&
-              this.props.summary.length === 0
-            }
-            trans={this.props.trans}
-            summary={this.props.summary}
-            summaryPlaceholder={summaryPlaceholder}
-            description={this.props.description}
-            setSummary={this.props.setSummary}
-            setDescription={this.props.setDescription}
+          <Input
+            classes={{
+              root: classes(commitRoot, commitMessageClass),
+              focused: activeStyle,
+              disabled: disabledStyle
+            }}
+            error={this.props.hasFiles && this._summary.length === 0}
+            multiline
+            minRows={1}
+            maxRows={10}
+            placeholder={messagePlaceholder}
+            title={this.props.trans.__(
+              'Enter a commit message. The first line is used as the commit summary; the following lines as the description.'
+            )}
+            value={this.props.message}
+            onChange={this._handleMessageChange}
+            disableUnderline={true}
+            fullWidth={true}
           />
         )}
         <ButtonGroup ref={this._anchorRef} fullWidth={true} size="small">
@@ -293,8 +290,26 @@ export class CommitBox extends React.Component<
     if (this.props.amend) {
       return this.props.hasFiles;
     }
-    return !!(this.props.hasFiles && this.props.summary);
+    return !!(this.props.hasFiles && this._summary);
   }
+
+  /**
+   * Commit message summary, i.e. the first line of the commit message.
+   */
+  private get _summary(): string {
+    return this.props.message.split('\n', 1)[0];
+  }
+
+  /**
+   * Callback invoked upon updating the commit message.
+   *
+   * @param event - event object
+   */
+  private _handleMessageChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    this.props.setMessage(event.target.value);
+  };
 
   /**
    * Get keystroke configured to act as a submit action.

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -19,6 +19,7 @@ import {
   commitDescriptionHintClass,
   commitFormBottomClass,
   commitFormClass,
+  commitHintErrorClass,
   commitMessageClass,
   commitPaperClass,
   commitPopperClass,
@@ -178,8 +179,13 @@ export class CommitBox extends React.Component<
   render(): React.ReactElement {
     const atBottom = this.props.position === 'bottom';
     const disabled = !this._canCommit();
+    const summaryEmpty = !this._summary && this.props.message.length > 0;
     const title = !this.props.hasFiles
       ? this.props.trans.__('Disabled: No files are staged for commit')
+      : summaryEmpty && !this.props.amend
+      ? this.props.trans.__(
+          'Disabled: The first line of the commit message is empty'
+        )
       : !this._summary && !this.props.amend
       ? this.props.trans.__('Disabled: No commit message')
       : this.props.label;
@@ -191,9 +197,13 @@ export class CommitBox extends React.Component<
       'Commit message (%1 to commit)',
       shortcutHint
     );
-    const summaryHint = this.props.trans.__(
-      'The first line is used as the commit summary; the following lines as the description.'
-    );
+    const summaryHint = summaryEmpty
+      ? this.props.trans.__(
+          'The first line is used as the commit summary and cannot be empty.'
+        )
+      : this.props.trans.__(
+          'The first line is used as the commit summary; the following lines as the description.'
+        );
     const showSummaryHint = this.props.message.includes('\n');
 
     return (
@@ -230,7 +240,11 @@ export class CommitBox extends React.Component<
             {showSummaryHint && (
               <p
                 id="jp-git-commit-message-hint"
-                className={commitDescriptionHintClass}
+                className={
+                  summaryEmpty
+                    ? commitHintErrorClass
+                    : commitDescriptionHintClass
+                }
               >
                 {summaryHint}
               </p>

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -17,6 +17,7 @@ import {
   activeStyle,
   commitButtonClass,
   commitDescriptionHintClass,
+  commitFormBottomClass,
   commitFormClass,
   commitMessageClass,
   commitPaperClass,
@@ -87,6 +88,11 @@ export interface ICommitBoxProps {
    * Warning element to display
    */
   warning?: JSX.Element | null;
+
+  /**
+   * Position of the box in the panel; defaults to 'top'
+   */
+  position?: 'top' | 'bottom';
 
   /**
    * Updates the commit message.
@@ -170,6 +176,7 @@ export class CommitBox extends React.Component<
    * @returns React element
    */
   render(): React.ReactElement {
+    const atBottom = this.props.position === 'bottom';
     const disabled = !this._canCommit();
     const title = !this.props.hasFiles
       ? this.props.trans.__('Disabled: No files are staged for commit')
@@ -190,7 +197,13 @@ export class CommitBox extends React.Component<
     const showSummaryHint = this.props.message.includes('\n');
 
     return (
-      <div className={classes(commitFormClass, 'jp-git-CommitBox')}>
+      <div
+        className={classes(
+          commitFormClass,
+          atBottom && commitFormBottomClass,
+          'jp-git-CommitBox'
+        )}
+      >
         {this.props.warning ?? null}
         {!this.props.amend && (
           <React.Fragment>
@@ -256,7 +269,7 @@ export class CommitBox extends React.Component<
           className={commitPopperClass}
           open={this.state.open}
           anchorEl={this._anchorRef.current}
-          placement="bottom-end"
+          placement={atBottom ? 'top-end' : 'bottom-end'}
           role={undefined}
           transition
           disablePortal

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -19,7 +19,9 @@ import {
   commitFormClass,
   commitMessageClass,
   commitPaperClass,
+  commitPopperClass,
   commitRoot,
+  commitVariantItemClass,
   commitVariantSelector,
   disabledStyle
 } from '../style/CommitBox';
@@ -235,8 +237,10 @@ export class CommitBox extends React.Component<
           </Button>
         </ButtonGroup>
         <Popper
+          className={commitPopperClass}
           open={this.state.open}
           anchorEl={this._anchorRef.current}
+          placement="bottom-end"
           role={undefined}
           transition
           disablePortal
@@ -249,7 +253,9 @@ export class CommitBox extends React.Component<
                     {this._options.map((option, index) => (
                       <MenuItem
                         key={option.title}
-                        classes={{ root: commitRoot }}
+                        classes={{
+                          root: classes(commitRoot, commitVariantItemClass)
+                        }}
                         selected={this.props.amend ? index === 1 : index === 0}
                         onClick={event =>
                           this._handleMenuItemClick(event, index)

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -306,7 +306,7 @@ export class CommitBox extends React.Component<
    * @param event - event object
    */
   private _handleMessageChange = (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ): void => {
     this.props.setMessage(event.target.value);
   };

--- a/src/components/CommitBox.tsx
+++ b/src/components/CommitBox.tsx
@@ -16,6 +16,7 @@ import { listItemIconClass } from '../style/BranchMenu';
 import {
   activeStyle,
   commitButtonClass,
+  commitDescriptionHintClass,
   commitFormClass,
   commitMessageClass,
   commitPaperClass,
@@ -183,30 +184,45 @@ export class CommitBox extends React.Component<
       'Commit message (%1 to commit)',
       shortcutHint
     );
+    const summaryHint = this.props.trans.__(
+      'The first line is used as the commit summary; the following lines as the description.'
+    );
+    const showSummaryHint = this.props.message.includes('\n');
 
     return (
       <div className={classes(commitFormClass, 'jp-git-CommitBox')}>
         {this.props.warning ?? null}
         {!this.props.amend && (
-          <Input
-            classes={{
-              root: classes(commitRoot, commitMessageClass),
-              focused: activeStyle,
-              disabled: disabledStyle
-            }}
-            error={this.props.hasFiles && this._summary.length === 0}
-            multiline
-            minRows={1}
-            maxRows={10}
-            placeholder={messagePlaceholder}
-            title={this.props.trans.__(
-              'Enter a commit message. The first line is used as the commit summary; the following lines as the description.'
+          <React.Fragment>
+            <Input
+              classes={{
+                root: classes(commitRoot, commitMessageClass),
+                focused: activeStyle,
+                disabled: disabledStyle
+              }}
+              error={this.props.hasFiles && this._summary.length === 0}
+              multiline
+              minRows={1}
+              maxRows={10}
+              placeholder={messagePlaceholder}
+              title={summaryHint}
+              aria-describedby={
+                showSummaryHint ? 'jp-git-commit-message-hint' : undefined
+              }
+              value={this.props.message}
+              onChange={this._handleMessageChange}
+              disableUnderline={true}
+              fullWidth={true}
+            />
+            {showSummaryHint && (
+              <p
+                id="jp-git-commit-message-hint"
+                className={commitDescriptionHintClass}
+              >
+                {summaryHint}
+              </p>
             )}
-            value={this.props.message}
-            onChange={this._handleMessageChange}
-            disableUnderline={true}
-            fullWidth={true}
-          />
+          </React.Fragment>
         )}
         <ButtonGroup ref={this._anchorRef} fullWidth={true} size="small">
           <Button

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -519,42 +519,48 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           'You have unsaved staged files. You probably want to save and stage all needed changes before committing.'
         );
 
+    const commitBoxPosition =
+      this.props.settings.composite['commitBoxPosition'] === 'bottom'
+        ? 'bottom'
+        : 'top';
+    const commitAction =
+      this.props.model.status.state !== Git.State.REBASING ? (
+        <CommitBox
+          commands={this.props.commands}
+          hasFiles={
+            inSimpleMode ? this._markedFiles.length > 0 : this._hasStagedFile()
+          }
+          trans={this.props.trans}
+          label={buttonLabel}
+          message={this.state.commitMessage}
+          amend={this.state.commitAmend}
+          position={commitBoxPosition}
+          setMessage={this._setCommitMessage}
+          setAmend={this._setCommitAmend}
+          onCommit={this.commitFiles}
+          warning={
+            this.state.hasDirtyFiles ? (
+              <WarningBox
+                headerIcon={<WarningRoundedIcon />}
+                title={warningTitle}
+                content={warningContent}
+              />
+            ) : null
+          }
+        />
+      ) : (
+        <RebaseAction
+          commands={this.props.commands}
+          hasConflict={this.state.files.some(
+            file => file.status === 'unmerged'
+          )}
+          trans={this.props.trans}
+        ></RebaseAction>
+      );
+
     return (
       <React.Fragment>
-        {this.props.model.status.state !== Git.State.REBASING ? (
-          <CommitBox
-            commands={this.props.commands}
-            hasFiles={
-              inSimpleMode
-                ? this._markedFiles.length > 0
-                : this._hasStagedFile()
-            }
-            trans={this.props.trans}
-            label={buttonLabel}
-            message={this.state.commitMessage}
-            amend={this.state.commitAmend}
-            setMessage={this._setCommitMessage}
-            setAmend={this._setCommitAmend}
-            onCommit={this.commitFiles}
-            warning={
-              this.state.hasDirtyFiles ? (
-                <WarningBox
-                  headerIcon={<WarningRoundedIcon />}
-                  title={warningTitle}
-                  content={warningContent}
-                />
-              ) : null
-            }
-          />
-        ) : (
-          <RebaseAction
-            commands={this.props.commands}
-            hasConflict={this.state.files.some(
-              file => file.status === 'unmerged'
-            )}
-            trans={this.props.trans}
-          ></RebaseAction>
-        )}
+        {commitBoxPosition === 'top' && commitAction}
         <FileList
           files={this._sortedFiles}
           model={this.props.model}
@@ -597,6 +603,7 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           collapsible={true}
           trans={this.props.trans}
         />
+        {commitBoxPosition === 'bottom' && commitAction}
       </React.Fragment>
     );
   }

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -123,14 +123,10 @@ export interface IGitPanelState {
   pastCommits: Git.ISingleCommitInfo[];
 
   /**
-   * Commit message summary.
+   * Commit message. The first line is used as the commit summary and the
+   * remaining lines as the commit description.
    */
-  commitSummary: string;
-
-  /**
-   * Commit message description.
-   */
-  commitDescription: string;
+  commitMessage: string;
 
   /**
    * Amend option toggle
@@ -195,8 +191,7 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       nCommitsBehind: 0,
       pastCommits: [],
       repository: pathRepository,
-      commitSummary: '',
-      commitDescription: '',
+      commitMessage: '',
       commitAmend: false,
       hasDirtyFiles: hasDirtyStagedFiles,
       referenceCommit: null,
@@ -392,11 +387,17 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
    * @returns a promise which commits changes
    */
   commitFiles = async (): Promise<void> => {
-    let msg = this.state.commitSummary;
+    const [summary, ...rest] = this.state.commitMessage.split('\n');
+    // Git only treats the text up to the first blank line as the commit
+    // summary, so separate the description with a blank line if it is not
+    // already there.
+    const description = rest.join('\n').replace(/^\n+/, '');
+
+    let msg = summary;
 
     // Only include description if not empty
-    if (this.state.commitDescription) {
-      msg = msg + '\n\n' + this.state.commitDescription + '\n';
+    if (description) {
+      msg = msg + '\n\n' + description + '\n';
     }
 
     if (!msg && !this.state.commitAmend) {
@@ -416,8 +417,7 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
 
       // Only erase commit message upon success
       this.setState({
-        commitSummary: '',
-        commitDescription: ''
+        commitMessage: ''
       });
     } catch (error) {
       console.error(error);
@@ -521,6 +521,40 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
 
     return (
       <React.Fragment>
+        {this.props.model.status.state !== Git.State.REBASING ? (
+          <CommitBox
+            commands={this.props.commands}
+            hasFiles={
+              inSimpleMode
+                ? this._markedFiles.length > 0
+                : this._hasStagedFile()
+            }
+            trans={this.props.trans}
+            label={buttonLabel}
+            message={this.state.commitMessage}
+            amend={this.state.commitAmend}
+            setMessage={this._setCommitMessage}
+            setAmend={this._setCommitAmend}
+            onCommit={this.commitFiles}
+            warning={
+              this.state.hasDirtyFiles ? (
+                <WarningBox
+                  headerIcon={<WarningRoundedIcon />}
+                  title={warningTitle}
+                  content={warningContent}
+                />
+              ) : null
+            }
+          />
+        ) : (
+          <RebaseAction
+            commands={this.props.commands}
+            hasConflict={this.state.files.some(
+              file => file.status === 'unmerged'
+            )}
+            trans={this.props.trans}
+          ></RebaseAction>
+        )}
         <FileList
           files={this._sortedFiles}
           model={this.props.model}
@@ -563,43 +597,6 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           collapsible={true}
           trans={this.props.trans}
         />
-
-        {this.props.model.status.state !== Git.State.REBASING ? (
-          <CommitBox
-            commands={this.props.commands}
-            hasFiles={
-              inSimpleMode
-                ? this._markedFiles.length > 0
-                : this._hasStagedFile()
-            }
-            trans={this.props.trans}
-            label={buttonLabel}
-            summary={this.state.commitSummary}
-            description={this.state.commitDescription}
-            amend={this.state.commitAmend}
-            setSummary={this._setCommitSummary}
-            setDescription={this._setCommitDescription}
-            setAmend={this._setCommitAmend}
-            onCommit={this.commitFiles}
-            warning={
-              this.state.hasDirtyFiles ? (
-                <WarningBox
-                  headerIcon={<WarningRoundedIcon />}
-                  title={warningTitle}
-                  content={warningContent}
-                />
-              ) : null
-            }
-          />
-        ) : (
-          <RebaseAction
-            commands={this.props.commands}
-            hasConflict={this.state.files.some(
-              file => file.status === 'unmerged'
-            )}
-            trans={this.props.trans}
-          ></RebaseAction>
-        )}
       </React.Fragment>
     );
   }
@@ -723,24 +720,13 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
   }
 
   /**
-   * Updates the commit message description.
+   * Updates the commit message.
    *
-   * @param description - commit message description
+   * @param message - commit message
    */
-  private _setCommitDescription = (description: string): void => {
+  private _setCommitMessage = (message: string): void => {
     this.setState({
-      commitDescription: description
-    });
-  };
-
-  /**
-   * Updates the commit message summary.
-   *
-   * @param summary - commit message summary
-   */
-  private _setCommitSummary = (summary: string): void => {
-    this.setState({
-      commitSummary: summary
+      commitMessage: message
     });
   };
 

--- a/src/components/RebaseAction.tsx
+++ b/src/components/RebaseAction.tsx
@@ -14,7 +14,9 @@ import { classes } from 'typestyle';
 import {
   commitButtonClass,
   commitPaperClass,
+  commitPopperClass,
   commitRoot,
+  commitVariantItemClass,
   commitVariantSelector,
   disabledStyle
 } from '../style/CommitBox';
@@ -111,7 +113,14 @@ export function RebaseAction(props: IRebaseActionProps): JSX.Element {
           <verticalMoreIcon.react tag="span"></verticalMoreIcon.react>
         </Button>
       </ButtonGroup>
-      <Popper open={open} anchorEl={anchor.current} transition disablePortal>
+      <Popper
+        className={commitPopperClass}
+        open={open}
+        anchorEl={anchor.current}
+        placement="bottom-end"
+        transition
+        disablePortal
+      >
         {({ TransitionProps }) => (
           <Grow {...TransitionProps}>
             <Paper classes={{ root: classes(commitRoot, commitPaperClass) }}>
@@ -119,7 +128,9 @@ export function RebaseAction(props: IRebaseActionProps): JSX.Element {
                 <MenuList id="rebase-split-button-menu">
                   <MenuItem
                     key={'skip'}
-                    classes={{ root: commitRoot }}
+                    classes={{
+                      root: classes(commitRoot, commitVariantItemClass)
+                    }}
                     onClick={onSkip}
                     title={props.trans.__('Skip the current commit.')}
                   >
@@ -127,7 +138,9 @@ export function RebaseAction(props: IRebaseActionProps): JSX.Element {
                   </MenuItem>
                   <MenuItem
                     key={'abort'}
-                    classes={{ root: commitRoot }}
+                    classes={{
+                      root: classes(commitRoot, commitVariantItemClass)
+                    }}
                     onClick={onAbort}
                     title={props.trans.__('Abort the rebase.')}
                   >

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -14,7 +14,6 @@ import {
   badgeClass,
   branchInfoClass,
   branchNameClass,
-  repoBranchColumnClass,
   repoButtonClass,
   repoButtonLabelClass,
   repoLabelClass,
@@ -117,10 +116,8 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
     const hasSubmodules = this.props.model.submodules.length > 0;
     return (
       <div className={toolbarNavClass}>
-        <div className={repoBranchColumnClass}>
-          {hasSubmodules ? this._renderRepoButton() : this._renderRepoLabel()}
-          {this._renderBranchInfo()}
-        </div>
+        {hasSubmodules ? this._renderRepoButton() : this._renderRepoLabel()}
+        {this._renderBranchInfo()}
         <span className={spacer} />
         {this._renderRemoteActions()}
       </div>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,4 +1,9 @@
-import { Notification, UseSignal } from '@jupyterlab/apputils';
+import {
+  IToolbarWidgetRegistry,
+  Notification,
+  ReactWidget,
+  UseSignal
+} from '@jupyterlab/apputils';
 import { PageConfig, PathExt } from '@jupyterlab/coreutils';
 import { TranslationBundle } from '@jupyterlab/translation';
 import {
@@ -17,26 +22,22 @@ import {
   repoButtonClass,
   repoButtonLabelClass,
   repoLabelClass,
-  spacer,
-  toolbarButtonClass,
-  toolbarClass,
-  toolbarMenuWrapperClass,
-  toolbarNavClass
+  toolbarButtonClass
 } from '../style/Toolbar';
 import { branchIcon, desktopIcon, pullIcon, pushIcon } from '../style/icons';
 import { CommandIDs, Git, IGitExtension } from '../tokens';
+import type { GitWidget } from '../widgets/GitWidget';
 import { ActionButton } from './ActionButton';
-import { SubmoduleMenu } from './SubmoduleMenu';
 
 /**
- * Interface describing  properties.
+ * Toolbar factory name of the Git panel toolbar.
  */
-export interface IToolbarProps {
-  /**
-   * Jupyter App commands registry
-   */
-  commands: CommandRegistry;
+export const GIT_PANEL_TOOLBAR_FACTORY = 'Git';
 
+/**
+ * Interface describing toolbar item properties.
+ */
+export interface IToolbarItemProps {
   /**
    * Git extension data model.
    */
@@ -49,143 +50,120 @@ export interface IToolbarProps {
 }
 
 /**
- * Interface describing component state.
+ * Interface describing repository toolbar item properties.
  */
-export interface IToolbarState {
+export interface IRepositoryItemProps extends IToolbarItemProps {
   /**
-   * Boolean indicating whether a refresh is currently in progress.
+   * The Git panel hosting the submodule menu.
    */
-  refreshInProgress: boolean;
-
-  /**
-   * Boolean indicating whether the repository menu is shown.
-   */
-  repoMenu: boolean;
+  panel: GitWidget;
 }
 
-export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
-  constructor(props: IToolbarProps) {
-    super(props);
-    this.state = {
-      refreshInProgress: false,
-      repoMenu: false
-    };
-  }
+/**
+ * Interface describing remote action toolbar item properties.
+ */
+export interface IRemoteActionItemProps extends IToolbarItemProps {
+  /**
+   * Jupyter App commands registry
+   */
+  commands: CommandRegistry;
+}
 
-  render(): React.ReactElement {
-    return (
-      <UseSignal signal={this.props.model.repositoryChanged}>
-        {() => {
-          if (this.props.model.pathRepository === null) {
-            return <div className={toolbarClass} />;
-          }
-          return (
-            <UseSignal signal={this.props.model.headChanged}>
-              {() => (
-                <UseSignal signal={this.props.model.branchesChanged}>
-                  {() => (
-                    <UseSignal signal={this.props.model.statusChanged}>
-                      {() => (
-                        <UseSignal signal={this.props.model.submodulesChanged}>
-                          {() => (
-                            <UseSignal signal={this.props.model.remotesChanged}>
-                              {() => (
-                                <div className={toolbarClass}>
-                                  {this._renderToolbarRow()}
-                                  {this.state.repoMenu
-                                    ? this._renderSubmodules()
-                                    : null}
-                                </div>
-                              )}
-                            </UseSignal>
-                          )}
-                        </UseSignal>
-                      )}
-                    </UseSignal>
-                  )}
+/**
+ * Toolbar item displaying the current repository, as a plain label or as a
+ * button toggling the submodule menu when the repository has submodules.
+ */
+export function RepositoryItem(props: IRepositoryItemProps): JSX.Element {
+  const { model, panel, trans } = props;
+
+  const getRepositoryName = (): string =>
+    PathExt.basename(
+      model.pathRepository || PageConfig.getOption('serverRoot')
+    ) || 'Jupyter Server Root';
+
+  const getFullRepositoryPath = (): string =>
+    PageConfig.getOption('serverRoot') + '/' + (model.pathRepository ?? '');
+
+  const renderLabel = (): JSX.Element => (
+    <span
+      className={repoLabelClass}
+      title={trans.__('Current repository: %1', getFullRepositoryPath())}
+    >
+      <desktopIcon.react tag="span" className="jp-Icon" />
+      <span className={repoButtonLabelClass}>{getRepositoryName()}</span>
+    </span>
+  );
+
+  const renderButton = (menuShown: boolean): JSX.Element => (
+    <button
+      type="button"
+      className={repoButtonClass}
+      title={trans.__(
+        'Current repository: %1 — click to switch submodule',
+        getFullRepositoryPath()
+      )}
+      aria-haspopup="menu"
+      aria-expanded={menuShown}
+      onClick={() => panel.toggleSubmoduleMenu()}
+    >
+      <desktopIcon.react tag="span" className="jp-Icon" />
+      <span className={repoButtonLabelClass}>{getRepositoryName()}</span>
+      {menuShown ? (
+        <caretUpIcon.react tag="span" className="jp-Icon" />
+      ) : (
+        <caretDownIcon.react tag="span" className="jp-Icon" />
+      )}
+    </button>
+  );
+
+  return (
+    <UseSignal signal={model.repositoryChanged}>
+      {() =>
+        model.pathRepository === null ? null : (
+          <UseSignal signal={model.submodulesChanged}>
+            {() =>
+              model.submodules.length > 0 ? (
+                <UseSignal
+                  signal={panel.submoduleMenuShownChanged}
+                  initialArgs={panel.submoduleMenuShown}
+                >
+                  {(_, menuShown) => renderButton(menuShown ?? false)}
                 </UseSignal>
-              )}
-            </UseSignal>
-          );
-        }}
-      </UseSignal>
-    );
-  }
+              ) : (
+                renderLabel()
+              )
+            }
+          </UseSignal>
+        )
+      }
+    </UseSignal>
+  );
+}
 
-  private _renderToolbarRow(): React.ReactElement {
-    const hasSubmodules = this.props.model.submodules.length > 0;
-    return (
-      <div className={toolbarNavClass}>
-        {hasSubmodules ? this._renderRepoButton() : this._renderRepoLabel()}
-        {this._renderBranchInfo()}
-        <span className={spacer} />
-        {this._renderRemoteActions()}
-      </div>
-    );
-  }
+/**
+ * Toolbar item displaying the current branch and repository state.
+ */
+export function BranchItem(props: IToolbarItemProps): JSX.Element {
+  const { model, trans } = props;
 
-  private _renderRepoLabel(): React.ReactElement {
-    const repositoryName = this._getRepositoryName();
-    return (
-      <span
-        className={repoLabelClass}
-        title={this.props.trans.__(
-          'Current repository: %1',
-          this._getFullRepositoryPath()
-        )}
-      >
-        <desktopIcon.react tag="span" className="jp-Icon" />
-        <span className={repoButtonLabelClass}>{repositoryName}</span>
-      </span>
-    );
-  }
-
-  private _renderRepoButton(): React.ReactElement {
-    const repositoryName = this._getRepositoryName();
-    return (
-      <button
-        type="button"
-        className={repoButtonClass}
-        title={this.props.trans.__(
-          'Current repository: %1 — click to switch submodule',
-          this._getFullRepositoryPath()
-        )}
-        aria-haspopup="menu"
-        aria-expanded={this.state.repoMenu}
-        onClick={this._onRepoClick}
-      >
-        <desktopIcon.react tag="span" className="jp-Icon" />
-        <span className={repoButtonLabelClass}>{repositoryName}</span>
-        {this.state.repoMenu ? (
-          <caretUpIcon.react tag="span" className="jp-Icon" />
-        ) : (
-          <caretDownIcon.react tag="span" className="jp-Icon" />
-        )}
-      </button>
-    );
-  }
-
-  private _renderBranchInfo(): React.ReactElement {
-    const currentBranch = this.props.model.currentBranch?.name || 'main';
+  const renderBranch = (): JSX.Element => {
+    const currentBranch = model.currentBranch?.name || 'main';
     let branchTitle: string;
-    switch (this.props.model.status.state) {
+    switch (model.status.state) {
       case Git.State.CHERRY_PICKING:
-        branchTitle = this.props.trans.__(
-          'Cherry-picking on %1',
-          currentBranch
-        );
+        branchTitle = trans.__('Cherry-picking on %1', currentBranch);
         break;
       case Git.State.DETACHED:
-        branchTitle = this.props.trans.__('Detached HEAD at %1', currentBranch);
+        branchTitle = trans.__('Detached HEAD at %1', currentBranch);
         break;
       case Git.State.MERGING:
-        branchTitle = this.props.trans.__('Merging on %1', currentBranch);
+        branchTitle = trans.__('Merging on %1', currentBranch);
         break;
       case Git.State.REBASING:
-        branchTitle = this.props.trans.__('Rebasing %1', currentBranch);
+        branchTitle = trans.__('Rebasing %1', currentBranch);
         break;
       default:
-        branchTitle = this.props.trans.__('Current branch: %1', currentBranch);
+        branchTitle = trans.__('Current branch: %1', currentBranch);
     }
 
     return (
@@ -194,123 +172,190 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
         <span className={branchNameClass}>{currentBranch}</span>
       </span>
     );
+  };
+
+  return (
+    <UseSignal signal={model.repositoryChanged}>
+      {() =>
+        model.pathRepository === null ? null : (
+          <UseSignal signal={model.headChanged}>
+            {() => (
+              <UseSignal signal={model.statusChanged}>
+                {() => renderBranch()}
+              </UseSignal>
+            )}
+          </UseSignal>
+        )
+      }
+    </UseSignal>
+  );
+}
+
+/**
+ * Toolbar item to pull the latest changes, with a badge showing whether the
+ * current branch is behind its remote.
+ */
+export class PullItem extends React.Component<IRemoteActionItemProps> {
+  render(): JSX.Element {
+    const { model } = this.props;
+    return (
+      <UseSignal signal={model.repositoryChanged}>
+        {() =>
+          model.pathRepository === null ? null : (
+            <UseSignal signal={model.statusChanged}>
+              {() => (
+                <UseSignal signal={model.remotesChanged}>
+                  {() => this._renderButton()}
+                </UseSignal>
+              )}
+            </UseSignal>
+          )
+        }
+      </UseSignal>
+    );
   }
 
-  private _renderRemoteActions(): React.ReactElement {
-    const activeBranch = this.props.model.branches.filter(
-      branch => branch.is_current_branch
-    );
-    const hasRemote = this.props.model.remotes.length > 0;
-    const hasUpstream = activeBranch[0]?.upstream !== null;
-
+  private _renderButton(): JSX.Element {
+    const { model, trans } = this.props;
+    const hasRemote = model.remotes.length > 0;
     return (
-      <React.Fragment>
-        <Badge
-          className={badgeClass}
-          variant="dot"
-          invisible={!hasRemote || this.props.model.status.behind === 0}
-        >
-          <ActionButton
-            className={toolbarButtonClass}
-            disabled={!hasRemote}
-            icon={pullIcon}
-            onClick={hasRemote ? this._onPullClick : undefined}
-            title={
-              hasRemote
-                ? this.props.trans.__('Pull latest changes') +
-                  (this.props.model.status.behind > 0
-                    ? this.props.trans.__(
-                        ' (behind by %1 commits)',
-                        this.props.model.status.behind
-                      )
-                    : '')
-                : this.props.trans.__('No remote repository defined')
-            }
-          />
-        </Badge>
-        <Badge
-          className={badgeClass}
-          variant="dot"
-          invisible={
-            !hasRemote || (this.props.model.status.ahead === 0 && hasUpstream)
-          }
-        >
-          <ActionButton
-            className={toolbarButtonClass}
-            disabled={!hasRemote}
-            icon={pushIcon}
-            onClick={hasRemote ? this._onPushClick : undefined}
-            title={
-              hasRemote
-                ? hasUpstream
-                  ? this.props.trans.__('Push committed changes') +
-                    (this.props.model.status.ahead > 0
-                      ? this.props.trans.__(
-                          ' (ahead by %1 commits)',
-                          this.props.model.status.ahead
-                        )
-                      : '')
-                  : this.props.trans.__('Publish branch')
-                : this.props.trans.__('No remote repository defined')
-            }
-          />
-        </Badge>
+      <Badge
+        className={badgeClass}
+        variant="dot"
+        invisible={!hasRemote || model.status.behind === 0}
+      >
         <ActionButton
           className={toolbarButtonClass}
-          icon={refreshIcon}
-          onClick={this._onRefreshClick}
-          disabled={this.state.refreshInProgress}
-          title={this.props.trans.__(
-            'Refresh the repository to detect local and remote changes'
-          )}
+          disabled={!hasRemote}
+          icon={pullIcon}
+          onClick={hasRemote ? this._onPullClick : undefined}
+          title={
+            hasRemote
+              ? trans.__('Pull latest changes') +
+                (model.status.behind > 0
+                  ? trans.__(' (behind by %1 commits)', model.status.behind)
+                  : '')
+              : trans.__('No remote repository defined')
+          }
         />
-      </React.Fragment>
-    );
-  }
-
-  private _renderSubmodules(): JSX.Element {
-    return (
-      <div className={toolbarMenuWrapperClass}>
-        <SubmoduleMenu
-          model={this.props.model}
-          submodules={this.props.model.submodules}
-          trans={this.props.trans}
-        />
-      </div>
-    );
-  }
-
-  private _getRepositoryName(): string {
-    return (
-      PathExt.basename(
-        this.props.model.pathRepository || PageConfig.getOption('serverRoot')
-      ) || 'Jupyter Server Root'
-    );
-  }
-
-  private _getFullRepositoryPath(): string {
-    return (
-      PageConfig.getOption('serverRoot') +
-      '/' +
-      (this.props.model.pathRepository ?? '')
+      </Badge>
     );
   }
 
   private _onPullClick = async (): Promise<void> => {
     await this.props.commands.execute(CommandIDs.gitPull);
   };
+}
+
+/**
+ * Toolbar item to push committed changes, with a badge showing whether the
+ * current branch is ahead of its remote.
+ */
+export class PushItem extends React.Component<IRemoteActionItemProps> {
+  render(): JSX.Element {
+    const { model } = this.props;
+    return (
+      <UseSignal signal={model.repositoryChanged}>
+        {() =>
+          model.pathRepository === null ? null : (
+            <UseSignal signal={model.branchesChanged}>
+              {() => (
+                <UseSignal signal={model.statusChanged}>
+                  {() => (
+                    <UseSignal signal={model.remotesChanged}>
+                      {() => this._renderButton()}
+                    </UseSignal>
+                  )}
+                </UseSignal>
+              )}
+            </UseSignal>
+          )
+        }
+      </UseSignal>
+    );
+  }
+
+  private _renderButton(): JSX.Element {
+    const { model, trans } = this.props;
+    const activeBranch = model.branches.filter(
+      branch => branch.is_current_branch
+    );
+    const hasRemote = model.remotes.length > 0;
+    const hasUpstream = activeBranch[0]?.upstream !== null;
+    return (
+      <Badge
+        className={badgeClass}
+        variant="dot"
+        invisible={!hasRemote || (model.status.ahead === 0 && hasUpstream)}
+      >
+        <ActionButton
+          className={toolbarButtonClass}
+          disabled={!hasRemote}
+          icon={pushIcon}
+          onClick={hasRemote ? this._onPushClick : undefined}
+          title={
+            hasRemote
+              ? hasUpstream
+                ? trans.__('Push committed changes') +
+                  (model.status.ahead > 0
+                    ? trans.__(' (ahead by %1 commits)', model.status.ahead)
+                    : '')
+                : trans.__('Publish branch')
+              : trans.__('No remote repository defined')
+          }
+        />
+      </Badge>
+    );
+  }
 
   private _onPushClick = async (): Promise<void> => {
     await this.props.commands.execute(CommandIDs.gitPush);
   };
+}
 
-  private _onRepoClick = (): void => {
-    this.setState({ repoMenu: !this.state.repoMenu });
-  };
-
+/**
+ * Interface describing refresh item state.
+ */
+interface IRefreshItemState {
   /**
-   * Callback invoked upon clicking a button to refresh the model.
+   * Boolean indicating whether a refresh is currently in progress.
    */
+  refreshInProgress: boolean;
+}
+
+/**
+ * Toolbar item to refresh the repository.
+ */
+export class RefreshItem extends React.Component<
+  IToolbarItemProps,
+  IRefreshItemState
+> {
+  constructor(props: IToolbarItemProps) {
+    super(props);
+    this.state = { refreshInProgress: false };
+  }
+
+  render(): JSX.Element {
+    const { model, trans } = this.props;
+    return (
+      <UseSignal signal={model.repositoryChanged}>
+        {() =>
+          model.pathRepository === null ? null : (
+            <ActionButton
+              className={toolbarButtonClass}
+              icon={refreshIcon}
+              onClick={this._onRefreshClick}
+              disabled={this.state.refreshInProgress}
+              title={trans.__(
+                'Refresh the repository to detect local and remote changes'
+              )}
+            />
+          )
+        }
+      </UseSignal>
+    );
+  }
+
   private _onRefreshClick = async (): Promise<void> => {
     const id = Notification.emit(
       this.props.trans.__('Refreshing…'),
@@ -338,4 +383,51 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
       this.setState({ refreshInProgress: false });
     }
   };
+}
+
+/**
+ * Add the Git panel toolbar item factories to the toolbar registry.
+ *
+ * @param toolbarRegistry Toolbar widget registry
+ * @param model Git extension data model
+ * @param commands Jupyter App commands registry
+ * @param trans The application language translator
+ */
+export function addToolbarItems(
+  toolbarRegistry: IToolbarWidgetRegistry,
+  model: IGitExtension,
+  commands: CommandRegistry,
+  trans: TranslationBundle
+): void {
+  const addItem = (
+    name: string,
+    itemClass: string,
+    render: (panel: GitWidget) => JSX.Element
+  ): void => {
+    toolbarRegistry.addFactory<GitWidget>(
+      GIT_PANEL_TOOLBAR_FACTORY,
+      name,
+      panel => {
+        const widget = ReactWidget.create(render(panel));
+        widget.addClass(itemClass);
+        return widget;
+      }
+    );
+  };
+
+  addItem('repository', 'jp-git-toolbarRepository', panel => (
+    <RepositoryItem model={model} panel={panel} trans={trans} />
+  ));
+  addItem('branch', 'jp-git-toolbarBranch', () => (
+    <BranchItem model={model} trans={trans} />
+  ));
+  addItem('pull', 'jp-git-toolbarPull', () => (
+    <PullItem commands={commands} model={model} trans={trans} />
+  ));
+  addItem('push', 'jp-git-toolbarPush', () => (
+    <PushItem commands={commands} model={model} trans={trans} />
+  ));
+  addItem('refresh', 'jp-git-toolbarRefresh', () => (
+    <RefreshItem model={model} trans={trans} />
+  ));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,11 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import {
+  createToolbarFactory,
   Dialog,
   ICommandPalette,
+  IToolbarWidgetRegistry,
+  setToolbar,
   showErrorMessage
 } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
@@ -28,6 +31,10 @@ import { createImageDiff } from './components/diff/ImageDiff';
 import { createNotebookDiff } from './components/diff/NotebookDiff';
 import { createPlainTextDiff } from './components/diff/PlainTextDiff';
 import { addStatusBarWidget } from './components/StatusWidget';
+import {
+  addToolbarItems,
+  GIT_PANEL_TOOLBAR_FACTORY
+} from './components/Toolbar';
 import { GitExtension } from './model';
 import { getServerSettings } from './server';
 import { gitIcon } from './style/icons';
@@ -50,7 +57,8 @@ const plugin: JupyterFrontEndPlugin<IGitExtension> = {
     IEditorServices,
     IDefaultFileBrowser,
     ISettingRegistry,
-    IDocumentManager
+    IDocumentManager,
+    IToolbarWidgetRegistry
   ],
   optional: [IMainMenu, IStatusBar, ICommandPalette, ITranslator],
   provides: IGitExtension,
@@ -152,6 +160,7 @@ async function activate(
   fileBrowser: IDefaultFileBrowser,
   settingRegistry: ISettingRegistry,
   docmanager: IDocumentManager,
+  toolbarRegistry: IToolbarWidgetRegistry,
   mainMenu: IMainMenu | null,
   statusBar: IStatusBar | null,
   palette: ICommandPalette | null,
@@ -161,6 +170,14 @@ async function activate(
   let gitServerSettings: Git.IServerSettings;
   translator = translator ?? nullTranslator;
   const trans = translator.load('jupyterlab_git');
+
+  const toolbarFactory = createToolbarFactory(
+    toolbarRegistry,
+    settingRegistry,
+    GIT_PANEL_TOOLBAR_FACTORY,
+    plugin.id,
+    translator
+  );
 
   // Attempt to load application settings
   try {
@@ -287,6 +304,8 @@ async function activate(
       translator
     );
 
+    addToolbarItems(toolbarRegistry, gitExtension, app.commands, trans);
+
     // Create the Git widget sidebar
     const gitPlugin = new GitWidget(
       gitExtension,
@@ -298,6 +317,8 @@ async function activate(
     gitPlugin.id = 'jp-git-sessions';
     gitPlugin.title.icon = gitIcon;
     gitPlugin.title.caption = 'Git';
+
+    setToolbar(gitPlugin, toolbarFactory);
 
     if (palette) {
       // Add the commands to the command palette

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,10 +176,6 @@ async function activate(
   translator = translator ?? nullTranslator;
   const trans = translator.load('jupyterlab_git');
 
-  // The schema sets `jupyter.lab.transform`, so the settings load below waits for a
-  // transform to be registered for this plugin and times out if none ever is.
-  // `createToolbarFactory` registers one; without a toolbar registry a pass-through
-  // transform takes its place and the panel is built without a toolbar.
   let toolbarFactory: ReturnType<typeof createToolbarFactory> | null = null;
   if (toolbarRegistry) {
     toolbarFactory = createToolbarFactory(
@@ -190,6 +186,8 @@ async function activate(
       translator
     );
   } else {
+    // The schema sets `jupyter.lab.transform`, so `settingRegistry.load` below
+    // would time out if no transform were ever registered.
     settingRegistry.transform(plugin.id, {});
   }
 
@@ -318,10 +316,8 @@ async function activate(
       translator
     );
 
-    // Register the widget factory for each toolbar item, keyed by the names used in
-    // the `jupyter.lab.toolbars` schema defaults and in the user settings. The toolbar
-    // built by `setToolbar` below instantiates the items through those factories, so
-    // they have to be registered first.
+    // The factory names must match the `jupyter.lab.toolbars` entries in the
+    // schema and user settings, and must be registered before `setToolbar` runs.
     if (toolbarRegistry) {
       addToolbarItems(toolbarRegistry, gitExtension, app.commands, trans);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,10 +57,15 @@ const plugin: JupyterFrontEndPlugin<IGitExtension> = {
     IEditorServices,
     IDefaultFileBrowser,
     ISettingRegistry,
-    IDocumentManager,
-    IToolbarWidgetRegistry
+    IDocumentManager
   ],
-  optional: [IMainMenu, IStatusBar, ICommandPalette, ITranslator],
+  optional: [
+    IToolbarWidgetRegistry,
+    IMainMenu,
+    IStatusBar,
+    ICommandPalette,
+    ITranslator
+  ],
   provides: IGitExtension,
   activate,
   autoStart: true
@@ -160,7 +165,7 @@ async function activate(
   fileBrowser: IDefaultFileBrowser,
   settingRegistry: ISettingRegistry,
   docmanager: IDocumentManager,
-  toolbarRegistry: IToolbarWidgetRegistry,
+  toolbarRegistry: IToolbarWidgetRegistry | null,
   mainMenu: IMainMenu | null,
   statusBar: IStatusBar | null,
   palette: ICommandPalette | null,
@@ -171,13 +176,22 @@ async function activate(
   translator = translator ?? nullTranslator;
   const trans = translator.load('jupyterlab_git');
 
-  const toolbarFactory = createToolbarFactory(
-    toolbarRegistry,
-    settingRegistry,
-    GIT_PANEL_TOOLBAR_FACTORY,
-    plugin.id,
-    translator
-  );
+  // The schema sets `jupyter.lab.transform`, so the settings load below waits for a
+  // transform to be registered for this plugin and times out if none ever is.
+  // `createToolbarFactory` registers one; without a toolbar registry a pass-through
+  // transform takes its place and the panel is built without a toolbar.
+  let toolbarFactory: ReturnType<typeof createToolbarFactory> | null = null;
+  if (toolbarRegistry) {
+    toolbarFactory = createToolbarFactory(
+      toolbarRegistry,
+      settingRegistry,
+      GIT_PANEL_TOOLBAR_FACTORY,
+      plugin.id,
+      translator
+    );
+  } else {
+    settingRegistry.transform(plugin.id, {});
+  }
 
   // Attempt to load application settings
   try {
@@ -304,7 +318,13 @@ async function activate(
       translator
     );
 
-    addToolbarItems(toolbarRegistry, gitExtension, app.commands, trans);
+    // Register the widget factory for each toolbar item, keyed by the names used in
+    // the `jupyter.lab.toolbars` schema defaults and in the user settings. The toolbar
+    // built by `setToolbar` below instantiates the items through those factories, so
+    // they have to be registered first.
+    if (toolbarRegistry) {
+      addToolbarItems(toolbarRegistry, gitExtension, app.commands, trans);
+    }
 
     // Create the Git widget sidebar
     const gitPlugin = new GitWidget(
@@ -318,7 +338,9 @@ async function activate(
     gitPlugin.title.icon = gitIcon;
     gitPlugin.title.caption = 'Git';
 
-    setToolbar(gitPlugin, toolbarFactory);
+    if (toolbarFactory) {
+      setToolbar(gitPlugin, toolbarFactory);
+    }
 
     if (palette) {
       // Add the commands to the command palette

--- a/src/style/CommitBox.ts
+++ b/src/style/CommitBox.ts
@@ -160,7 +160,28 @@ export const commitInputWrapperClass = style({
 });
 
 export const commitPaperClass = style({
-  maxWidth: '250px'
+  maxWidth: '250px',
+  border: 'var(--jp-border-width) solid var(--jp-border-color1)',
+  boxShadow: 'var(--jp-elevation-z6) !important'
+});
+
+// The commit variant menu renders inline (disablePortal) before the file list,
+// whose virtualized rows are absolutely positioned and would paint over it.
+export const commitPopperClass = style({
+  zIndex: 1
+});
+
+// commitRoot pins the item background with !important, which also suppresses
+// the MUI hover/focus tints; restate them at higher specificity.
+export const commitVariantItemClass = style({
+  $nest: {
+    '&:hover': {
+      backgroundColor: 'var(--jp-layout-color2) !important'
+    },
+    '&.Mui-focusVisible': {
+      backgroundColor: 'var(--jp-layout-color2) !important'
+    }
+  }
 });
 
 export const commitVariantText = style({

--- a/src/style/CommitBox.ts
+++ b/src/style/CommitBox.ts
@@ -10,7 +10,7 @@ export const commitFormClass = style({
   alignItems: 'flex-start',
 
   backgroundColor: 'var(--jp-layout-color1)',
-  borderTop: 'var(--jp-border-width) solid var(--jp-border-color2)'
+  borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)'
 });
 
 export const dirtyStagedFilesWarningBoxClass = style({
@@ -91,10 +91,43 @@ export const commitDescriptionClass = style({
   }
 });
 
+export const commitMessageClass = style({
+  marginBottom: '8px',
+  padding: 'var(--jp-code-padding) !important',
+
+  outline: 'none',
+  overflowX: 'auto',
+  resize: 'none',
+
+  border: 'var(--jp-border-width) solid var(--jp-border-color2)',
+  borderRadius: '4px',
+
+  transition: 'border-color 120ms ease, box-shadow 120ms ease',
+
+  $nest: {
+    '&.Mui-error': {
+      border: 'calc(2 * var(--jp-border-width)) solid var(--jp-error-color1)'
+    },
+    '&>*::placeholder': {
+      color: 'var(--jp-ui-font-color3)'
+    },
+    '&>*::-webkit-input-placeholder': {
+      color: 'var(--jp-ui-font-color3)'
+    },
+    '&>*::-moz-placeholder': {
+      color: 'var(--jp-ui-font-color3)'
+    },
+    '&>*::-ms-input-placeholder': {
+      color: 'var(--jp-ui-font-color3)'
+    }
+  }
+});
+
 export const commitButtonClass = style({
+  height: '28px',
   color: 'var(--jp-ui-inverse-font-color1) !important',
   backgroundColor: 'var(--jp-brand-color1) !important',
-  textTransform: 'none' as any,
+  textTransform: 'none !important' as any,
   fontWeight: 600,
 
   $nest: {

--- a/src/style/CommitBox.ts
+++ b/src/style/CommitBox.ts
@@ -123,6 +123,16 @@ export const commitMessageClass = style({
   }
 });
 
+export const commitDescriptionHintClass = style({
+  width: '100%',
+  // Tuck the hint under the input's 8px bottom margin
+  margin: '-4px 0 8px',
+
+  color: 'var(--jp-ui-font-color2)',
+  fontSize: 'var(--jp-ui-font-size0)',
+  lineHeight: 1.35
+});
+
 export const commitButtonClass = style({
   height: '28px',
   color: 'var(--jp-ui-inverse-font-color1) !important',

--- a/src/style/CommitBox.ts
+++ b/src/style/CommitBox.ts
@@ -128,14 +128,21 @@ export const commitMessageClass = style({
   }
 });
 
-export const commitDescriptionHintClass = style({
+const commitDescriptionHint = {
   width: '100%',
   // Tuck the hint under the input's 8px bottom margin
   margin: '-4px 0 8px',
 
-  color: 'var(--jp-ui-font-color2)',
   fontSize: 'var(--jp-ui-font-size0)',
   lineHeight: 1.35
+};
+
+export const commitDescriptionHintClass = style(commitDescriptionHint, {
+  color: 'var(--jp-ui-font-color2)'
+});
+
+export const commitHintErrorClass = style(commitDescriptionHint, {
+  color: 'var(--jp-error-color1)'
 });
 
 export const commitButtonClass = style({

--- a/src/style/CommitBox.ts
+++ b/src/style/CommitBox.ts
@@ -13,6 +13,11 @@ export const commitFormClass = style({
   borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)'
 });
 
+export const commitFormBottomClass = style({
+  borderBottom: 'none',
+  borderTop: 'var(--jp-border-width) solid var(--jp-border-color2)'
+});
+
 export const dirtyStagedFilesWarningBoxClass = style({
   marginBottom: '1em',
   padding: 'var(--jp-code-padding)',

--- a/src/style/Toolbar.ts
+++ b/src/style/Toolbar.ts
@@ -152,10 +152,6 @@ export const toolbarButtonClass = style({
   }
 });
 
-export const spacer = style({
-  flex: '1 1 auto'
-});
-
 export const badgeClass = style({
   $nest: {
     '& > .MuiBadge-badge': {

--- a/src/style/Toolbar.ts
+++ b/src/style/Toolbar.ts
@@ -1,30 +1,32 @@
 import { style } from 'typestyle';
 
-export const toolbarClass = style({
-  display: 'flex',
-  flexDirection: 'column',
-
-  backgroundColor: 'var(--jp-layout-color1)',
-  borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)'
-});
-
-export const toolbarNavClass = style({
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  flexWrap: 'nowrap',
-
-  padding: '4px 8px',
-  gap: '4px',
-
-  fontSize: 'var(--jp-ui-font-size1)',
-  color: 'var(--jp-ui-font-color1)',
-  backgroundColor: 'var(--jp-layout-color1)'
+export const panelToolbarClass = style({
+  $nest: {
+    // The `&.jp-Toolbar`-prefixed selectors need the extra specificity to win
+    // over the core `.jp-Toolbar` and `.jp-Toolbar > .jp-Toolbar-item` rules
+    '&.jp-Toolbar': {
+      padding: '2px 8px',
+      gap: '4px'
+    },
+    '&.jp-Toolbar > .jp-Toolbar-item': {
+      alignItems: 'center'
+    },
+    '&.jp-Toolbar > .jp-git-toolbarRepository': {
+      flex: '0 1 auto',
+      minWidth: 0,
+      overflow: 'hidden'
+    },
+    // Shrink well before the repository label but never collapse entirely
+    '&.jp-Toolbar > .jp-git-toolbarBranch': {
+      flex: '0 10000 auto',
+      minWidth: '54px'
+    }
+  }
 });
 
 export const toolbarMenuWrapperClass = style({
   background: 'var(--jp-layout-color1)',
-  borderTop: 'var(--jp-border-width) solid var(--jp-border-color2)'
+  borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)'
 });
 
 export const repoButtonLabelClass = style({

--- a/src/style/Toolbar.ts
+++ b/src/style/Toolbar.ts
@@ -15,20 +15,11 @@ export const toolbarNavClass = style({
   flexWrap: 'nowrap',
 
   padding: '4px 8px',
-  gap: '6px',
+  gap: '4px',
 
   fontSize: 'var(--jp-ui-font-size1)',
   color: 'var(--jp-ui-font-color1)',
   backgroundColor: 'var(--jp-layout-color1)'
-});
-
-export const repoBranchColumnClass = style({
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-start',
-  flex: '0 1 auto',
-  minWidth: 0,
-  gap: '2px'
 });
 
 export const toolbarMenuWrapperClass = style({
@@ -107,8 +98,9 @@ export const branchInfoClass = style({
   boxSizing: 'border-box',
   display: 'inline-flex',
   alignItems: 'center',
-  flex: '0 1 auto',
-  minWidth: 0,
+  // Shrink well before the repository label but never collapse entirely
+  flex: '0 10000 auto',
+  minWidth: '54px',
   gap: '4px',
 
   height: '18px',

--- a/src/widgets/GitWidget.tsx
+++ b/src/widgets/GitWidget.tsx
@@ -1,20 +1,22 @@
-import { ReactWidget } from '@jupyterlab/apputils';
+import { ReactWidget, UseSignal } from '@jupyterlab/apputils';
 import { FileBrowserModel } from '@jupyterlab/filebrowser';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { TranslationBundle } from '@jupyterlab/translation';
 import { CommandRegistry } from '@lumino/commands';
 import { Message } from '@lumino/messaging';
+import { ISignal, Signal } from '@lumino/signaling';
 import { PanelLayout, Widget } from '@lumino/widgets';
 import * as React from 'react';
 import { PanelWithToolbar, SidePanel } from '@jupyterlab/ui-components';
 import { GitPanel } from '../components/GitPanel';
-import { Toolbar } from '../components/Toolbar';
+import { SubmoduleMenu } from '../components/SubmoduleMenu';
 import { GitExtension } from '../model';
 import {
   gitWidgetStyle,
   sectionBodyStyle,
   sectionStyle
 } from '../style/GitWidgetStyle';
+import { panelToolbarClass, toolbarMenuWrapperClass } from '../style/Toolbar';
 
 /**
  * The Git extension's main side-bar widget.
@@ -40,9 +42,10 @@ export class GitWidget extends SidePanel {
     this._model = model;
     this._settings = settings;
 
-    const topToolbar = ReactWidget.create(this._renderTopToolbar());
-    topToolbar.addClass('jp-git-TopToolbar');
-    (this.layout as PanelLayout).insertWidget(0, topToolbar);
+    this.toolbar.addClass(panelToolbarClass);
+    this.toolbar.addClass('jp-git-PanelToolbar');
+    model.repositoryChanged.connect(this._onRepositoryChanged, this);
+    this.toolbar.setHidden(model.pathRepository === null);
 
     this.addWidget(
       this._createSection('Changes', this._createChangesSection())
@@ -57,6 +60,48 @@ export class GitWidget extends SidePanel {
     // Add refresh standby condition if this widget is hidden
     model.refreshStandbyCondition = (): boolean =>
       !this._settings.composite['refreshIfHidden'] && this.isHidden;
+  }
+
+  /**
+   * Whether the submodule menu is currently shown below the toolbar.
+   */
+  get submoduleMenuShown(): boolean {
+    return this._submoduleMenu !== null;
+  }
+
+  /**
+   * A signal emitted when the submodule menu is shown or hidden.
+   */
+  get submoduleMenuShownChanged(): ISignal<GitWidget, boolean> {
+    return this._submoduleMenuShownChanged;
+  }
+
+  /**
+   * Show or hide the submodule menu below the panel toolbar.
+   */
+  toggleSubmoduleMenu(): void {
+    if (this._submoduleMenu) {
+      this._submoduleMenu.dispose();
+      this._submoduleMenu = null;
+      this._submoduleMenuShownChanged.emit(false);
+    } else {
+      const menu = ReactWidget.create(
+        <UseSignal signal={this._model.submodulesChanged}>
+          {() => (
+            <SubmoduleMenu
+              model={this._model}
+              submodules={this._model.submodules}
+              trans={this._gitTrans}
+            />
+          )}
+        </UseSignal>
+      );
+      menu.addClass(toolbarMenuWrapperClass);
+      const layout = this.layout as PanelLayout;
+      layout.insertWidget(layout.widgets.indexOf(this.content), menu);
+      this._submoduleMenu = menu;
+      this._submoduleMenuShownChanged.emit(true);
+    }
   }
 
   /**
@@ -123,14 +168,11 @@ export class GitWidget extends SidePanel {
     );
   }
 
-  private _renderTopToolbar(): React.ReactElement {
-    return (
-      <Toolbar
-        commands={this._commands}
-        model={this._model}
-        trans={this._gitTrans}
-      />
-    );
+  private _onRepositoryChanged(): void {
+    this.toolbar.setHidden(this._model.pathRepository === null);
+    if (this._submoduleMenu) {
+      this.toggleSubmoduleMenu();
+    }
   }
 
   private _gitTrans: TranslationBundle;
@@ -138,4 +180,6 @@ export class GitWidget extends SidePanel {
   private _fileBrowserModel: FileBrowserModel;
   private _model: GitExtension;
   private _settings: ISettingRegistry.ISettings;
+  private _submoduleMenu: Widget | null = null;
+  private _submoduleMenuShownChanged = new Signal<GitWidget, boolean>(this);
 }

--- a/ui-tests/tests/commit.spec.ts
+++ b/ui-tests/tests/commit.spec.ts
@@ -33,7 +33,7 @@ test.describe('Commit', () => {
     await page.getByRole('button', { name: 'Stage this change' }).click();
 
     await page
-      .getByPlaceholder('Summary (Ctrl+Enter to commit)')
+      .getByPlaceholder('Commit message (Ctrl+Enter to commit)')
       .fill('My new commit');
 
     await page.getByRole('button', { name: 'Commit', exact: true }).click();


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab-git/issues/1513

- [x] Move the commit box to the top of the panel
- [x] Keep only one input since it can be used to specify both the message and the description
- [x] Make the toolbar configurable via the settings, so items could be reordered or even removed (for example hiding the branch)
- [x] Update tests


| Before | After |
| :---: | :---: |
| <img width="1120" height="1900" alt="before" src="https://github.com/user-attachments/assets/6b4aca43-40a5-4a63-bc09-6d145d0772ec" />  | <img width="1120" height="1900" alt="after" src="https://github.com/user-attachments/assets/ba1e216b-4f02-4075-82a7-8a7f1c6dd19e" /> |

**Toolbar changes**

https://github.com/user-attachments/assets/d3ed6955-e44a-4b9c-9180-e8f084d3e727


**Commit box hint**

Show a hint when there are multiple lines, since the box now combines the message and the description.

<img width="584" height="576" alt="image" src="https://github.com/user-attachments/assets/4d2ba16b-b130-4469-99e1-5e7236b7bbbb" />
