### PR TITLE
Surface stash apply failures in the UI

### DIFF
--- a/src/__tests__/model.spec.tsx
+++ b/src/__tests__/model.spec.tsx
@@ -200,6 +200,50 @@ describe('IGitExtension', () => {
     });
   });
 
+  describe('#applyStash', () => {
+    beforeEach(async () => {
+      mockResponses.responses['stash'] = {
+        body: () => ({
+          code: 0,
+          stashes: [{ index: 0, branch: 'main', message: 'notebook stash' }]
+        })
+      };
+      mockResponses.responses['stash?index=0'] = {
+        body: () => ({
+          code: 0,
+          files: ['notebook.ipynb']
+        })
+      };
+
+      model.pathRepository = DEFAULT_REPOSITORY_PATH;
+      await model.ready;
+      await (model as GitExtension).refreshStash();
+    });
+
+    it('should throw an exception if applying a stash fails', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const message = 'CONFLICT (content): Merge conflict in notebook.ipynb';
+      mockResponses.responses['stash_apply'] = {
+        body: () => ({ code: 128, message }),
+        status: 500
+      };
+
+      let error: unknown;
+      try {
+        await model.applyStash(0);
+      } catch (reason) {
+        error = reason;
+      }
+
+      expect(error).toBeInstanceOf(Git.GitResponseError);
+      expect((error as Git.GitResponseError).json).toMatchObject({
+        code: 128,
+        message
+      });
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to apply stash', error);
+    });
+  });
+
   describe('#status', () => {
     it('should be clear if not in a git repository', async () => {
       let status: Partial<Git.IStatusResult> = {

--- a/src/components/GitPanel.tsx
+++ b/src/components/GitPanel.tsx
@@ -444,7 +444,14 @@ export class GitPanel extends React.Component<IGitPanelProps, IGitPanelState> {
   };
 
   private _gitStashApplyLatest = async (): Promise<void> => {
-    await this.props.model.applyStash(0);
+    try {
+      await this.props.model.applyStash(0);
+    } catch (error) {
+      Notification.error(
+        this.props.trans.__('Failed to apply stash'),
+        showError(error as Error, this.props.trans)
+      );
+    }
   };
 
   /**

--- a/src/components/GitStash.tsx
+++ b/src/components/GitStash.tsx
@@ -12,7 +12,7 @@ import { hiddenButtonStyle } from '../style/ActionButtonStyle';
 import { ActionButton } from './ActionButton';
 import { addIcon, trashIcon, discardIcon } from '../style/icons';
 import { TranslationBundle } from '@jupyterlab/translation';
-import { UseSignal } from '@jupyterlab/apputils';
+import { Notification, UseSignal } from '@jupyterlab/apputils';
 import { FixedSizeList } from 'react-window';
 import {
   listStyle,
@@ -24,6 +24,7 @@ import {
 import { FilePath } from './FilePath';
 import { stopPropagation, stopPropagationWrapper } from '../utils';
 import { classes } from 'typestyle';
+import { showError } from '../notifications';
 
 const HEADER_HEIGHT = 34;
 const ITEM_HEIGHT = 25;
@@ -242,10 +243,13 @@ export const GitStash: React.FunctionComponent<IGitStashProps> = (
       try {
         await props.model.applyStash(index);
       } catch (err) {
-        console.error(err);
+        Notification.error(
+          props.trans.__('Failed to apply stash'),
+          showError(err as Error, props.trans)
+        );
       }
     },
-    [props.model]
+    [props.model, props.trans]
   );
 
   return (

--- a/src/model.ts
+++ b/src/model.ts
@@ -1740,8 +1740,10 @@ export class GitExtension implements IGitExtension {
       });
     } catch (error) {
       console.error('Failed to apply stash', error);
+      throw error;
+    } finally {
+      await this.refreshStash();
     }
-    await this.refreshStash();
   }
 
   /**


### PR DESCRIPTION
Closes #1422

Fixes stash apply errors being silently swallowed by rethrowing failed applyStash requests and showing the existing detailed error notification in the stash UI. This lets users see git conflict details, including affected files, when applying a stash fails. Added focused model coverage for the failure path.