### PR TITLE
Fix: git.py:268 read `scope.cancelled_caught` to detect that move_on_after's...

### DIFF
--- a/packages/core/jupyterlab_git_core/git.py
+++ b/packages/core/jupyterlab_git_core/git.py
@@ -265,7 +265,7 @@ class Git:
         lock = _get_execution_lock()
         with anyio.move_on_after(self._execute_timeout) as scope:
             await lock.acquire()
-        if scope.cancelled_caught:
+        if scope.cancel_called:
             return 1, "", "Unable to get the lock on the directory"
         try:
             return await execute(

--- a/packages/core/tests/test_execute.py
+++ b/packages/core/tests/test_execute.py
@@ -10,19 +10,61 @@ class _TinyTimeoutConfig:
     git_command_timeout = 0.01
 
 
+class _CancelScopeWithoutCancelledCaught:
+    """Wraps a real anyio CancelScope but hides ``cancelled_caught``.
+
+    anyio 3.0.0's CancelScope only exposes ``cancel_called``; the
+    ``cancelled_caught`` property was added in a later anyio release and is
+    present (alongside ``cancel_called``) in this environment's installed
+    anyio (4.x), which is why a plain regression test using the real
+    CancelScope cannot distinguish the fixed code from the old,
+    ``cancelled_caught``-reading code. This wrapper simulates anyio 3.0.0's
+    actual attribute surface so the test genuinely exercises the
+    AttributeError path when the old attribute name is used.
+    """
+
+    def __init__(self, real_scope):
+        self._real_scope = real_scope
+
+    def __getattr__(self, name):
+        if name == "cancelled_caught":
+            raise AttributeError(
+                "'CancelScope' object has no attribute 'cancelled_caught'"
+            )
+        return getattr(self._real_scope, name)
+
+    def __enter__(self):
+        self._real_scope.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._real_scope.__exit__(*args)
+
+
 @pytest.mark.anyio
 async def test_execute_lock_timeout_uses_cancel_called(tmp_path):
     """Regression test for #1520.
 
-    anyio 3 renamed CancelScope.cancelled_caught to CancelScope.cancel_called.
-    When the lock cannot be acquired before the timeout, __execute must read
-    the new attribute name instead of raising AttributeError (which was
-    previously being swallowed and surfaced as a None return / false
-    "git command not found" error).
+    anyio 3.0.0's CancelScope only has ``cancel_called``; ``cancelled_caught``
+    was added later and happens to also exist on the anyio version installed
+    in this environment, so testing against the real CancelScope would pass
+    regardless of which attribute name __execute reads. To make the test
+    actually able to fail on the old code, we patch anyio.move_on_after to
+    return a scope object that raises AttributeError on ``cancelled_caught``
+    access, mirroring anyio 3.0.0's real attribute surface. If __execute were
+    reverted to read ``scope.cancelled_caught``, this test would fail with an
+    AttributeError instead of returning the expected lock-timeout result.
     """
     git = Git(config=_TinyTimeoutConfig())
     lock = _get_execution_lock()
     release_event = anyio.Event()
+
+    real_move_on_after = anyio.move_on_after
+
+    def fake_move_on_after(*args, **kwargs):
+        return _CancelScopeWithoutCancelledCaught(
+            real_move_on_after(*args, **kwargs)
+        )
 
     async def hold_lock(*, task_status):
         async with lock:
@@ -36,7 +78,8 @@ async def test_execute_lock_timeout_uses_cancel_called(tmp_path):
         await tg.start(hold_lock)
 
         cmd = ["git", "dummy"]
-        result = await git._Git__execute(cmd, cwd=str(tmp_path))
+        with patch("anyio.move_on_after", side_effect=fake_move_on_after):
+            result = await git._Git__execute(cmd, cwd=str(tmp_path))
 
         release_event.set()
 

--- a/packages/core/tests/test_execute.py
+++ b/packages/core/tests/test_execute.py
@@ -1,6 +1,48 @@
+import anyio
 import pytest
 from unittest.mock import patch
 from jupyterlab_git_core.git import Git, _get_execution_lock
+
+
+class _TinyTimeoutConfig:
+    """Minimal config stand-in exposing only what Git.__init__ reads."""
+
+    git_command_timeout = 0.01
+
+
+@pytest.mark.anyio
+async def test_execute_lock_timeout_uses_cancel_called(tmp_path):
+    """Regression test for #1520.
+
+    anyio 3 renamed CancelScope.cancelled_caught to CancelScope.cancel_called.
+    When the lock cannot be acquired before the timeout, __execute must read
+    the new attribute name instead of raising AttributeError (which was
+    previously being swallowed and surfaced as a None return / false
+    "git command not found" error).
+    """
+    git = Git(config=_TinyTimeoutConfig())
+    lock = _get_execution_lock()
+    release_event = anyio.Event()
+
+    async def hold_lock(*, task_status):
+        async with lock:
+            task_status.started()
+            await release_event.wait()
+
+    # Hold the lock from a separate task so that __execute's own acquire()
+    # call is forced to wait past the (very short) timeout and the anyio
+    # CancelScope actually fires.
+    async with anyio.create_task_group() as tg:
+        await tg.start(hold_lock)
+
+        cmd = ["git", "dummy"]
+        result = await git._Git__execute(cmd, cwd=str(tmp_path))
+
+        release_event.set()
+
+    # No AttributeError was raised, and we get the expected lock-timeout
+    # result rather than None.
+    assert result == (1, "", "Unable to get the lock on the directory")
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
Changed packages/core/jupyterlab_git_core/git.py:268 from `if scope.cancelled_caught:` to `if scope.cancel_called:`, which is the attribute reliably present across anyio 3.x and 4.x for detecting that this (unshielded, single-level) CancelScope's deadline fired via move_on_after. This fix was already committed in a prior attempt (commit 9b7ac22); this round only strengthened the regression test per reviewer feedback.

## Problem
jupyterlab/jupyterlab-git issue reference: jupyterlab/jupyterlab-git#1520

## Root Cause
git.py:268 read `scope.cancelled_caught` to detect that move_on_after's deadline fired. `cancelled_caught` and `cancel_called` are NOT a simple rename of the same property between anyio versions — they are two distinct properties. `cancel_called` has existed since early anyio 3.x (including 3.0.0); `cancelled_caught` was added later in anyio's history and both properties coexist in anyio 4.12.1 (the version installed in this environment). anyio 3.0.0's CancelScope lacks `cancelled_caught` entirely, so on that version (or any anyio release predating its introduction) the attribute access raises AttributeError, which was being caught elsewhere and turned into a None return.

## Testing
PASS: both tests pass with the fix (scope.cancel_called) in place. Verified the regression test is meaningful by manually reverting git.py to scope.cancelled_caught and rerunning — the test now correctly FAILS with an AttributeError (matching the real #1520 symptom), then re-passes once the fix is restored.

## Related Issue
jupyterlab/jupyterlab-git#1520
