### PR TITLE
Add UI branch comparison

### DIFF
--- a/src/__tests__/test-components/BranchMenu.spec.tsx
+++ b/src/__tests__/test-components/BranchMenu.spec.tsx
@@ -101,6 +101,7 @@ describe('BranchMenu', () => {
         execute: jest.fn()
       } as any,
       trans: trans,
+      onCompareWithCurrent: jest.fn(),
       ...props
     };
   }
@@ -190,10 +191,14 @@ describe('BranchMenu', () => {
         tag: ''
       }
     ].forEach(branch => {
-      const display = !(branch.is_current_branch || branch.is_remote_branch);
+      const count = branch.is_current_branch
+        ? 0
+        : branch.is_remote_branch
+        ? 1
+        : 3;
       it(`should${
-        display ? ' ' : 'not '
-      }display delete and merge buttons for ${JSON.stringify(branch)}`, () => {
+        count ? ' ' : 'not '
+      }display branch action buttons for ${JSON.stringify(branch)}`, () => {
         render(
           <BranchMenu
             {...createProps({
@@ -205,8 +210,29 @@ describe('BranchMenu', () => {
 
         expect(
           screen.getByRole('listitem').querySelectorAll('button').length
-        ).toEqual(display ? 2 : 0);
+        ).toEqual(count);
       });
+    });
+
+    it('should compare a branch with the current branch', async () => {
+      const branch = BRANCHES[1];
+      const onCompareWithCurrent = jest.fn();
+
+      render(
+        <BranchMenu
+          {...createProps({
+            branches: [BRANCHES[0], branch],
+            onCompareWithCurrent
+          })}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Compare with current branch' })
+      );
+
+      expect(onCompareWithCurrent).toHaveBeenCalledTimes(1);
+      expect(onCompareWithCurrent).toHaveBeenCalledWith(branch);
     });
 
     it('should call delete branch when clicked on the delete button', async () => {

--- a/src/__tests__/test-components/CommitComparisonBox.spec.tsx
+++ b/src/__tests__/test-components/CommitComparisonBox.spec.tsx
@@ -1,25 +1,44 @@
 import { nullTranslator } from '@jupyterlab/translation';
 import '@testing-library/jest-dom';
-import { render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import 'jest';
 import * as React from 'react';
 import { CommitComparisonBox } from '../../components/CommitComparisonBox';
+import { Git } from '../../tokens';
 
 describe('CommitComparisonBox', () => {
   const trans = nullTranslator.load('jupyterlab_git');
 
+  function createDiffResult(filename: string): Git.IDiffResult {
+    return {
+      code: 0,
+      result: [
+        {
+          deletions: '1',
+          filename,
+          insertions: '2'
+        }
+      ]
+    };
+  }
+
+  function createDeferred<T>(): {
+    promise: Promise<T>;
+    reject: (reason?: unknown) => void;
+    resolve: (value: T) => void;
+  } {
+    let reject!: (reason?: unknown) => void;
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, reject, resolve };
+  }
+
   it('should request a diff between two Git refs', async () => {
     const model = {
-      diff: jest.fn().mockResolvedValue({
-        code: 0,
-        result: [
-          {
-            deletions: '1',
-            filename: 'src/index.ts',
-            insertions: '2'
-          }
-        ]
-      })
+      diff: jest.fn().mockResolvedValue(createDiffResult('src/index.ts'))
     };
 
     render(
@@ -36,5 +55,126 @@ describe('CommitComparisonBox', () => {
     await waitFor(() => {
       expect(model.diff).toHaveBeenCalledWith('main', 'feature');
     });
+  });
+
+  it('should keep the history comparison empty state text', () => {
+    const model = {
+      diff: jest.fn()
+    };
+
+    render(
+      <CommitComparisonBox
+        header="Compare main and ..."
+        reference={{ ref: 'main', label: 'main' }}
+        challenger={null}
+        model={model as any}
+        trans={trans}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText('No challenger commit selected.')
+    ).toBeInTheDocument();
+    expect(model.diff).not.toHaveBeenCalled();
+  });
+
+  it('should ignore stale diff results when refs change', async () => {
+    const firstDiff = createDeferred<Git.IDiffResult>();
+    const secondDiff = createDeferred<Git.IDiffResult>();
+    const model = {
+      diff: jest
+        .fn()
+        .mockReturnValueOnce(firstDiff.promise)
+        .mockReturnValueOnce(secondDiff.promise)
+    };
+
+    const { rerender } = render(
+      <CommitComparisonBox
+        header="Compare main and feature-one"
+        reference={{ ref: 'main', label: 'main' }}
+        challenger={{ ref: 'feature-one', label: 'feature-one' }}
+        model={model as any}
+        trans={trans}
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(model.diff).toHaveBeenCalledWith('main', 'feature-one');
+    });
+
+    rerender(
+      <CommitComparisonBox
+        header="Compare main and feature-two"
+        reference={{ ref: 'main', label: 'main' }}
+        challenger={{ ref: 'feature-two', label: 'feature-two' }}
+        model={model as any}
+        trans={trans}
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(model.diff).toHaveBeenCalledWith('main', 'feature-two');
+    });
+
+    await act(async () => {
+      secondDiff.resolve(createDiffResult('second.ts'));
+      await secondDiff.promise;
+    });
+
+    expect(await screen.findByText('second.ts')).toBeInTheDocument();
+
+    await act(async () => {
+      firstDiff.resolve(createDiffResult('first.ts'));
+      await firstDiff.promise;
+    });
+
+    expect(screen.queryByText('first.ts')).not.toBeInTheDocument();
+    expect(screen.getByText('second.ts')).toBeInTheDocument();
+  });
+
+  it('should clear existing files when a diff request fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const model = {
+      diff: jest
+        .fn()
+        .mockResolvedValueOnce(createDiffResult('old.ts'))
+        .mockRejectedValueOnce(new Error('Failed'))
+    };
+
+    const { rerender } = render(
+      <CommitComparisonBox
+        header="Compare main and feature"
+        reference={{ ref: 'main', label: 'main' }}
+        challenger={{ ref: 'feature', label: 'feature' }}
+        model={model as any}
+        trans={trans}
+        onClose={jest.fn()}
+      />
+    );
+
+    try {
+      expect(await screen.findByText('old.ts')).toBeInTheDocument();
+
+      rerender(
+        <CommitComparisonBox
+          header="Compare main and broken"
+          reference={{ ref: 'main', label: 'main' }}
+          challenger={{ ref: 'broken', label: 'broken' }}
+          model={model as any}
+          trans={trans}
+          onClose={jest.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(model.diff).toHaveBeenCalledWith('main', 'broken');
+        expect(screen.queryByText('old.ts')).not.toBeInTheDocument();
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/src/__tests__/test-components/CommitComparisonBox.spec.tsx
+++ b/src/__tests__/test-components/CommitComparisonBox.spec.tsx
@@ -1,0 +1,40 @@
+import { nullTranslator } from '@jupyterlab/translation';
+import '@testing-library/jest-dom';
+import { render, waitFor } from '@testing-library/react';
+import 'jest';
+import * as React from 'react';
+import { CommitComparisonBox } from '../../components/CommitComparisonBox';
+
+describe('CommitComparisonBox', () => {
+  const trans = nullTranslator.load('jupyterlab_git');
+
+  it('should request a diff between two Git refs', async () => {
+    const model = {
+      diff: jest.fn().mockResolvedValue({
+        code: 0,
+        result: [
+          {
+            deletions: '1',
+            filename: 'src/index.ts',
+            insertions: '2'
+          }
+        ]
+      })
+    };
+
+    render(
+      <CommitComparisonBox
+        header="Compare main and feature"
+        reference={{ ref: 'main', label: 'main' }}
+        challenger={{ ref: 'feature', label: 'feature' }}
+        model={model as any}
+        trans={trans}
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(model.diff).toHaveBeenCalledWith('main', 'feature');
+    });
+  });
+});

--- a/src/__tests__/test-components/GitPanel.spec.tsx
+++ b/src/__tests__/test-components/GitPanel.spec.tsx
@@ -519,7 +519,51 @@ describe('GitPanel', () => {
       );
 
       await waitFor(() => {
-        expect(props.model.diff).toHaveBeenCalledWith('main', 'feature');
+        expect(props.model.diff).toHaveBeenCalledWith(
+          'refs/heads/main',
+          'refs/heads/feature'
+        );
+      });
+    });
+
+    it('should compare a selected remote branch against the current branch', async () => {
+      const currentBranch = {
+        is_current_branch: true,
+        is_remote_branch: false,
+        name: 'feature',
+        tag: null,
+        top_commit: 'feature-hash',
+        upstream: null
+      };
+      const baseBranch = {
+        is_current_branch: false,
+        is_remote_branch: true,
+        name: 'origin/main',
+        tag: null,
+        top_commit: 'main-hash',
+        upstream: null
+      };
+
+      (props.model as any).branches = [currentBranch, baseBranch];
+      (props.model as any).currentBranch = currentBranch;
+      (props.model as any).pathRepository = '/path';
+      (props.model as any).status = { files: [], state: 0 };
+      (props.model as any).diff = jest.fn().mockResolvedValue({
+        code: 0,
+        result: []
+      });
+
+      render(<GitPanel {...props} contentMode="branches" />);
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Compare with current branch' })
+      );
+
+      await waitFor(() => {
+        expect(props.model.diff).toHaveBeenCalledWith(
+          'refs/remotes/origin/main',
+          'refs/heads/feature'
+        );
       });
     });
   });

--- a/src/__tests__/test-components/GitPanel.spec.tsx
+++ b/src/__tests__/test-components/GitPanel.spec.tsx
@@ -484,5 +484,43 @@ describe('GitPanel', () => {
         screen.getByRole('button', { name: 'Commit' })
       ).toBeInTheDocument();
     });
+
+    it('should compare a selected branch against the current branch', async () => {
+      const currentBranch = {
+        is_current_branch: true,
+        is_remote_branch: false,
+        name: 'feature',
+        tag: null,
+        top_commit: 'feature-hash',
+        upstream: null
+      };
+      const baseBranch = {
+        is_current_branch: false,
+        is_remote_branch: false,
+        name: 'main',
+        tag: null,
+        top_commit: 'main-hash',
+        upstream: null
+      };
+
+      (props.model as any).branches = [currentBranch, baseBranch];
+      (props.model as any).currentBranch = currentBranch;
+      (props.model as any).pathRepository = '/path';
+      (props.model as any).status = { files: [], state: 0 };
+      (props.model as any).diff = jest.fn().mockResolvedValue({
+        code: 0,
+        result: []
+      });
+
+      render(<GitPanel {...props} contentMode="branches" />);
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Compare with current branch' })
+      );
+
+      await waitFor(() => {
+        expect(props.model.diff).toHaveBeenCalledWith('main', 'feature');
+      });
+    });
   });
 });

--- a/src/components/BranchMenu.tsx
+++ b/src/components/BranchMenu.tsx
@@ -26,7 +26,7 @@ import {
   newBranchButtonClass,
   wrapperClass
 } from '../style/BranchMenu';
-import { branchIcon, mergeIcon, trashIcon } from '../style/icons';
+import { branchIcon, diffIcon, mergeIcon, trashIcon } from '../style/icons';
 import { CommandIDs, Git, IGitExtension } from '../tokens';
 import { ActionButton } from './ActionButton';
 import { NewBranchDialog } from './NewBranchDialog';
@@ -121,6 +121,11 @@ export interface IBranchMenuProps {
    * The application language translator.
    */
   trans: TranslationBundle;
+
+  /**
+   * Callback invoked to compare a branch with the current branch.
+   */
+  onCompareWithCurrent: (branch: Git.IBranch) => void;
 }
 
 /**
@@ -283,6 +288,19 @@ export class BranchMenu extends React.Component<
       >
         <branchIcon.react className={listItemIconClass} tag="span" />
         <span className={nameClass}>{branch.name}</span>
+        {!isActive && (
+          <ActionButton
+            className={hiddenButtonStyle}
+            icon={diffIcon}
+            title={this.props.trans.__('Compare with current branch')}
+            onClick={(
+              event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+            ) => {
+              event?.stopPropagation();
+              this.props.onCompareWithCurrent(branch);
+            }}
+          />
+        )}
         {!branch.is_remote_branch && !isActive && (
           <>
             <ActionButton

--- a/src/components/CommitComparisonBox.tsx
+++ b/src/components/CommitComparisonBox.tsx
@@ -78,7 +78,7 @@ export function CommitComparisonBox(
   const [collapsed, setCollapsed] = React.useState<boolean>(false);
   const [files, setFiles] = React.useState<Git.ICommitModifiedFile[]>([]);
 
-  const { reference, challenger, model } = props;
+  const { reference, challenger, model, trans } = props;
   const referenceRef = reference?.ref ?? null;
   const referenceLabel = reference?.label ?? null;
   const challengerRef = challenger?.ref ?? null;
@@ -94,11 +94,15 @@ export function CommitComparisonBox(
   }, 0);
 
   React.useEffect(() => {
+    let cancelled = false;
+
     (async () => {
       if (referenceRef === null || challengerRef === null) {
         setFiles([]);
         return;
       }
+
+      setFiles([]);
 
       let diffResult: Git.IDiffResult | null = null;
       try {
@@ -107,11 +111,20 @@ export function CommitComparisonBox(
           throw new Error(diffResult.message);
         }
       } catch (err: any) {
+        if (cancelled) {
+          return;
+        }
         const msg = `Failed to get the diff for ${referenceLabel} and ${challengerLabel}.`;
         console.error(msg, err);
-        Notification.error(msg, showError(err, props.trans));
+        setFiles([]);
+        Notification.error(msg, showError(err, trans));
         return;
       }
+
+      if (cancelled) {
+        return;
+      }
+
       if (diffResult) {
         setFiles(
           (diffResult.result ?? []).map(changedFile => {
@@ -133,7 +146,18 @@ export function CommitComparisonBox(
         setFiles([]);
       }
     })();
-  }, [referenceRef, referenceLabel, challengerRef, challengerLabel, model]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    referenceRef,
+    referenceLabel,
+    challengerRef,
+    challengerLabel,
+    model,
+    trans
+  ]);
 
   return (
     <div className={commitComparisonBoxStyle}>
@@ -178,7 +202,7 @@ export function CommitComparisonBox(
           <p>
             {hasDiff
               ? props.trans.__('No changes')
-              : props.trans.__('No challenger selected.')}
+              : props.trans.__('No challenger commit selected.')}
           </p>
         ))}
     </div>

--- a/src/components/CommitComparisonBox.tsx
+++ b/src/components/CommitComparisonBox.tsx
@@ -5,7 +5,6 @@ import {
   caretRightIcon,
   closeIcon
 } from '@jupyterlab/ui-components';
-import { CommandRegistry } from '@lumino/commands';
 import * as React from 'react';
 import { showError } from '../notifications';
 import {
@@ -26,19 +25,14 @@ import { CommitDiff } from './CommitDiff';
  */
 export interface ICommitComparisonBoxProps {
   /**
-   * Jupyter App commands registry.
+   * The Git ref to compare against.
    */
-  commands: CommandRegistry;
+  reference: Git.IRefComparison | null;
 
   /**
-   * The commit to compare against.
+   * The Git ref to compare.
    */
-  referenceCommit: Git.ISingleCommitInfo | null;
-
-  /**
-   * The commit to compare.
-   */
-  challengerCommit: Git.ISingleCommitInfo | null;
+  challenger: Git.IRefComparison | null;
 
   /**
    * Header text.
@@ -76,7 +70,7 @@ export interface ICommitComparisonBoxProps {
 }
 
 /**
- * A component which displays a comparison between two commits.
+ * A component which displays a comparison between two Git refs.
  */
 export function CommitComparisonBox(
   props: ICommitComparisonBoxProps
@@ -84,8 +78,12 @@ export function CommitComparisonBox(
   const [collapsed, setCollapsed] = React.useState<boolean>(false);
   const [files, setFiles] = React.useState<Git.ICommitModifiedFile[]>([]);
 
-  const { referenceCommit, challengerCommit, model } = props;
-  const hasDiff = referenceCommit !== null && challengerCommit !== null;
+  const { reference, challenger, model } = props;
+  const referenceRef = reference?.ref ?? null;
+  const referenceLabel = reference?.label ?? null;
+  const challengerRef = challenger?.ref ?? null;
+  const challengerLabel = challenger?.label ?? null;
+  const hasDiff = reference !== null && challenger !== null;
   const totalInsertions = files.reduce((acc, file) => {
     const insertions = Number.parseInt(file.insertion, 10);
     return acc + (Number.isNaN(insertions) ? 0 : insertions);
@@ -97,22 +95,19 @@ export function CommitComparisonBox(
 
   React.useEffect(() => {
     (async () => {
-      if (referenceCommit === null || challengerCommit === null) {
+      if (referenceRef === null || challengerRef === null) {
         setFiles([]);
         return;
       }
 
       let diffResult: Git.IDiffResult | null = null;
       try {
-        diffResult = await model.diff(
-          referenceCommit.commit,
-          challengerCommit.commit
-        );
+        diffResult = await model.diff(referenceRef, challengerRef);
         if (diffResult.code !== 0) {
           throw new Error(diffResult.message);
         }
       } catch (err: any) {
-        const msg = `Failed to get the diff for ${referenceCommit.commit} and ${challengerCommit.commit}.`;
+        const msg = `Failed to get the diff for ${referenceLabel} and ${challengerLabel}.`;
         console.error(msg, err);
         Notification.error(msg, showError(err, props.trans));
         return;
@@ -138,7 +133,7 @@ export function CommitComparisonBox(
         setFiles([]);
       }
     })();
-  }, [referenceCommit, challengerCommit]);
+  }, [referenceRef, referenceLabel, challengerRef, challengerLabel, model]);
 
   return (
     <div className={commitComparisonBoxStyle}>
@@ -183,7 +178,7 @@ export function CommitComparisonBox(
           <p>
             {hasDiff
               ? props.trans.__('No changes')
-              : props.trans.__('No challenger commit selected.')}
+              : props.trans.__('No challenger selected.')}
           </p>
         ))}
     </div>

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -777,17 +777,20 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
 
     this.setState({
       branchComparison: {
-        reference: {
-          ref: branch.name,
-          label: branch.name
-        },
-        challenger: {
-          ref: currentBranch.name,
-          label: currentBranch.name
-        }
+        reference: this._branchToDiffRef(branch),
+        challenger: this._branchToDiffRef(currentBranch)
       }
     });
   };
+
+  private _branchToDiffRef(branch: Git.IBranch): Git.IRefComparison {
+    return {
+      ref: branch.is_remote_branch
+        ? `refs/remotes/${branch.name}`
+        : `refs/heads/${branch.name}`,
+      label: branch.name
+    };
+  }
 
   /**
    * Updates the commit message description.

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -19,7 +19,11 @@ import {
 } from '../style/GitPanel';
 import { addIcon, rewindIcon, trashIcon } from '../style/icons';
 import { CommandIDs, Git } from '../tokens';
-import { openFileDiff, stopPropagationWrapper } from '../utils';
+import {
+  commitToDiffRef,
+  openFileDiff,
+  stopPropagationWrapper
+} from '../utils';
 import { GitAuthorForm } from '../widgets/AuthorBox';
 import { ActionButton } from './ActionButton';
 import { CommitBox } from './CommitBox';
@@ -153,6 +157,14 @@ export interface IGitPanelState {
   challengerCommit: Git.ISingleCommitInfo | null;
 
   /**
+   * Branch comparison to display.
+   */
+  branchComparison: {
+    reference: Git.IRefComparison;
+    challenger: Git.IRefComparison;
+  } | null;
+
+  /**
    * Stashed files
    *
    */
@@ -201,6 +213,7 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       hasDirtyFiles: hasDirtyStagedFiles,
       referenceCommit: null,
       challengerCommit: null,
+      branchComparison: null,
       stash: stash,
       tagsList: tagsList,
       submodules: submodules
@@ -217,7 +230,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       this.setState({
         repository: args.newValue,
         referenceCommit: null,
-        challengerCommit: null
+        challengerCommit: null,
+        branchComparison: null
       });
       this.refreshView();
     }, this);
@@ -334,7 +348,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
     this.setState({
       currentBranch: currentBranch ? currentBranch.name : 'main',
       referenceCommit: null,
-      challengerCommit: null
+      challengerCommit: null,
+      branchComparison: null
     });
   };
 
@@ -482,7 +497,29 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
           commands={this.props.commands}
           model={this.props.model}
           trans={this.props.trans}
+          onCompareWithCurrent={this._onCompareBranchWithCurrent}
         />
+        {this.state.branchComparison && (
+          <CommitComparisonBox
+            header={this.props.trans.__(
+              'Compare %1 and %2',
+              this.state.branchComparison.reference.label,
+              this.state.branchComparison.challenger.label
+            )}
+            reference={this.state.branchComparison.reference}
+            challenger={this.state.branchComparison.challenger}
+            model={this.props.model}
+            trans={this.props.trans}
+            onClose={event => {
+              event?.stopPropagation();
+              this.setState({ branchComparison: null });
+            }}
+            onOpenDiff={openFileDiff(this.props.commands)(
+              this.state.branchComparison.challenger,
+              this.state.branchComparison.reference
+            )}
+          />
+        )}
         <TagMenu
           pastCommits={this.state.pastCommits}
           tagsList={this.state.tagsList}
@@ -645,9 +682,16 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
                   ? this.state.challengerCommit.commit.substring(0, 7)
                   : '...'
               )}
-              referenceCommit={this.state.referenceCommit}
-              challengerCommit={this.state.challengerCommit}
-              commands={this.props.commands}
+              reference={
+                this.state.referenceCommit
+                  ? commitToDiffRef(this.state.referenceCommit)
+                  : null
+              }
+              challenger={
+                this.state.challengerCommit
+                  ? commitToDiffRef(this.state.challengerCommit)
+                  : null
+              }
               model={this.props.model}
               trans={this.props.trans}
               onClose={event => {
@@ -660,8 +704,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
               onOpenDiff={
                 this.state.referenceCommit && this.state.challengerCommit
                   ? openFileDiff(this.props.commands)(
-                      this.state.challengerCommit,
-                      this.state.referenceCommit
+                      commitToDiffRef(this.state.challengerCommit),
+                      commitToDiffRef(this.state.referenceCommit)
                     )
                   : undefined
               }
@@ -721,6 +765,29 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       </React.Fragment>
     );
   }
+
+  private _onCompareBranchWithCurrent = (branch: Git.IBranch): void => {
+    const currentBranch =
+      this.props.model.currentBranch ??
+      this.state.branches.find(branch => branch.is_current_branch);
+
+    if (!currentBranch) {
+      return;
+    }
+
+    this.setState({
+      branchComparison: {
+        reference: {
+          ref: branch.name,
+          label: branch.name
+        },
+        challenger: {
+          ref: currentBranch.name,
+          label: currentBranch.name
+        }
+      }
+    });
+  };
 
   /**
    * Updates the commit message description.
@@ -1085,8 +1152,8 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
       this.state.challengerCommit
     ) {
       openFileDiff(this.props.commands)(
-        this.state.challengerCommit,
-        this.state.referenceCommit
+        commitToDiffRef(this.state.challengerCommit),
+        commitToDiffRef(this.state.referenceCommit)
       )(
         this.props.model.selectedHistoryFile.to,
         !this.props.model.selectedHistoryFile.is_binary

--- a/src/components/HistorySideBar.tsx
+++ b/src/components/HistorySideBar.tsx
@@ -13,7 +13,7 @@ import {
   historySideBarWrapperStyle
 } from '../style/HistorySideBarStyle';
 import { ContextCommandIDs, Git } from '../tokens';
-import { openFileDiff } from '../utils';
+import { commitToDiffRef, openFileDiff } from '../utils';
 import { ActionButton } from './ActionButton';
 import { FileItem } from './FileItem';
 import { PastCommitNode } from './PastCommitNode';
@@ -213,7 +213,7 @@ export const HistorySideBar: React.FunctionComponent<IHistorySideBarProps> = (
             // and its diff is viewable
             const onOpenDiff =
               props.model.selectedHistoryFile && !commit.is_binary
-                ? openFileDiff(props.commands)(commit)(
+                ? openFileDiff(props.commands)(commitToDiffRef(commit))(
                     commit.file_path ?? props.model.selectedHistoryFile.to,
                     !commit.is_binary,
                     commit.previous_file_path
@@ -262,7 +262,9 @@ export const HistorySideBar: React.FunctionComponent<IHistorySideBarProps> = (
                 {!props.model.selectedHistoryFile && (
                   <SinglePastCommitInfo
                     {...commonProps}
-                    onOpenDiff={openFileDiff(props.commands)(commit)}
+                    onOpenDiff={openFileDiff(props.commands)(
+                      commitToDiffRef(commit)
+                    )}
                   />
                 )}
               </PastCommitNode>

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1232,6 +1232,24 @@ export namespace Git {
     previous_file_path?: string;
   }
 
+  /**
+   * A Git reference that can be compared with another ref.
+   */
+  export interface IRefComparison {
+    /**
+     * Git reference used by git commands.
+     */
+    ref: string;
+    /**
+     * Label used when rendering the comparison.
+     */
+    label: string;
+    /**
+     * Fallback reference to compare against when no explicit reference is set.
+     */
+    previousRef?: string;
+  }
+
   /** Interface for GitCommit request result,
    * has the info of a committed file
    */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,21 +81,37 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
- * A callback function to display a file diff between two commits.
+ * Convert a commit to a comparable Git ref.
+ *
+ * @param commit Commit data.
+ * @returns comparable Git ref.
+ */
+export function commitToDiffRef(
+  commit: Git.ISingleCommitInfo
+): Git.IRefComparison {
+  return {
+    ref: commit.commit,
+    label: commit.commit.substring(0, 7),
+    previousRef: commit.pre_commits[0]
+  };
+}
+
+/**
+ * A callback function to display a file diff between two Git refs.
  * @param commands the command registry.
  * @returns a callback function to display a file diff.
  */
 export const openFileDiff =
   (commands: CommandRegistry) =>
   /**
-   * A callback function to display a file diff between two commits.
+   * A callback function to display a file diff between two Git refs.
    *
-   * @param commit Commit data.
-   * @param previousCommit Previous commit data to display the diff against. If not specified, the diff will be against the preceding commit.
+   * @param current Ref data to compare.
+   * @param previous Previous ref data to display the diff against. If not specified, the diff will use the current ref fallback.
    *
    * @returns A callback function.
    */
-  (commit: Git.ISingleCommitInfo, previousCommit?: Git.ISingleCommitInfo) =>
+  (current: Git.IRefComparison, previous?: Git.IRefComparison) =>
   /**
    * Returns a callback to be invoked on click to display a file diff.
    *
@@ -125,8 +141,8 @@ export const openFileDiff =
               previousFilePath,
               isText,
               context: {
-                previousRef: previousCommit?.commit ?? commit.pre_commits[0], // not sure
-                currentRef: commit.commit
+                previousRef: previous?.ref ?? current.previousRef ?? 'HEAD',
+                currentRef: current.ref
               }
             }
           ]


### PR DESCRIPTION
Closes #1512 

This PR adds a UI action to compare any non-current branch against the current branch from the Branches and Tags section. It addresses #1512 by letting users inspect all changes between, for example, main and a feature branch without checking each commit individually.

The implementation reuses the existing diff API, which already accepts Git refs. `CommitComparisonBox` now works with generic Git refs instead of commit-only objects, branch rows expose a “Compare with current branch” diff action, and GitPanel renders the resulting changed-file summary below the branch list. Existing commit comparison behaviour is preserved by converting commits into the same ref-based shape.

Tests were added and updated for the branch compare button, GitPanel branch comparison flow, and generic ref diff handling in `CommitComparisonBox`.