### PR TITLE
Clarify conflict resolution actions for unmerged files

### DIFF
--- a/src/__tests__/commands.spec.tsx
+++ b/src/__tests__/commands.spec.tsx
@@ -3,6 +3,7 @@ import { showDialog } from '@jupyterlab/apputils';
 import { FileBrowserModel } from '@jupyterlab/filebrowser';
 import { nullTranslator } from '@jupyterlab/translation';
 import { CommandRegistry } from '@lumino/commands';
+import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import 'jest';
 import { CommandArguments, addCommands } from '../commandsAndMenu';
 import * as git from '../git';
@@ -65,6 +66,41 @@ describe('git-commands', () => {
       null as any,
       nullTranslator
     );
+  });
+
+  describe('git:context-diff', () => {
+    function diffArgs(statuses: Git.Status[]): ReadonlyPartialJSONObject {
+      return {
+        files: statuses.map((status, index) => ({
+          filePath: `file-${index}.txt`,
+          isText: true,
+          status
+        }))
+      } as unknown as ReadonlyPartialJSONObject;
+    }
+
+    it('should use conflict resolution labels for unmerged files', () => {
+      const args = diffArgs(['unmerged']);
+
+      expect(commands.label(ContextCommandIDs.gitFileDiff, args)).toBe(
+        'Resolve Conflicts'
+      );
+      expect(commands.caption(ContextCommandIDs.gitFileDiff, args)).toBe(
+        'Resolve conflicts in selected file'
+      );
+    });
+
+    it('should keep diff labels for non-conflict and mixed selections', () => {
+      expect(
+        commands.label(ContextCommandIDs.gitFileDiff, diffArgs(['staged']))
+      ).toBe('Diff');
+      expect(
+        commands.label(
+          ContextCommandIDs.gitFileDiff,
+          diffArgs(['unmerged', 'staged'])
+        )
+      ).toBe('Diff');
+    });
   });
 
   describe('git:context-discard', () => {

--- a/src/commandsAndMenu.tsx
+++ b/src/commandsAndMenu.tsx
@@ -28,7 +28,7 @@ import {
 } from '@jupyterlab/ui-components';
 import { ArrayExt, find } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
-import { PromiseDelegate } from '@lumino/coreutils';
+import { PromiseDelegate, ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import { Message } from '@lumino/messaging';
 import { ContextMenu, DockPanel, Menu, Panel, Widget } from '@lumino/widgets';
 import * as React from 'react';
@@ -121,6 +121,12 @@ function pluralizedContextLabel(singular: string, plural: string) {
       return singular;
     }
   };
+}
+
+function isOnlyUnmergedDiff(args: ReadonlyPartialJSONObject): boolean {
+  const files = (args as unknown as Partial<CommandArguments.IGitFileDiff>)
+    .files;
+  return !!files?.length && files.every(file => file.status === 'unmerged');
 }
 
 /**
@@ -1233,12 +1239,24 @@ export function addCommands(
     }
   });
 
+  const diffCaption = pluralizedContextLabel(
+    trans.__('Diff selected file'),
+    trans.__('Diff selected files')
+  );
+  const resolveConflictsCaption = pluralizedContextLabel(
+    trans.__('Resolve conflicts in selected file'),
+    trans.__('Resolve conflicts in selected files')
+  );
+
   commands.addCommand(ContextCommandIDs.gitFileDiff, {
-    label: trans.__('Diff'),
-    caption: pluralizedContextLabel(
-      trans.__('Diff selected file'),
-      trans.__('Diff selected files')
-    ),
+    label: args =>
+      isOnlyUnmergedDiff(args)
+        ? trans.__('Resolve Conflicts')
+        : trans.__('Diff'),
+    caption: args =>
+      isOnlyUnmergedDiff(args)
+        ? resolveConflictsCaption(args)
+        : diffCaption(args),
     execute: async args => {
       const { files } = args as any as CommandArguments.IGitFileDiff;
       if (gitModel.pathRepository === null) {

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -15,6 +15,7 @@ import {
   addIcon,
   diffIcon,
   discardIcon,
+  mergeIcon,
   openIcon,
   removeIcon,
   rewindIcon
@@ -91,7 +92,7 @@ export const CONTEXT_COMMANDS: ContextCommands = {
     ContextCommandIDs.gitFileHistory
   ],
   unmodified: [ContextCommandIDs.gitFileHistory],
-  unmerged: [ContextCommandIDs.gitFileDiff],
+  unmerged: [ContextCommandIDs.gitFileOpen, ContextCommandIDs.gitFileDiff],
   stashed: [ContextCommandIDs.gitFileStashPop]
 };
 
@@ -122,7 +123,7 @@ const SIMPLE_CONTEXT_COMMANDS: ContextCommands = {
     ContextCommandIDs.gitFileDelete
   ],
   unmodified: [ContextCommandIDs.gitFileHistory],
-  unmerged: [ContextCommandIDs.gitFileDiff],
+  unmerged: [ContextCommandIDs.gitFileOpen, ContextCommandIDs.gitFileDiff],
   stashed: [ContextCommandIDs.gitFileStashPop]
 };
 
@@ -709,7 +710,19 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     return (
       <FileItem
         trans={this.props.trans}
-        actions={!file.is_binary ? diffButton : null}
+        actions={
+          <React.Fragment>
+            <ActionButton
+              className={hiddenButtonStyle}
+              icon={openIcon}
+              title={this.props.trans.__('Open this file')}
+              onClick={stopPropagationWrapper(() =>
+                this.openSelectedFiles(file)
+              )}
+            />
+            {!file.is_binary ? diffButton : null}
+          </React.Fragment>
+        }
         contextMenu={this.openContextMenu}
         file={file}
         model={this.props.model}
@@ -1277,8 +1290,12 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
       (getDiffProvider(file.to) || !file.is_binary) && (
         <ActionButton
           className={hiddenButtonStyle}
-          icon={diffIcon}
-          title={this.props.trans.__('Diff this file')}
+          icon={file.status === 'unmerged' ? mergeIcon : diffIcon}
+          title={
+            file.status === 'unmerged'
+              ? this.props.trans.__('Resolve conflicts')
+              : this.props.trans.__('Diff this file')
+          }
           onClick={stopPropagationWrapper(handleClick)}
         />
       )


### PR DESCRIPTION
closes #1403

This improves the discoverability of the existing conflict-resolution workflow for unmerged files.

- Add an Open action to conflicted file rows and context menus
- Show the existing unmerged diff action as “Resolve Conflicts” instead of generic “Diff”
- Use the merge icon/tooltip for conflicted file resolution actions
- Add command-label coverage for unmerged, non-conflict, and mixed selections

Looks below:

<img width="1439" height="686" alt="Screenshot 2026-08-25 at 1 29 26 PM" src="https://github.com/user-attachments/assets/e5579b26-0f0e-4b22-a413-a7a0fedce055" />
<img width="1439" height="686" alt="Screenshot 2026-08-25 at 1 29 38 PM" src="https://github.com/user-attachments/assets/4afba26a-15ef-455d-937b-baf691fd1a94" />
