### PR TITLE
Optimize Git.status() performance and fix numstat parsing

### DIFF
--- a/packages/core/jupyterlab_git_core/git.py
+++ b/packages/core/jupyterlab_git_core/git.py
@@ -552,8 +552,8 @@ class Git:
         are_binary = dict()
         if text_code == 0:
             for line in filter(lambda l: len(l) > 0, strip_and_split(text_output)):
-                diff, name = line.rsplit("\t", maxsplit=1)
-                are_binary[name] = diff.startswith("-\t-")
+                insertions, deletions, name = line.split("\t", maxsplit=2)
+                are_binary[name] = insertions == "-" and deletions == "-"
 
         data = {
             "code": code,

--- a/packages/core/jupyterlab_git_core/git.py
+++ b/packages/core/jupyterlab_git_core/git.py
@@ -534,15 +534,20 @@ class Git:
             }
 
         # Add attribute `is_binary`
-        command = [  # Compare stage to an empty tree see `_is_binary`
-            "git",
-            "diff",
-            "--numstat",
-            "-z",
-            "--cached",
-            "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
-        ]
+        command = ["git", "diff", "--numstat", "-z", "--no-renames", "HEAD"]
         text_code, text_output, _ = await self.__execute(command, cwd=path)
+
+        if text_code != 0:
+            # No commits yet: compare the stage to an empty tree instead
+            command = [
+                "git",
+                "diff",
+                "--numstat",
+                "-z",
+                "--cached",
+                "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+            ]
+            text_code, text_output, _ = await self.__execute(command, cwd=path)
 
         are_binary = dict()
         if text_code == 0:

--- a/packages/core/tests/test_status.py
+++ b/packages/core/tests/test_status.py
@@ -351,8 +351,12 @@ async def test_status(tmp_path, output, diff_output, expected):
         repository = tmp_path / "test_curr_path"
         (repository / ".git" / "rebase-merge").mkdir(parents=True)
 
+        # Without commits there is no HEAD, so the diff falls back to the empty tree.
+        is_initial = expected["branch"] == "(initial)"
+
         mock_execute.side_effect = [
             (0, "\x00".join(output) + "\x00", ""),
+            *([(128, "", "fatal: bad revision 'HEAD'")] if is_initial else []),
             (0, "\x00".join(diff_output) + "\x00", ""),
             (0 if expected["state"] == 4 else 128, "", "cherry pick"),
             (0 if expected["state"] == 2 else 128, "", "merge"),
@@ -374,20 +378,35 @@ async def test_status(tmp_path, output, diff_output, expected):
                 is_binary=False,
             ),
             call(
-                [
-                    "git",
-                    "diff",
-                    "--numstat",
-                    "-z",
-                    "--cached",
-                    "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
-                ],
+                ["git", "diff", "--numstat", "-z", "--no-renames", "HEAD"],
                 cwd=str(repository),
                 env=None,
                 username=None,
                 password=None,
                 is_binary=False,
             ),
+        ]
+
+        if is_initial:
+            expected_calls.append(
+                call(
+                    [
+                        "git",
+                        "diff",
+                        "--numstat",
+                        "-z",
+                        "--cached",
+                        "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+                    ],
+                    cwd=str(repository),
+                    env=None,
+                    username=None,
+                    password=None,
+                    is_binary=False,
+                )
+            )
+
+        expected_calls += [
             call(
                 ["git", "show", "--quiet", "CHERRY_PICK_HEAD"],
                 cwd=str(repository),

--- a/packages/core/tests/test_status.py
+++ b/packages/core/tests/test_status.py
@@ -16,6 +16,7 @@ from jupyterlab_git_core.git import Git
                 "A  notebook with spaces.ipynb",
                 "M  notebook with λ.ipynb",
                 "M  binary file.gif",
+                "M  file with\ttab.py",
                 "R  renamed_to_θ.py",
                 "originally_named_π.py",
                 "?? untracked.ipynb",
@@ -23,6 +24,7 @@ from jupyterlab_git_core.git import Git
             (
                 "0\t0\tnotebook with spaces.ipynb",
                 "-\t-\tbinary file.gif",
+                "1\t0\tfile with\ttab.py",
                 "0\t0\trenamed_to_θ.py",
             ),
             {
@@ -53,6 +55,13 @@ from jupyterlab_git_core.git import Git
                         "to": "binary file.gif",
                         "from": "binary file.gif",
                         "is_binary": True,
+                    },
+                    {
+                        "x": "M",
+                        "y": " ",
+                        "to": "file with\ttab.py",
+                        "from": "file with\ttab.py",
+                        "is_binary": False,
                     },
                     {
                         "x": "R",


### PR DESCRIPTION
Fixes #1431.                                                                                                               
                                                                                                                        
Credit to @dualc for diagnosing the bottleneck in #1431. This improves on #1432 - see below.                                                                                                      
                                                                                                                        
## Problem                                                                                                                 

`Git.status()` runs this unconditionally on every status refresh (i.e. all the time):                                                                                                                                                    
```                                                                                                                        
git diff --numstat -z --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904                                                    
```                                                                                                                                                                                                                                      
That diffs the whole index against the empty tree, so git reads every tracked file to produce line counts. On our 12,331-file / 1.4 GB repository it takes **over 20 s** on cold page cache,  ~8 s once warm.                                                                                                                       
 
The point of all this is to find out if the files in `git status` output are binary or text.

## Change                                                                                                                  
                                                                                                                        
Two commits.

**1. Compare against HEAD instead of the empty tree.** `git diff --numstat -z --no-renames HEAD` reports only files that actually differ.

`--no-renames` forces renames to be reported as a delete plus an add. Keeps every line a plain three-field tab-separated record.

A repository with no commits has no HEAD, so the diff exits non-zero there and falls back to the empty-tree comparison.
                                                                                             
**2. Split numstat records from the left.** Independent latent bug found while looking at the code. `-z` emits paths raw and unquoted, and filenames may contain tabs, so the last tab is not reliably the field separator:                                       

```                                                                                                                        
line = "1\t0\tfile with\ttab.py"
diff, name = line.rsplit("\t", maxsplit=1)
diff # '1\t0\tfile with'
name # 'tab.py'                                          
```                                                                                                                        

It fails silently rather than crashing and the result would be subtle: binary file with tab in its filename will be treated as text. But it is worth fixing IMO.

## How is this different from #1432

Same core idea but three concrete differences:

|              | #1432 (dualc)                         | #1531 (michalkahle)                       |
|--------------|---------------------------------------|-------------------------------------|
| command      | `git diff --numstat -z --cached`      | `git diff --numstat -z --no-renames HEAD` |
| compares     | index vs HEAD                         | working tree vs HEAD                |
| no-HEAD case | `_is_first_commit()` probe every refresh | fallback on non-zero exit        |

1. `--no-renames`. Without it, rename detection turns on, and --numstat -z emits a rename as 0\t0\t\0<from>\0<to>\0 — three NUL records, two with no tab which breaks the parser.
2. `HEAD`, not `--cached`. Index-vs-HEAD only sees staged changes, so working-tree-only modifications are not covered. Working-tree-vs-HEAD matches main everywhere and gains a flag on staged deletions.
3. Exit code, not a probe. `git rev-parse --verify HEAD` on every refresh starts a subprocess to handle a state that exists only before a repo's first commit. Letting the diff fail costs the extra call only there.

Worth saying plainly: @dualc identified the bottleneck and had the right instinct about HEAD. This PR is that idea with some modifications.
                                                                                                                                                                             
## Testing                                                                                                                 
                                                                                                                        
`packages/core/tests/test_status.py`:
- changed to mirror conditional invocation of `git diff`.
- Case of a filename with tab added.